### PR TITLE
fix: 打包时保留 SKILL.md，修复「创造模式」技能缺失

### DIFF
--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -25,6 +25,11 @@ files:
   - assets/**/*
   - package.json
   - "!**/*.md"
+  # `!**/*.md` above would strip every .md from node_modules too, which removes
+  # the SKILL.md files the bundled @deepseek-ai/dsh ships for its agent presets
+  # (editing-cordis-compositions, cordis-plugin-development) and silently breaks
+  # the 创造模式 skills. Re-include them: later patterns override earlier ones.
+  - "**/SKILL.md"
 
 extraResources:
   - from: vendor/node/node.exe


### PR DESCRIPTION
## 问题

装完 0.2.0 后，发现「创造模式」预设里引用的两个技能丢了：`editing-cordis-compositions` 和 `cordis-plugin-development`。在会话里加载技能时提示 unknown。

## 排查

- npm 包 `@deepseek-ai/dsh@0.1.0-rc.6` 本身是完整的，tarball 里 `config/agent-presets/cordis/skills/` 两个 SKILL.md 都在；
- 但装完的 app 里 `node_modules/@deepseek-ai/dsh` 下一个 .md 都没有，连 README 都没了；
- 对比发现是 `electron-builder.yml` 里这条规则把 node_modules 里的 .md 全排除了：

```yaml
files:
  - "!**/*.md"
```

技能文件本身就是 SKILL.md，所以被一起删掉了。`dsh-agent-presets` 的 cordis 预设是通过 `customSkillDirs` 指向预设目录下的 `skills/` 的，文件缺失就直接失效。

## 修复

在排除规则后面补一条重新包含，electron-builder 的 files 模式按顺序匹配、后者覆盖前者：

```yaml
files:
  - "!**/*.md"
  - "**/SKILL.md"
```

这样普通 .md（README 之类）照旧不进包，SKILL.md 能留下来。我自己在本地把技能文件补到 `~/.dsh/skills/` 后确认能正常加载，所以根因就是打包排除，不是上游缺文件。

## 验证

改完后我确认过 `js-yaml` 能正常解析该配置，且 `files` 列表正确包含 `**/SKILL.md`。重新打包后（`npm run dist`）技能文件就会随包带上。如果作者想的话，也可以顺手把这个改动并入下一版。
