### PR TITLE
fix(session): 打包内置 dsh-session 事件词汇表补丁，修复插件事件导致的历史会话无法加载

### DIFF
--- a/dsh-desktop/README.md
+++ b/dsh-desktop/README.md
@@ -176,6 +176,7 @@ npm run dist                   # 构建 portable + NSIS 安装包，输出到 di
 - **首次启动慢**：dsh 首次引导 profile 需要数秒到数十秒，属正常现象。
 - **更新下载慢**：设置环境变量 `NPM_CONFIG_REGISTRY=https://registry.npmmirror.com` 后重启应用。
 - **收不到通知**：确认菜单「会话完成通知」已勾选；便携版确认开始菜单里存在「DSH Desktop」快捷方式（首次运行自动创建，勿删除）；检查 Windows「通知与操作」设置里应用通知未被禁用。
+- **历史会话打不开（`SessionFormatUnsupportedError: ... unknown to this harness and not marked ignorable`）**：dsh-agent-teams / dsh-message-edit / dsh-web-search-exa 等插件写入的自定义会话事件不在内置核心的事件词汇表内导致。无需重装，一条命令修复：`npx dsh-session-history-fix`（幂等，可重复运行；改完重启应用即可）。本仓库 PR #10 已把该补丁集成到打包流程，合入后的新版本开箱即修。
 - **端口被占**：应用自动使用空闲端口，无需手动处理。
 
 ## 目录结构

--- a/dsh-desktop/scripts/after-pack.js
+++ b/dsh-desktop/scripts/after-pack.js
@@ -22,6 +22,12 @@ const path = require('node:path');
 // not just `npm run dist`.
 require('./patch-portable-template');
 
+// Patch the bundled dsh-session event vocabulary so plugin events
+// (dsh-agent-teams / dsh-message-edit / dsh-web-search-exa) are accepted by
+// the session reader — otherwise "history unavailable ... unknown to this
+// harness and not marked ignorable" breaks session history loading.
+const { patchDshSessionVocabulary } = require('./patch-event-vocabulary');
+
 // Regexes for files that are safe to delete (pure metadata / dev artifacts).
 const DROP_BASENAME = /^(LICENSE.*|README.*|CHANGELOG.*|HISTORY.*|COPYING.*|NOTICE.*|AUTHORS.*|SECURITY.*|CONTRIBUTING.*|\.gitignore|\.npmignore|\.editorconfig|\.eslintrc.*|\.prettierrc.*|\.babelrc.*)$/i;
 const DROP_EXT = new Set(['.map', '.md', '.markdown', '.tsbuildinfo', '.d.ts']);
@@ -77,4 +83,15 @@ module.exports = async function afterPack(context) {
   let total = 0;
   for (const t of targets) total += pruneDroppable(t);
   console.log(`afterPack: pruned ${total} redundant files (install shrink)`);
+
+  // Patch the packaged dsh-session vocabulary in the packed app (idempotent).
+  // Runs after pruning so the .js files it modifies are the final copies.
+  const sessionPkgDir = path.join(appOutDir, 'resources', 'app', 'node_modules',
+    '@deepseek-ai', 'dsh-session');
+  if (fs.existsSync(path.join(sessionPkgDir, 'lib', 'index.js'))) {
+    const changed = patchDshSessionVocabulary(sessionPkgDir);
+    console.log(`afterPack: session event vocabulary ${changed > 0 ? `patched (+${changed} types)` : 'already up to date'}`);
+  } else {
+    console.warn('afterPack: bundled dsh-session not found — vocabulary patch skipped');
+  }
 };

--- a/dsh-desktop/scripts/patch-event-vocabulary.js
+++ b/dsh-desktop/scripts/patch-event-vocabulary.js
@@ -1,0 +1,129 @@
+'use strict';
+// Patch the bundled @deepseek-ai/dsh-session event vocabulary so that
+// out-of-repo plugin events (dsh-agent-teams, dsh-message-edit,
+// dsh-web-search-exa) are accepted by the session reader, fixing:
+//
+//   history unavailable for session "...": SessionFormatUnsupportedError:
+//   session "..." contains event type "agent-teams/team-created" (seq N)
+//   unknown to this harness and not marked ignorable; refusing to interpret
+//   the log — it was likely written by a newer harness
+//
+// Root cause: the session reader only accepts event types in the generated
+// KNOWN_SESSION_EVENT_TYPES vocabulary (or events explicitly marked
+// ignorable). Plugin events are out-of-repo, `Session.append()` exposes no
+// ignorable option, and the core has no registration surface for them yet
+// (see deepseek-ai/deepseek-harness discussion #802).
+//
+// This script adds the plugin event types to BOTH copies of the vocabulary
+// (@deepseek-ai/dsh-session/lib/index.js and lib/types/known-event-types.js).
+// The vocabulary Set is located BY CONTENT (contains "agent-preset/selected"),
+// never by "first Set literal in the file" — that one is SURFACE_EVENT_TYPES
+// and must not be touched. Idempotent: safe to run any number of times, and
+// after a DSH Desktop app update overwrites the packaged files.
+//
+// Usage:
+//   node scripts/patch-event-vocabulary.js <path-to-dsh-session-package-dir>
+// (also exported for use from after-pack.js)
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AGENT_TEAMS = [
+  'agent-teams/member-added',
+  'agent-teams/member-removed',
+  'agent-teams/message-sent',
+  'agent-teams/task-created',
+  'agent-teams/task-updated',
+  'agent-teams/team-created',
+  'agent-teams/team-deleted',
+];
+const WANTED = [
+  ...AGENT_TEAMS,
+  'message-edit/version',
+  'web/exa-search-request',
+];
+
+function setSpans(text) {
+  const spans = [];
+  let i = 0;
+  for (;;) {
+    const j = text.indexOf('new Set([', i);
+    if (j === -1) break;
+    const k = text.indexOf(']);', j);
+    if (k === -1) break;
+    spans.push({ start: j, end: k + 3 });
+    i = k + 3;
+  }
+  return spans;
+}
+
+function itemsOf(body, quote) {
+  const re = new RegExp(`${quote}([^${quote}]+)${quote}`, 'g');
+  const items = [];
+  let m;
+  while ((m = re.exec(body)) !== null) items.push(m[1]);
+  return items;
+}
+
+function replaceSet(text, span, items, indent, quote) {
+  const lines = items.map((t) => `${indent}${quote}${t}${quote},`);
+  return text.slice(0, span.start)
+    + `new Set([\n${lines.join('\n')}\n${indent}]);`
+    + text.slice(span.end);
+}
+
+function patchFile(file, quote) {
+  const src = fs.readFileSync(file, 'utf8');
+  const knownSpan = setSpans(src).find((s) =>
+    itemsOf(src.slice(s.start, s.end), quote).includes('agent-preset/selected'));
+  if (!knownSpan) {
+    console.warn(`patch-event-vocabulary: KNOWN_SESSION_EVENT_TYPES not found in ${file}`);
+    return 0;
+  }
+  const current = itemsOf(src.slice(knownSpan.start, knownSpan.end), quote);
+  const missing = WANTED.filter((w) => !current.includes(w));
+  if (missing.length === 0) {
+    console.log(`patch-event-vocabulary: ${file} already patched (${current.length} types)`);
+    return 0;
+  }
+  const sorted = [...current];
+  for (const item of missing) {
+    const at = sorted.findIndex((x) => x > item);
+    sorted.splice(at === -1 ? sorted.length : at, 0, item);
+  }
+  const indent = file.endsWith('index.js') ? '\t' : '    ';
+  fs.writeFileSync(file, replaceSet(src, knownSpan, sorted, indent, quote));
+  console.log(`patch-event-vocabulary: ${file} +${missing.length} types (${sorted.length} total)`);
+  return missing.length;
+}
+
+/** Patch both vocabulary copies under the @deepseek-ai/dsh-session package dir. */
+function patchDshSessionVocabulary(sessionPkgDir) {
+  const targets = [
+    [path.join(sessionPkgDir, 'lib', 'index.js'), '"'],
+    [path.join(sessionPkgDir, 'lib', 'types', 'known-event-types.js'), "'"],
+  ];
+  let changed = 0;
+  for (const [file, quote] of targets) {
+    if (!fs.existsSync(file)) {
+      console.warn(`patch-event-vocabulary: missing ${file}`);
+      continue;
+    }
+    changed += patchFile(file, quote);
+  }
+  return changed;
+}
+
+module.exports = { patchDshSessionVocabulary, WANTED };
+
+if (require.main === module) {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error('usage: node scripts/patch-event-vocabulary.js <path-to-dsh-session-package-dir>');
+    process.exit(2);
+  }
+  const changed = patchDshSessionVocabulary(path.resolve(dir));
+  console.log(changed > 0
+    ? `patched ${changed} type(s) — restart DSH Desktop to pick it up`
+    : 'nothing to patch (already up to date)');
+}


### PR DESCRIPTION
## 问题

打包版 DSH Desktop（内置 @deepseek-ai/dsh-session 0.1.0-rc.6）在会话历史中
存在 dsh-agent-teams / dsh-message-edit / dsh-web-search-exa 等插件写入的
持久化会话事件时，历史无法加载：

``
history unavailable for session ...:
SessionFormatUnsupportedError: session ... contains event type
agent-teams/team-created (seq N) unknown to this harness and not
marked ignorable; refusing to interpret the log
``

## 根因

- 会话读取器只接受生成词汇表 KNOWN_SESSION_EVENT_TYPES 中的事件类型，
  其余类型必须带 ignorable: true，否则拒绝解释整个日志；
- 上述插件事件不在词汇表中，且核心 Session.append() 没有 ignorable 选项、
  核心也没有给仓库外插件提供事件类型注册面（上游 deepseek-ai/deepseek-harness
  discussion #802 正在讨论该缺口）；
- 官方 npm 当前发布的核心（0.0.1-rc.1）尚未包含词汇表检查机制，所以原版
  CLI 暂不受影响；打包版内置的 rc.6 已带该机制，因此命中此问题。

## 修复

- 新增 scripts/patch-event-vocabulary.js：向打包内置的两份词汇表副本
  （lib/index.js 与 lib/types/known-event-types.js）加入 9 个插件事件类型
  （44 → 53）。幂等，可独立运行：node scripts/patch-event-vocabulary.js <dsh-session目录>；
- after-pack.js 在 electron-builder 打包后自动调用，后续每个版本的安装包
  都内置修复（无需用户手动操作）；
- README「日志与排障」补充一条 npx 临时修复指引，未升级的用户也能自救。

### 关于实现细节（供 review）

1. **过渡补丁定位**：这是打包层的临时 workaround。上游 harness 提供插件
   事件注册 API（discussion #802）后，本补丁即可整体移除——脚本与 after-pack
   调用点相互独立，删除方便。
2. **按内容匹配，不依赖行号**：脚本通过内容定位词汇表（查找包含
   agent-preset/selected 的 Set 字面量，再按字母序插入缺失类型并重写该
   Set 块），上游 known-event-types.js 增删类型、行号偏移都不会使脚本失效；
   缺失类型已存在时幂等跳过。仅当上游将来移除 agent-preset/selected 或
   改变 Set 字面量格式时才需要调整（脚本此时会打印警告而非静默失败）。
3. **只放行解析，不动 UI**：加入 KNOWN_SESSION_EVENT_TYPES 仅表示解析器
   可读取该事件；刻意避开 SURFACE_EVENT_TYPES（消息产生事件集合），插件
   事件不会被当作消息渲染进对话流，不会影响界面。UI 对插件事件的展示由
   各插件自身的客户端折叠逻辑负责，与本次补丁无关。

## 验证

- 对原始 rc.6 包运行：两份文件各 +9 类型（44 → 53），可重复执行；
- 对已打补丁的包运行：幂等跳过（already patched）；
- 打包流程 afterPack 顺序：先裁剪冗余文件，再打补丁。

## 相关

- 独立修复工具（npx dsh-session-history-fix / 一键 bat / 校验脚本）：
  https://github.com/jiayuxuan123/dsh-session-history-fix
- 上游讨论：https://github.com/deepseek-ai/deepseek-harness/discussions/802

Closes #11