### PR TITLE
fix: renderer 崩溃/挂起自恢复与受限端口重启（#9）

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -4,6 +4,24 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 一键启动 Web UI。
 
 
+## [未发布] — Issue #9 渲染进程崩溃自恢复
+
+### 修复
+- **渲染进程崩溃后永久黑屏/白屏（0xC0000005）**：新增 `renderer-recovery.js` 自恢复状态机，主窗与会话浮窗统一接管：
+  - `render-process-gone`（crashed/killed/oom）→ 指数退避自动重载（首次 0.8s，上限 15s + 抖动）
+  - 连续失败第 3 次 → 主窗销毁重建 BrowserWindow（保持隐藏/托盘状态）；浮窗直接关闭
+  - 失败超过上限 → 主窗切到本地恢复页（重新加载/重启客户端/打开日志），并弹系统通知；绝不无限循环
+  - 页面加载成功后需「稳定存活 30 秒」才清零故障计数，杜绝「加载即崩溃」型循环
+  - `clean-exit`、退出中、窗口已销毁一律不触发恢复；服务进程退出时交由既有重启对话框，不双弹窗
+- **界面挂起（AppHangB1）无恢复**：监听 `unresponsive`，20s 宽限后强制终结 renderer 复用恢复路径；preload 每 5s 心跳兜底「挂起但无 unresponsive 事件」的场景（以 show/hide 事件追踪可见性，隐藏/最小化不误判，也不依赖在挂起/RDP 场景下会误报的 `isVisible()`）
+- **加载失败白屏**：新增 `did-fail-load` 处理，服务健在时退避重试（覆盖插件市场重启间隙），`ERR_ABORTED` 忽略
+- **崩溃无法取证**：固定 `crashDumps` 到数据目录并启用本地 Crashpad（`uploadToServer:false`），minidump 可离线分析 0xC0000005 底层来源；恢复状态写入 `run-state.json`
+- **dsh web / 预览服务随机命中 Chromium 受限端口导致页面永远无法加载**：`--port 0` 可能选中 4045/6000 等受限端口（实测命中 4045，`ERR_UNSAFE_PORT`），现在命中即自动重启服务换端口（上限 4 次）
+
+### 开发
+- 新增 `scripts/test/unit-recovery.test.js`（node:test 状态机单元测试，17 例）与 `scripts/test/integration-runner.js`（真实 Electron 集成测试，10 场景：健康启动/崩溃恢复/重建/放弃/挂起/服务重启/进程被杀/浮窗/启动早期崩溃/受限端口重启，全部隔离 DSH_HOME 与 userData）
+- 集成测试通道：`DSH_DESKTOP_TEST=1` 时经文件轮询下达命令（crash/kill/hang/quit…），renderer 崩溃时仍可用
+
 ## [0.3.2] — 2026-08-15
 
 ### 新增

--- a/dsh-desktop/assets/recovery.html
+++ b/dsh-desktop/assets/recovery.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<title>DSH Desktop</title>
+<style>
+  :root { color-scheme: dark; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 18px;
+    background: radial-gradient(1200px 600px at 50% -10%, #2a1b4d 0%, #0b1220 55%);
+    color: #e6ecff;
+    font-family: "Segoe UI", "Microsoft YaHei", system-ui, sans-serif;
+    user-select: none;
+  }
+  .card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    max-width: 520px;
+    padding: 30px 36px;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.03);
+  }
+  .mark {
+    width: 56px; height: 56px; border-radius: 50%;
+    display: grid; place-items: center;
+    background: rgba(255, 122, 133, 0.14);
+    color: #ff7a85; font-size: 30px; line-height: 1;
+  }
+  h1 { font-size: 20px; font-weight: 600; letter-spacing: 0.5px; }
+  .desc { font-size: 13px; color: #a9b8de; line-height: 22px; text-align: center; }
+  .note { font-size: 12px; color: #6f82b8; line-height: 20px; text-align: center; }
+  .details {
+    font-size: 11.5px; color: #5f6f9c; line-height: 18px; text-align: center;
+    font-family: Consolas, "Courier New", monospace;
+  }
+  .actions { display: flex; gap: 10px; margin-top: 4px; flex-wrap: wrap; justify-content: center; }
+  button {
+    appearance: none; border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(255, 255, 255, 0.06); color: #e6ecff;
+    font: inherit; font-size: 13px; line-height: 20px;
+    padding: 8px 18px; border-radius: 9px; cursor: pointer;
+    transition: background 0.12s, border-color 0.12s;
+  }
+  button:hover { background: rgba(255, 255, 255, 0.12); border-color: rgba(255, 255, 255, 0.3); }
+  button.primary {
+    background: #3d5ce6; border-color: #4d6bf0;
+  }
+  button.primary:hover { background: #4d6bf0; }
+  button.danger { color: #ffb3ba; }
+  button.danger:hover { background: rgba(232, 17, 35, 0.25); border-color: rgba(255, 122, 133, 0.5); }
+  .status { font-size: 12px; color: #8b9ac4; min-height: 16px; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="mark">⚠</div>
+    <h1>界面遇到问题</h1>
+    <p class="desc">界面渲染进程多次异常退出，已暂停自动恢复。</p>
+    <p class="note">你的数据与后台任务不受影响，仍在继续运行。<br>可以先尝试重新加载界面；若问题持续，请重启客户端。</p>
+    <p class="details" id="details"></p>
+    <div class="actions">
+      <button class="primary" id="reload" type="button">重新加载界面</button>
+      <button id="openLogs" type="button">打开日志目录</button>
+      <button class="danger" id="restart" type="button">重启客户端</button>
+    </div>
+    <p class="status" id="status"></p>
+  </div>
+  <script>
+    (function () {
+      var $ = function (id) { return document.getElementById(id); };
+      var setStatus = function (text) { $('status').textContent = text || ''; };
+      var esc = function (s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+          return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+      };
+      var bridge = window.dshDesktop && window.dshDesktop.recovery;
+      if (!bridge) {
+        setStatus('无法连接桌面客户端桥接，请重启客户端。');
+        return;
+      }
+      bridge.getState().then(function (info) {
+        if (!info) return;
+        var lines = [];
+        if (info.appVersion) lines.push('DSH Desktop v' + esc(info.appVersion));
+        var st = info.state;
+        if (st && st.lastFailure) {
+          var f = st.lastFailure;
+          lines.push('最近异常: ' + esc(f.reason) + (f.exitCode != null ? ' (exitCode=' + esc(f.exitCode) + ')' : ''));
+          lines.push('发生时间: ' + esc(String(f.at || '').replace('T', ' ').slice(0, 19)));
+          lines.push('尝试次数: ' + esc(st.failures));
+        }
+        if (info.logsDir) lines.push('日志目录: ' + esc(info.logsDir));
+        if (info.crashDumpsDir) lines.push('崩溃转储: ' + esc(info.crashDumpsDir));
+        $('details').textContent = lines.join('\n');
+      }).catch(function () {});
+
+      $('reload').addEventListener('click', function () {
+        setStatus('正在重新加载…');
+        bridge.reload().then(function (r) {
+          if (r && r.ok) setStatus('正在加载界面…');
+          else setStatus('重新加载失败：' + ((r && r.error) || '未知错误'));
+        }).catch(function (e) { setStatus('重新加载失败：' + String(e && e.message || e)); });
+      });
+      $('restart').addEventListener('click', function () {
+        setStatus('正在重启客户端…');
+        bridge.restart();
+      });
+      $('openLogs').addEventListener('click', function () {
+        bridge.openLogs();
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -14,7 +14,7 @@
 // modules (sharp, node-pty, koffi, ...) match the Node ABI they were
 // installed for. We deliberately never rebuild them against Electron.
 
-const { app, BrowserWindow, Menu, Tray, shell, dialog, Notification, ipcMain, clipboard } = require('electron');
+const { app, BrowserWindow, Menu, Tray, shell, dialog, Notification, ipcMain, clipboard, crashReporter } = require('electron');
 const { spawn } = require('node:child_process');
 const path = require('node:path');
 const fs = require('node:fs');
@@ -25,6 +25,7 @@ const updater = require('./updater');
 const clientUpdater = require('./client-updater');
 const balance = require('./balance');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
+const { RendererRecovery } = require('./renderer-recovery');
 const zlib = require('node:zlib');
 
 // ---------------------------------------------------------------------------
@@ -96,6 +97,8 @@ let balanceCache = null;
 let balanceTimer = null;
 let restartingServer = false;
 let trayRecoveryTimer = null;
+let recovery = null; // 渲染进程崩溃/挂起自恢复状态机（renderer-recovery.js）
+let crashDumpsDir = '';
 
 // ---------------------------------------------------------------------------
 // 会话浮窗（分屏）：把会话弹出到独立窗口
@@ -359,7 +362,37 @@ function showBox(opts) {
 // dsh web server lifecycle
 // ---------------------------------------------------------------------------
 
+// Chromium 限制端口（net::ERR_UNSAFE_PORT）。dsh web / 预览服务用 --port 0
+// 随机选端口，可能命中这些端口导致页面永远无法加载（实测命中过 4045）。
+// 命中时自动重启服务换端口，而不是让用户面对无法加载的窗口。
+const CHROMIUM_RESTRICTED_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79,
+  87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137,
+  139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532,
+  540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723,
+  2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669,
+  6697, 10080,
+]);
+
+function restrictedPortOf(url) {
+  try {
+    const u = new URL(url);
+    const port = Number(u.port || (u.protocol === 'https:' ? '443' : '80'));
+    return CHROMIUM_RESTRICTED_PORTS.has(port) ? port : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// 集成测试专用：DSH_DESKTOP_TEST_FORCE_UNSAFE=1 时把第一次探测到的端口
+// 强制视为受限端口（6000），端到端验证「重启换端口」交接路径。
+let testForceUnsafeOnce = process.env.DSH_DESKTOP_TEST_FORCE_UNSAFE === '1';
+
 function startServer() {
+  return startServerWithRetries(4);
+}
+
+function startServerWithRetries(unsafePortRetries) {
   return new Promise((resolve, reject) => {
     // M1 修复：重入前先终结旧进程，避免孤儿 harness 同时写同一 DSH_HOME。
     if (serverProc && !serverProc.killed && !quitting) {
@@ -387,6 +420,7 @@ function startServer() {
     });
     serverProc = proc;
     let settled = false;
+    let handedOff = false; // 受限端口重启：本实例的退出不再影响外层 Promise/弹窗
     let bootTimer = null;
     const finish = (fn, value) => {
       if (!settled) { settled = true; fn(value); }
@@ -397,7 +431,31 @@ function startServer() {
       const text = chunk.toString();
       for (const line of text.split(/\r?\n/)) {
         const m = line.match(/dsh web:\s+(https?:\/\/\S+)/);
-        if (m) finish(resolve, m[1]);
+        if (!m) continue;
+        let blocked;
+        if (testForceUnsafeOnce) {
+          testForceUnsafeOnce = false;
+          blocked = 6000; // 测试钩子：仅第一次强制视为受限端口
+        } else {
+          blocked = restrictedPortOf(m[1]);
+        }
+        if (blocked && unsafePortRetries > 0) {
+          // 端口命中 Chromium 受限列表：结束该实例重启换端口（有上限）。
+          // 标记 handedOff，本实例的 exit 事件不得提前 reject 外层 Promise
+          // 或弹出「服务已停止」对话框，结果交由递归重启决定。
+          handedOff = true;
+          log('dsh', `端口 ${blocked} 属于 Chromium 受限端口（ERR_UNSAFE_PORT），重启服务换端口（剩余重试 ${unsafePortRetries} 次）`);
+          killTree(proc);
+          setTimeout(() => {
+            if (quitting) return finish(reject, new Error('应用正在退出'));
+            startServerWithRetries(unsafePortRetries - 1).then(
+              (url) => finish(resolve, url),
+              (err) => finish(reject, err)
+            );
+          }, 600);
+          return;
+        }
+        finish(resolve, m[1]);
       }
     };
     proc.stdout.on('data', onData);
@@ -409,8 +467,10 @@ function startServer() {
       // 原地重启（插件市场）或已替换为新进程时，不打扰用户、也不清掉新进程的句柄。
       const intentional = restartingServer || serverProc !== proc;
       if (serverProc === proc) serverProc = null;
-      finish(reject, new Error(`dsh web 启动失败（退出码 ${code}）。日志: ${path.join(logsDir, 'dsh-web.log')}`));
-      if (!quitting && !intentional && webUrl && mainWindow && !mainWindow.isDestroyed()) {
+      if (!handedOff) {
+        finish(reject, new Error(`dsh web 启动失败（退出码 ${code}）。日志: ${path.join(logsDir, 'dsh-web.log')}`));
+      }
+      if (!quitting && !intentional && !handedOff && webUrl && mainWindow && !mainWindow.isDestroyed()) {
         showBox({
           type: 'error',
           title: 'DSH 服务已停止',
@@ -494,7 +554,7 @@ function handleBootFailure(err) {
 // Window
 // ---------------------------------------------------------------------------
 
-function createWindow() {
+function createWindow(opts = {}) {
   mainWindow = new BrowserWindow({
     width: 1400,
     height: 900,
@@ -514,13 +574,15 @@ function createWindow() {
       spellcheck: false,
     },
   });
+  const win = mainWindow;
 
-  mainWindow.loadFile(path.join(__dirname, 'assets', 'loading.html'));
-  mainWindow.once('ready-to-show', () => mainWindow.show());
+  win.loadFile(path.join(__dirname, 'assets', 'loading.html'));
+  // startHidden：崩溃恢复重建窗口时保持「隐藏到托盘」状态，不突然弹出窗口。
+  win.once('ready-to-show', () => { if (!win.isDestroyed() && !opts.startHidden) win.show(); });
   // Keep the app brand in the OS title bar (the web UI sets its own <title>).
-  mainWindow.on('page-title-updated', (event) => {
+  win.on('page-title-updated', (event) => {
     event.preventDefault();
-    mainWindow.setTitle('DSH Desktop');
+    win.setTitle('DSH Desktop');
   });
 
   // Open target=_blank / window.open in the system browser.
@@ -554,14 +616,13 @@ function createWindow() {
   mainWindow.webContents.on('will-redirect', guardNavigation);
 
   // 渲染进程错误捕获：插件/页面异常统一落到 desktop.log，便于排查空白视图。
-  mainWindow.webContents.on('console-message', (_e, level, message, line, sourceId) => {
+  win.webContents.on('console-message', (_e, level, message, line, sourceId) => {
     if (level === 'error' || level === 'warning') {
       log('page', `[${level}] ${message} (${sourceId || 'unknown'}:${line})`);
     }
   });
-  mainWindow.webContents.on('render-process-gone', (_e, details) => {
-    log('page', `渲染进程异常退出: ${details.reason} (exitCode=${details.exitCode})`);
-  });
+  // 渲染进程崩溃/挂起的自恢复由 renderer-recovery.js 统一接管
+  // （boot 阶段经 wireWindowRecovery() 挂载），这里不再只记日志。
 
   // 移除菜单栏后仍保留的键盘快捷键。
   mainWindow.webContents.on('before-input-event', (event, input) => {
@@ -570,7 +631,7 @@ function createWindow() {
     if (input.key === 'F11') { mainWindow.setFullScreen(!mainWindow.isFullScreen()); event.preventDefault(); }
     else if (input.key === 'F12') { mainWindow.webContents.toggleDevTools(); event.preventDefault(); }
     else if (input.control && input.shift && key === 'i') { mainWindow.webContents.toggleDevTools(); event.preventDefault(); }
-    else if (input.control && key === 'r') { mainWindow.reload(); event.preventDefault(); }
+    else if (input.control && key === 'r') { reloadMainWindow(); event.preventDefault(); }
     else if (input.alt && key === 'f4') { mainWindow.close(); event.preventDefault(); }
   });
 
@@ -597,10 +658,85 @@ function createWindow() {
   });
 
   mainWindow.on('closed', () => {
-    mainWindow = null;
+    // 崩溃恢复会销毁并重建主窗：旧窗口的 closed 可能晚于新窗口创建，
+    // 必须校验身份，避免把新的 mainWindow 全局引用置空。
+    if (mainWindow === win) mainWindow = null;
     if (sponsorWindow && !sponsorWindow.isDestroyed()) sponsorWindow.destroy();
     sponsorWindow = null;
   });
+}
+
+// ---------------------------------------------------------------------------
+// 渲染进程自恢复：装配 renderer-recovery 状态机（Issue #9 根治修复）
+// ---------------------------------------------------------------------------
+
+function initRendererRecovery() {
+  if (recovery) return recovery;
+  const opts = {
+    log: (msg) => log('recovery', msg),
+    isQuitting: () => quitting,
+    isServerAlive: () => !!serverProc && serverProc.exitCode === null && !serverProc.killed,
+    getTarget: () => (webUrl ? { kind: 'url', url: webUrl } : null),
+    loadingPage: path.join(__dirname, 'assets', 'loading.html'),
+    recoveryPage: path.join(__dirname, 'assets', 'recovery.html'),
+    rebuildMainWindow: ({ startHidden } = {}) => {
+      if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy();
+      createWindow({ startHidden: !!startHidden });
+      wireWindowRecovery();
+      return mainWindow;
+    },
+    waitServerUp: (maxMs) => {
+      if (!webUrl) return Promise.reject(new Error('webUrl 未知'));
+      return waitUntilUp(webUrl, maxMs);
+    },
+    onGaveUp: (lastFailure) => {
+      writeRunState({ renderer: { state: 'gave-up', lastFailure, at: new Date().toISOString() } });
+    },
+    onStable: () => {
+      writeRunState({ renderer: { state: 'healthy', at: new Date().toISOString() } });
+    },
+    notify: (title, body) => {
+      try {
+        const n = new Notification({
+          title,
+          body,
+          icon: path.join(__dirname, 'assets', 'icon.png'),
+        });
+        n.on('click', () => showMainWindow());
+        n.show();
+      } catch (err) {
+        log('recovery', '通知发送失败: ' + err.message);
+      }
+    },
+  };
+  // 集成测试专用：缩短「稳定期」，加快测试节奏。生产环境恒为默认 30s。
+  if (process.env.DSH_DESKTOP_TEST && process.env.DSH_DESKTOP_TEST_STABILITY_MS) {
+    opts.STABILITY_MS = Number(process.env.DSH_DESKTOP_TEST_STABILITY_MS);
+  }
+  recovery = new RendererRecovery(opts);
+  return recovery;
+}
+
+function wireWindowRecovery() {
+  if (recovery && mainWindow && !mainWindow.isDestroyed()) recovery.attach(mainWindow, 'main');
+}
+
+// 统一的「重新加载」入口：处于恢复页（已放弃自动恢复）时走恢复流程，
+// 否则普通 reload。菜单与 Ctrl+R 共用。
+function reloadMainWindow() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  const st = recovery ? recovery.stateOf(mainWindow) : null;
+  if (st && st.gaveUp) {
+    log('recovery', '用户在恢复页触发重新加载');
+    recovery.retryNow(mainWindow);
+    return;
+  }
+  mainWindow.reload();
+}
+
+function startHeartbeatLoop() {
+  // renderer 心跳由 preload 每 5s 上报；这里周期性判定「可见窗口」是否失联。
+  setInterval(() => { if (recovery) recovery.checkHeartbeats(); }, 15000).unref();
 }
 
 // ---------------------------------------------------------------------------
@@ -647,9 +783,8 @@ function guardWebContents(wc) {
       log('float-page', `[${lvl}] ${text} (${src}:${lineNo})`);
     }
   });
-  wc.on('render-process-gone', (_e, details) => {
-    log('float-page', `浮窗渲染进程异常退出: ${details.reason} (exitCode=${details.exitCode})`);
-  });
+  // 浮窗渲染进程崩溃/挂起的自恢复由 renderer-recovery.js 统一接管
+  // （createFloatWindow 里经 recovery.attach 挂载），这里不再只记日志。
 }
 
 // 创建并登记一个会话浮窗。返回 BrowserWindow；失败返回 null。
@@ -701,6 +836,7 @@ function createFloatWindow(sessionId, { title } = {}) {
     }
   });
   guardWebContents(win.webContents);
+  if (recovery) recovery.attach(win, 'float');
 
   log('float', '已创建会话浮窗 sessionId=' + sessionId);
   return win;
@@ -1080,7 +1216,7 @@ function registerChromeIpc() {
       return { notifyOnTurnEnd, closeToTray: closeToTrayEnabled() };
     }
     switch (action) {
-      case 'reload': mainWindow.reload(); break;
+      case 'reload': reloadMainWindow(); break;
       case 'devtools': mainWindow.webContents.toggleDevTools(); break;
       case 'fullscreen': mainWindow.setFullScreen(!mainWindow.isFullScreen()); break;
       case 'open-browser': if (webUrl) shell.openExternal(webUrl); break;
@@ -1261,6 +1397,54 @@ function registerChromeIpc() {
     } catch (err) {
       return { ok: false, error: String((err && err.message) || err) };
     }
+  });
+
+  // renderer 心跳（preload 每 5s 上报）：用于「挂起无 unresponsive 事件」兜底判定。
+  ipcMain.on('dsh:renderer-heartbeat', (event) => {
+    if (recovery) recovery.noteHeartbeat(event.sender.id);
+  });
+
+  // 恢复页面（assets/recovery.html）的三个按钮。全部校验来源必须是主窗。
+  ipcMain.handle('chrome:recovery-state', (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return null;
+    return {
+      appVersion: APP_VERSION,
+      logsDir,
+      crashDumpsDir,
+      state: recovery ? recovery.stateOf(mainWindow) : null,
+    };
+  });
+
+  ipcMain.handle('chrome:recovery-reload', async (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
+    // 服务进程已退出时先重启服务（可能换新端口），再恢复加载。
+    if (!serverProc || serverProc.exitCode !== null || serverProc.killed) {
+      try {
+        await startAndShow();
+      } catch (err) {
+        return { ok: false, error: String((err && err.message) || err) };
+      }
+    }
+    recovery.retryNow(mainWindow);
+    return { ok: true };
+  });
+
+  ipcMain.handle('chrome:recovery-restart', (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
+    log('recovery', '用户在恢复页面选择重启客户端');
+    quitting = true;
+    forceQuit = true;
+    markCleanExit();
+    killTree(serverProc);
+    app.relaunch();
+    app.exit(0);
+    return { ok: true };
+  });
+
+  ipcMain.handle('chrome:recovery-open-logs', (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
+    shell.openPath(logsDir);
+    return { ok: true };
   });
 }
 
@@ -1843,11 +2027,127 @@ function startPreviewStaticServer() {
       res.end();
     }
   });
-  server.listen(0, "127.0.0.1", () => {
-    previewStaticPort = server.address().port;
-    log("boot", "预览静态服务已启动: http://127.0.0.1:" + previewStaticPort);
-  });
+  const listenPreview = (retriesLeft) => {
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      if (CHROMIUM_RESTRICTED_PORTS.has(port) && retriesLeft > 0) {
+        log("boot", `预览服务端口 ${port} 受限，重试换端口（剩余 ${retriesLeft} 次）`);
+        server.close(() => listenPreview(retriesLeft - 1));
+        return;
+      }
+      previewStaticPort = port;
+      log("boot", "预览静态服务已启动: http://127.0.0.1:" + previewStaticPort);
+    });
+  };
+  listenPreview(4);
   server.on("error", (err) => log("boot", "预览静态服务失败: " + err.message));
+}
+
+// ---------------------------------------------------------------------------
+// 集成测试控制通道：仅在 DSH_DESKTOP_TEST=1 时启用。
+// 测试 harness 向 DSH_DESKTOP_TEST_DIR/test-control.json 写入命令，
+// 本进程轮询执行并把结果写入 test-status.json。renderer 崩溃时页面不可用，
+// 因此选择文件通道而非 IPC，保证任何时刻都能下达命令。
+// ---------------------------------------------------------------------------
+function setupTestChannel() {
+  const dir = process.env.DSH_DESKTOP_TEST_DIR;
+  if (!process.env.DSH_DESKTOP_TEST || !dir) return;
+  const ctrlFile = path.join(dir, 'test-control.json');
+  const statFile = path.join(dir, 'test-status.json');
+  const writeStatus = (id, ok, detail) => {
+    try {
+      fs.writeFileSync(statFile, JSON.stringify({ id, ok: !!ok, detail: detail === undefined ? null : detail, at: new Date().toISOString() }));
+    } catch {}
+  };
+  const commands = {
+    'crash-main': () => {
+      if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.forcefullyCrashRenderer();
+      else throw new Error('no main window');
+    },
+    'kill-main': () => {
+      const pid = mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents.getOSProcessId() : 0;
+      if (!pid) throw new Error('no renderer pid');
+      process.kill(pid);
+    },
+    'hang-main': () => {
+      if (!mainWindow || mainWindow.isDestroyed()) throw new Error('no main window');
+      // 在 renderer 主线程注入 120s 忙循环制造挂起；恢复机制会强制终结该进程。
+      mainWindow.webContents
+        .executeJavaScript('(function(){var s=Date.now();while(Date.now()-s<120000){}})()')
+        .catch(() => {});
+    },
+    'crash-float': () => {
+      const sid = '__test_float__';
+      const win = createFloatWindow(sid, { title: '测试浮窗' });
+      if (!win) throw new Error('float creation failed');
+      setTimeout(() => {
+        try {
+          if (!win.isDestroyed()) win.webContents.forcefullyCrashRenderer();
+        } catch {}
+      }, 2500);
+    },
+    'kill-server-silent': () => {
+      // 模拟插件市场式原地重启的前半程：退出处理器不弹窗。
+      // 不置空 serverProc：让 isServerAlive() 依据真实退出状态，
+      // 优雅终止完成（exit 事件）后自然变为 false。
+      restartingServer = true;
+      killTree(serverProc);
+    },
+    'restart-server': async () => {
+      restartingServer = true;
+      try {
+        const url = await startAndShow();
+        return { ok: true, url };
+      } finally {
+        restartingServer = false;
+      }
+    },
+    'reload-main': () => {
+      if (!mainWindow || mainWindow.isDestroyed()) throw new Error('no main window');
+      mainWindow.reload();
+    },
+    'recovery-reload': () => {
+      if (!recovery || !mainWindow || mainWindow.isDestroyed()) throw new Error('no window');
+      recovery.retryNow(mainWindow);
+    },
+    state: () => {
+      const url = mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents.getURL() : null;
+      return {
+        url,
+        webUrl,
+        serverAlive: !!serverProc && serverProc.exitCode === null && !serverProc.killed,
+        recovery: recovery ? recovery.stateOf(mainWindow) : null,
+      };
+    },
+    quit: () => {
+      forceQuit = true;
+      setTimeout(() => app.quit(), 100);
+    },
+  };
+  let lastId = null;
+  const poll = setInterval(() => {
+    let raw;
+    try { raw = fs.readFileSync(ctrlFile, 'utf8'); } catch { return; }
+    let cmd;
+    try { cmd = JSON.parse(raw); } catch { return; }
+    if (!cmd || !cmd.id || cmd.id === lastId) return;
+    lastId = cmd.id;
+    try {
+      const fn = commands[cmd.cmd];
+      if (!fn) { writeStatus(cmd.id, false, 'unknown-command'); return; }
+      const r = fn(cmd.args || {});
+      if (r && typeof r.then === 'function') {
+        r.then((v) => writeStatus(cmd.id, true, v))
+          .catch((e) => writeStatus(cmd.id, false, String((e && e.message) || e)));
+      } else {
+        writeStatus(cmd.id, true, r === undefined ? null : r);
+      }
+    } catch (err) {
+      writeStatus(cmd.id, false, String((err && err.stack) || err));
+    }
+  }, 150);
+  poll.unref();
+  log('test-event', 'test-channel-ready');
 }
 
 async function boot() {
@@ -1860,6 +2160,22 @@ async function boot() {
 
   userDataDir = app.getPath('userData');
   logsDir = path.join(userDataDir, 'logs');
+  // 崩溃取证（Issue #9）：把 Crashpad minidump 固定到数据目录并保留，
+  // 用于后续定位 0xC0000005 的底层来源（不联网上传）。
+  crashDumpsDir = path.join(userDataDir, 'crash-dumps');
+  try {
+    fs.mkdirSync(crashDumpsDir, { recursive: true });
+    app.setPath('crashDumps', crashDumpsDir);
+    crashReporter.start({
+      productName: 'DSH Desktop',
+      companyName: 'DSH Desktop',
+      submitURL: '',
+      uploadToServer: false,
+      compress: true,
+    });
+  } catch (err) {
+    log('crash', 'crashReporter 初始化失败: ' + err.message);
+  }
   // DSH_HOME: respect an explicit override; otherwise let dsh use its own
   // default (~/.dsh), so the desktop app shares config/sessions with the CLI.
   dshHome = process.env.DSH_HOME || '';
@@ -1884,7 +2200,11 @@ async function boot() {
   syncCompanionPlugins();
   applyRuntimeFlashFix();
   applyPromptExposeFix();
+  initRendererRecovery();
   createWindow();
+  wireWindowRecovery();
+  startHeartbeatLoop();
+  setupTestChannel();
   const home = dshHome || process.env.DSH_HOME || require('node:path').join(require('node:os').homedir(), '.dsh');
   await repairProfileFallback(home);
   startAndShow()
@@ -1915,6 +2235,7 @@ async function boot() {
         setTimeout(() => runClientUpdateFlow(false), 60000).unref();
         setInterval(() => runClientUpdateFlow(false), 12 * 3600 * 1000).unref();
       }
+      log('test-event', 'boot-ready');
     })
     .catch((err) => handleBootFailure(err));
 }
@@ -1961,6 +2282,7 @@ if (!gotLock) {
     killTree(serverProc);
     updater.abort();
     if (sessionWatcher) sessionWatcher.stop();
+    if (recovery) recovery.dispose();
     if (balanceTimer) clearInterval(balanceTimer);
     if (trayRecoveryTimer) { clearInterval(trayRecoveryTimer); trayRecoveryTimer = null; }
     if (tray) { try { tray.destroy(); } catch {} tray = null; }

--- a/dsh-desktop/preload.js
+++ b/dsh-desktop/preload.js
@@ -60,9 +60,32 @@ const dshDesktop = {
     open: (sessionId) => ipcRenderer.invoke('chrome:float-window', { action: 'open', sessionId }),
     close: () => ipcRenderer.send('float:close'),
   },
+  // 恢复页面（assets/recovery.html）使用的动作与状态读取。
+  recovery: {
+    getState: () => ipcRenderer.invoke('chrome:recovery-state'),
+    reload: () => ipcRenderer.invoke('chrome:recovery-reload'),
+    restart: () => ipcRenderer.invoke('chrome:recovery-restart'),
+    openLogs: () => ipcRenderer.invoke('chrome:recovery-open-logs'),
+  },
 };
 
 contextBridge.exposeInMainWorld('dshDesktop', dshDesktop);
+
+// ---------------------------------------------------------------------------
+// Renderer 心跳：每 5s 向主进程上报一次。主进程用它兜底判定「挂起但
+// Chromium 未发出 unresponsive 事件」的场景（窗口不可见时页面定时器会被
+// 节流，主进程只对可见窗口做判定；重新可见时立即补报一次心跳）。
+// ---------------------------------------------------------------------------
+{
+  const beat = () => {
+    try { ipcRenderer.send('dsh:renderer-heartbeat'); } catch {}
+  };
+  beat();
+  setInterval(beat, 5000);
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) beat();
+  });
+}
 
 // 浮窗模式检测：preload 的 process.argv 由 webPreferences.additionalArguments 注入。
 // 浮窗内注入 window.__DSH_FLOAT__ = { sessionId }，供 dsh-float-window 插件识别；

--- a/dsh-desktop/renderer-recovery.js
+++ b/dsh-desktop/renderer-recovery.js
@@ -1,0 +1,574 @@
+'use strict';
+
+// ============================================================================
+// DSH Desktop — 渲染进程崩溃/挂起自恢复状态机（Issue #9 根治修复核心模块）
+//
+// 背景：renderer 以 0xC0000005（ACCESS_VIOLATION）等异常退出后，旧实现只在
+// 三处 render-process-gone 处理器里记录日志、没有任何恢复动作，窗口永久
+// 黑屏/白屏，用户只能强制退出。本模块为「主窗 + 会话浮窗」提供统一自恢复：
+//
+//   · render-process-gone（crashed / killed / oom / …）→ 指数退避重新加载
+//   · 连续失败第 3 次 → 主窗销毁重建 BrowserWindow；浮窗直接关闭
+//   · 失败超过上限 → 主窗切到本地错误页（重载/重启/看日志按钮）+ 系统通知；
+//     绝不允许无限崩溃循环
+//   · unresponsive / 心跳丢失（AppHangB1 挂起）→ 宽限期后强制终结 renderer，
+//     复用同一条恢复路径
+//   · did-fail-load（连接失败等）→ 服务进程健在时退避重试（覆盖插件市场
+//     重启服务的间隙）；服务进程已退出时不动作，交给既有
+//     「DSH 服务已停止」对话框接管，避免双弹窗
+//   · 只有页面加载成功后「稳定存活 30 秒」才清零故障计数 —— 防止
+//     「加载即崩溃」的场景每次加载成功都重置计数造成无限快速循环
+//   · clean-exit / 退出中 / 窗口已销毁 一律不触发恢复
+//
+// 设计约束：本模块不 require('electron')，全部副作用经注入回调完成，
+// 状态机决策函数纯函数化导出，便于 node:test 单元测试与
+// DSH_DESKTOP_TEST 集成测试直接验证。
+// ============================================================================
+
+const { pathToFileURL } = require('node:url');
+
+const DEFAULT_OPTS = {
+  // 一个「故障窗口」内允许的自动恢复动作总数（含重建主窗）。
+  MAX_ATTEMPTS: 4,
+  // 故障窗口时长：超过此时长无新故障（或已稳定）才清零计数。
+  ATTEMPT_WINDOW_MS: 90 * 1000,
+  // 加载成功后需要稳定存活这么久才清零故障计数。
+  STABILITY_MS: 30 * 1000,
+  FIRST_DELAY_MS: 800,
+  BACKOFF_BASE_MS: 2000,
+  BACKOFF_MAX_MS: 15000,
+  LOAD_TIMEOUT_MS: 30 * 1000,
+  UNRESPONSIVE_GRACE_MS: 20 * 1000,
+  HEARTBEAT_MISS_MS: 45 * 1000,
+  SERVER_WAIT_MAX_MS: 60 * 1000,
+  ERROR_PAGE_RELOAD_MIN_INTERVAL_MS: 10 * 1000,
+  HANG_PENDING_TOLERANCE_MS: 10 * 1000,
+};
+
+// 纯函数：按故障次数计算退避延迟（指数退避 + 抖动，避免雷击效应）。
+function computeBackoff(failureCount, opts) {
+  const o = { ...DEFAULT_OPTS, ...(opts || {}) };
+  if (failureCount <= 1) return o.FIRST_DELAY_MS;
+  const cap = Math.min(o.BACKOFF_MAX_MS, o.BACKOFF_BASE_MS * 2 ** (failureCount - 1));
+  const jitter = Math.round(cap * (0.15 + 0.2 * Math.random())); // +15%~+35%
+  return Math.round(cap + jitter);
+}
+
+// 纯函数：由当前故障计数决定下一步动作。
+//   failures 1~2 → reload；3（主窗且本窗口未重建过）→ rebuild；>MAX → give-up。
+function nextAction(failures, kind, rebuiltInBurst) {
+  if (failures > DEFAULT_OPTS.MAX_ATTEMPTS) return 'give-up';
+  if (kind === 'main' && failures === 3 && !rebuiltInBurst) return 'rebuild';
+  return 'reload';
+}
+
+function sameOrigin(a, b) {
+  try { return new URL(a).origin === new URL(b).origin; } catch { return false; }
+}
+
+class RendererRecovery {
+  // opts 注入（全部由 main.js 提供）：
+  //   log(msg)                      写日志
+  //   isQuitting() -> bool          应用是否正在退出
+  //   isServerAlive() -> bool       dsh web 服务进程是否健在
+  //   getTarget(win) -> {kind:'url',url}|{kind:'file',path}|null   当前目标页
+  //   loadingPage / recoveryPage    加载页 / 错误页绝对路径
+  //   rebuildMainWindow({startHidden}) -> BrowserWindow   销毁并重建主窗
+  //   waitServerUp(maxMs) -> Promise  等待 dsh web 服务可访问
+  //   onGaveUp(lastFailure) / onRecovered() / onStable()   事件回调（日志/状态）
+  //   notify(title, body)           系统通知
+  constructor(opts) {
+    this.opts = { ...DEFAULT_OPTS, ...opts };
+    this._states = new Map(); // winId -> state
+    this._wins = new Set(); // BrowserWindow
+    this._heartbeats = new Map(); // webContentsId -> lastBeatAt
+  }
+
+  // ---------------------------------------------------------------- helpers
+
+  _log(msg) {
+    try { this.opts.log(msg); } catch { /* 日志失败不影响恢复 */ }
+  }
+
+  _state(win) {
+    let s = this._states.get(win.id);
+    if (!s) {
+      s = {
+        kind: 'main',
+        failures: 0,
+        windowStart: 0,
+        gaveUp: false,
+        expectingWeb: false,
+        userHidden: true, // 窗口创建时是隐藏的；show 事件后置 false
+        attemptTimer: null,
+        stabilityTimer: null,
+        hangGrace: null,
+        hangDetectedAt: 0,
+        gen: 0,
+        rebuiltInBurst: false,
+        failuresAtLoad: 0,
+        loadFlight: null, // 在途加载标记：{active}；active=true 时 did-fail-load 由加载调用方处理
+        lastFailure: null,
+        lastErrorPageAt: 0,
+        pendingHangCrash: 0,
+      };
+      this._states.set(win.id, s);
+    }
+    return s;
+  }
+
+  _clearTimers(s) {
+    if (s.attemptTimer) { clearTimeout(s.attemptTimer); s.attemptTimer = null; }
+    if (s.stabilityTimer) { clearTimeout(s.stabilityTimer); s.stabilityTimer = null; }
+    if (s.hangGrace) { clearTimeout(s.hangGrace); s.hangGrace = null; }
+  }
+
+  _resetBurst(s) {
+    this._clearTimers(s);
+    s.failures = 0;
+    s.failuresAtLoad = 0;
+    s.windowStart = 0;
+    s.gaveUp = false;
+    s.rebuiltInBurst = false;
+    s.lastFailure = null;
+    s.pendingHangCrash = 0;
+    s.hangDetectedAt = 0;
+  }
+
+  _countFailure(win, s) {
+    const now = Date.now();
+    if (s.windowStart && now - s.windowStart > this.opts.ATTEMPT_WINDOW_MS) {
+      // 故障窗口已过：这是一轮新的故障序列。
+      s.windowStart = now;
+      s.failures = 0;
+      s.rebuiltInBurst = false;
+    }
+    if (!s.windowStart) s.windowStart = now;
+    s.failures += 1;
+  }
+
+  _sameTargetUrl(url, target) {
+    if (!target || !url) return false;
+    if (target.kind === 'url') return sameOrigin(url, target.url);
+    if (target.kind === 'file') {
+      try { return url === pathToFileURL(target.path).href; } catch { return false; }
+    }
+    return false;
+  }
+
+  // ---------------------------------------------------------------- 对外 API
+
+  // 把恢复机制挂到窗口上（主窗/浮窗）。重复 attach 同窗口只会追加一次状态。
+  attach(win, kind) {
+    if (!win || win.isDestroyed()) return;
+    const s = this._state(win);
+    s.kind = kind;
+    const wc = win.webContents;
+
+    wc.on('render-process-gone', (_e, details) => this._onGone(win, details));
+    wc.on('unresponsive', () => this._onUnresponsive(win));
+    wc.on('responsive', () => this._onResponsive(win));
+    wc.on('did-finish-load', () => this._onFinishLoad(win));
+    wc.on('did-fail-load', (_e, code, desc, url, isMainFrame) => {
+      if (isMainFrame) this._onFailLoad(win, { code, desc, url });
+    });
+    wc.on('destroyed', () => {
+      this._states.delete(win.id);
+      this._heartbeats.delete(wc.id);
+      this._wins.delete(win);
+    });
+    // 可见性用 show/hide 事件自行追踪（而非 isVisible()）：后者在挂起、
+    // RDP/服务会话等场景下会误报 false，导致挂起判定被永远跳过。
+    win.on('show', () => {
+      const st = this._state(win);
+      st.userHidden = false;
+      // 窗口重新可见：给 renderer 一段宽限恢复心跳（后台节流会让心跳
+      // 时间戳陈旧），避免「从托盘唤出」瞬间被误判为挂起。
+      this._heartbeats.set(wc.id, Date.now());
+    });
+    win.on('hide', () => {
+      this._state(win).userHidden = true;
+    });
+
+    this._wins.add(win);
+  }
+
+  // preload 每 5s 上报一次心跳。
+  noteHeartbeat(wcId) {
+    this._heartbeats.set(wcId, Date.now());
+  }
+
+  // 由 main.js 的定时器周期调用；只对「可见（未被用户隐藏）且应显示
+  // Web UI」的窗口判定。可见性来自 show/hide 事件追踪。
+  checkHeartbeats() {
+    const now = Date.now();
+    for (const win of this._wins) {
+      if (!win || win.isDestroyed()) continue;
+      const s = this._state(win);
+      if (!s.expectingWeb || s.gaveUp || s.hangGrace) continue;
+      if (s.userHidden) continue;
+      const last = this._heartbeats.get(win.webContents.id) || 0;
+      if (last && now - last > this.opts.HEARTBEAT_MISS_MS) {
+        this._log(`心跳丢失 ${now - last}ms（kind=${s.kind}），视为挂起进入恢复`);
+        this._onUnresponsive(win);
+      }
+    }
+  }
+
+  // 错误页「重新加载」按钮：清零状态并立即重新加载目标页。
+  retryNow(win) {
+    if (!win || win.isDestroyed()) return false;
+    const s = this._state(win);
+    this._resetBurst(s);
+    s.gen += 1;
+    this._log(`用户请求立即恢复加载（kind=${s.kind}）`);
+    this._schedule(win, s);
+    return true;
+  }
+
+  // 错误页展示用状态。
+  stateOf(win) {
+    if (!win || win.isDestroyed()) return null;
+    const s = this._state(win);
+    return {
+      kind: s.kind,
+      failures: s.failures,
+      gaveUp: s.gaveUp,
+      expectingWeb: s.expectingWeb,
+      lastFailure: s.lastFailure,
+    };
+  }
+
+  dispose() {
+    for (const s of this._states.values()) this._clearTimers(s);
+    this._states.clear();
+    this._wins.clear();
+    this._heartbeats.clear();
+  }
+
+  // ---------------------------------------------------------------- 事件入口
+
+  _onGone(win, details) {
+    if (this.opts.isQuitting() || win.isDestroyed()) return;
+    const s = this._state(win);
+    const reason = details && details.reason;
+    if (reason === 'clean-exit') {
+      // 主动销毁/退出产生的正常退出：只复位计时器，不触发恢复。
+      this._clearTimers(s);
+      return;
+    }
+    const now = Date.now();
+    if (s.pendingHangCrash && now - s.pendingHangCrash < this.opts.HANG_PENDING_TOLERANCE_MS) {
+      // 挂起流程已经计数并准备恢复，这里不重复计数。
+      s.pendingHangCrash = 0;
+    } else {
+      this._countFailure(win, s);
+    }
+    s.lastFailure = {
+      reason: String(reason || 'unknown'),
+      exitCode: details && details.exitCode !== undefined ? Number(details.exitCode) : null,
+      at: new Date().toISOString(),
+    };
+    // 使在途的恢复加载尝试失效：其后续完成/失败结果不再被信任，
+    // 避免「崩溃事件已计数、旧尝试失败路径又计数一次」的重复计数。
+    s.gen += 1;
+    this._log(
+      `渲染进程异常退出: reason=${s.lastFailure.reason} exitCode=${s.lastFailure.exitCode} ` +
+      `kind=${s.kind} failures=${s.failures}${s.gaveUp ? ' (已放弃自动恢复)' : ''}`
+    );
+    if (s.gaveUp) {
+      // 错误页自身崩溃：限频地重新加载错误页；浮窗直接关闭。
+      if (s.kind === 'main') this._showErrorPage(win, s);
+      else this._closeFloat(win);
+      return;
+    }
+    this._schedule(win, s);
+  }
+
+  _onUnresponsive(win) {
+    if (this.opts.isQuitting() || win.isDestroyed()) return;
+    const s = this._state(win);
+    if (s.gaveUp || !s.expectingWeb || s.hangGrace) return;
+    this._log(`检测到界面无响应（kind=${s.kind}），宽限 ${this.opts.UNRESPONSIVE_GRACE_MS}ms 后强制恢复`);
+    s.hangDetectedAt = Date.now();
+    s.hangGrace = setTimeout(() => {
+      s.hangGrace = null;
+      if (win.isDestroyed() || this.opts.isQuitting() || s.gaveUp) return;
+      // 宽限期到：若「挂起判定之后」收到过心跳说明 renderer 已恢复，
+      // 取消处理；否则强制终结 renderer 触发恢复路径。
+      const last = this._heartbeats.get(win.webContents.id) || 0;
+      if (last && last > s.hangDetectedAt) {
+        this._log('宽限期内心跳恢复，取消挂起处理');
+        return;
+      }
+      this._log('界面持续无响应，强制终结渲染进程以触发恢复');
+      s.pendingHangCrash = Date.now();
+      s.lastFailure = { reason: 'unresponsive', exitCode: null, at: new Date().toISOString() };
+      this._countFailure(win, s);
+      let forced = false;
+      try {
+        if (typeof win.webContents.forcefullyCrashRenderer === 'function') {
+          win.webContents.forcefullyCrashRenderer(); // 后续由 render-process-gone 统一走恢复
+          forced = true;
+        }
+      } catch (err) {
+        this._log('强制终结渲染进程失败: ' + err.message);
+      }
+      if (!forced) this._schedule(win, s);
+    }, this.opts.UNRESPONSIVE_GRACE_MS);
+    if (s.hangGrace && typeof s.hangGrace.unref === 'function') s.hangGrace.unref();
+  }
+
+  _onResponsive(win) {
+    const s = this._state(win);
+    if (s.hangGrace) {
+      clearTimeout(s.hangGrace);
+      s.hangGrace = null;
+      this._log('界面已恢复响应，取消挂起处理');
+    }
+  }
+
+  _onFinishLoad(win) {
+    if (win.isDestroyed()) return;
+    const s = this._state(win);
+    const target = this.opts.getTarget(win);
+    const url = win.webContents.getURL();
+    if (target && target.kind === 'url' && this._sameTargetUrl(url, target)) {
+      if (s.gaveUp) {
+        // 放弃后由旧尝试加载成功的 Web UI 不算恢复：强制切回错误页，
+        // 防止「放弃 → 旧尝试加载成功 → 清零 → 再崩溃」的撤销循环。
+        this._log('已放弃自动恢复，忽略迟到的 Web 加载，回到恢复页');
+        this._showErrorPage(win, s, true);
+        return;
+      }
+      // Web UI 加载成功：进入「心跳监控」；记录加载时刻的故障计数，
+      // 稳定期结束时若期间又发生新故障则保留计数（脏检查），
+      // 防止「崩溃→恢复→崩溃」的慢速循环因每次都清零而无限延续。
+      s.expectingWeb = true;
+      s.failuresAtLoad = s.failures;
+      this._log(`界面加载成功: ${url}`);
+      if (s.stabilityTimer) clearTimeout(s.stabilityTimer);
+      s.stabilityTimer = setTimeout(() => {
+        s.stabilityTimer = null;
+        if (win.isDestroyed()) return;
+        if (s.failures === (s.failuresAtLoad || 0)) {
+          // 本轮加载后没有新故障：完全康复，清零计数并上报健康状态。
+          this._log(`界面已稳定（failures=${s.failures}），清零故障计数`);
+          try { this.opts.onStable && this.opts.onStable(); } catch {}
+          this._resetBurst(s);
+        } else {
+          this._log(`界面已稳定，但故障窗口内又发生故障（failures=${s.failures}），保留计数防止循环`);
+        }
+        s.expectingWeb = true;
+      }, this.opts.STABILITY_MS);
+      if (s.stabilityTimer && typeof s.stabilityTimer.unref === 'function') s.stabilityTimer.unref();
+    } else if (target && target.kind === 'file' && this._sameTargetUrl(url, target)) {
+      // 加载页/错误页加载完成：非 Web 内容，心跳监控不启用。
+      s.expectingWeb = false;
+    }
+  }
+
+  _onFailLoad(win, { code, desc, url }) {
+    if (this.opts.isQuitting() || win.isDestroyed()) return;
+    if (code === -3) return; // ERR_ABORTED：重载/跳转的正常中断
+    const s = this._state(win);
+    if (s.gaveUp) return; // 错误页自身的加载失败无须处理
+    if (s.loadFlight && s.loadFlight.active) {
+      // 属于恢复模块自己的在途加载：由 _attempt 的 Promise 结果统一处理，
+      // 这里不重复计数/调度。
+      return;
+    }
+    const target = this.opts.getTarget(win);
+    if (!this._sameTargetUrl(url, target)) return; // 只关心目标页主框架
+    this._log(`目标页加载失败: code=${code} desc=${desc || ''} url=${url}`);
+    if (!this.opts.isServerAlive()) {
+      // 服务进程已退出：既有「DSH 服务已停止」对话框接管交互；
+      // 浮窗留在原地是死屏，直接关闭。
+      this._log('服务进程已退出，交由既有重启对话框处理');
+      if (s.kind === 'float') this._closeFloat(win);
+      return;
+    }
+    this._countFailure(win, s);
+    this._schedule(win, s);
+  }
+
+  // ---------------------------------------------------------------- 恢复流程
+
+  _schedule(win, s) {
+    if (s.attemptTimer) {
+      // 新故障到来时取消排队中的恢复动作，按最新计数重新决策：
+      // 否则单飞机制会让「重建 / 放弃」分级被快速故障潮跳过
+      // （例如计数从 2 直接跳到 6，重建档永远轮不到）。
+      clearTimeout(s.attemptTimer);
+      s.attemptTimer = null;
+      s.gen += 1; // 同时放弃可能在途的加载尝试，其结果不再被信任
+    }
+    const action = nextAction(s.failures, s.kind, s.rebuiltInBurst);
+    if (action === 'give-up') { this._giveUp(win, s); return; }
+    if (action === 'rebuild') { this._rebuildNow(win, s); return; }
+    const delay = computeBackoff(s.failures, this.opts);
+    this._log(`安排恢复: kind=${s.kind} failures=${s.failures} 延迟=${delay}ms 动作=reload`);
+    s.attemptTimer = setTimeout(() => {
+      s.attemptTimer = null;
+      this._attempt(win, s, ++s.gen);
+    }, delay);
+    if (s.attemptTimer && typeof s.attemptTimer.unref === 'function') s.attemptTimer.unref();
+  }
+
+  async _attempt(win, s, gen) {
+    if (this.opts.isQuitting() || win.isDestroyed() || gen !== s.gen) return;
+    let target = this.opts.getTarget(win);
+    if (!target) {
+      // 尚未拿到 webUrl（启动早期崩溃）：主窗回加载页，boot 流程会继续接管；
+      // 浮窗此时不存在，防御性关闭。
+      if (s.kind === 'float') { this._closeFloat(win); return; }
+      target = { kind: 'file', path: this.opts.loadingPage };
+    }
+    try {
+      await this._loadTracked(win, s, target, gen);
+      return; // 成功：由 did-finish-load 进入稳定期判定
+    } catch (err) {
+      if (this.opts.isQuitting() || win.isDestroyed() || gen !== s.gen) return;
+      if (/ERR_ABORTED/.test(String((err && err.message) || err))) {
+        // 被更新的加载（用户 Ctrl+R / 新恢复动作）取代：不视为失败。
+        return;
+      }
+      this._log(`恢复加载失败: ${((err && err.message) || err)}`);
+      // 1) 服务进程健在但连不上：多为插件市场原地重启的间隙，
+      //    等待服务恢复后用「最新」webUrl 重试一次，不计入崩溃失败。
+      if (target.kind === 'url' && this.opts.isServerAlive()) {
+        let waited = false;
+        try {
+          await this.opts.waitServerUp(this.opts.SERVER_WAIT_MAX_MS);
+          waited = true;
+        } catch { waited = false; }
+        if (this.opts.isQuitting() || win.isDestroyed() || gen !== s.gen) return;
+        const fresh = this.opts.getTarget(win);
+        if (waited && fresh && fresh.kind === 'url') {
+          try {
+            await this._loadTracked(win, s, fresh, gen);
+            return;
+          } catch (err2) {
+            if (gen !== s.gen || /ERR_ABORTED/.test(String((err2 && err2.message) || err2))) return;
+            this._log(`服务恢复后重试加载仍失败: ${((err2 && err2.message) || err2)}`);
+          }
+        }
+      }
+      // 2) 服务进程已退出：既有对话框接管，不循环、不弹窗。
+      if (target.kind === 'url' && !this.opts.isServerAlive()) {
+        this._log('服务进程已退出，交由既有重启对话框处理');
+        if (s.kind === 'float') this._closeFloat(win);
+        return;
+      }
+      // 3) 常规失败：计入并进入下一档（重载 → 重建 → 放弃）。
+      this._countFailure(win, s);
+      this._schedule(win, s);
+    }
+  }
+
+  // 带「在途标记」的加载：did-fail-load 事件与该加载属于同一动作，
+  // 由本函数的 Promise 结果统一处理，避免事件与拒绝路径重复计数。
+  async _loadTracked(win, s, target, gen) {
+    const flight = { active: true };
+    s.loadFlight = flight;
+    try {
+      await this._loadWithTimeout(win, target, gen);
+    } finally {
+      flight.active = false;
+      if (s.loadFlight === flight) s.loadFlight = null;
+    }
+  }
+
+  _loadWithTimeout(win, target, gen) {
+    return new Promise((resolve, reject) => {
+      if (win.isDestroyed()) return reject(new Error('window destroyed'));
+      let settled = false;
+      let timer = null;
+      const done = (fn, v) => {
+        if (settled) return;
+        settled = true;
+        if (timer) { clearTimeout(timer); timer = null; }
+        fn(v);
+      };
+      const p = target.kind === 'url'
+        ? win.webContents.loadURL(target.url)
+        : win.webContents.loadFile(target.path);
+      p.then(
+        (v) => done(resolve, v),
+        (err) => done(reject, err)
+      );
+      timer = setTimeout(() => {
+        // 超时只放弃本次等待，绝不 kill webContents：慢加载（首次启动等）
+        // 是合法场景；后续故障事件或下一次调度会继续处理。
+        done(reject, new Error('load timeout'));
+      }, this.opts.LOAD_TIMEOUT_MS);
+      if (timer && typeof timer.unref === 'function') timer.unref();
+    });
+  }
+
+  _rebuildNow(win, s) {
+    this._log(`连续失败达到重建阈值（failures=${s.failures}），重建主窗口`);
+    const carried = {
+      failures: s.failures,
+      windowStart: s.windowStart,
+      rebuiltInBurst: true,
+      lastFailure: s.lastFailure,
+    };
+    let newWin = null;
+    try {
+      newWin = this.opts.rebuildMainWindow({ startHidden: s.userHidden });
+    } catch (err) {
+      this._log(`重建主窗口异常: ${((err && err.message) || err)}`);
+      this._countFailure(win, s);
+      this._schedule(win, s);
+      return;
+    }
+    if (!newWin || newWin.isDestroyed()) {
+      this._countFailure(win, s);
+      this._schedule(win, s);
+      return;
+    }
+    const ns = this._state(newWin);
+    Object.assign(ns, carried);
+    this._log('主窗口已重建，继续恢复流程');
+    this._schedule(newWin, ns);
+  }
+
+  _giveUp(win, s) {
+    if (s.gaveUp) return;
+    s.gaveUp = true;
+    this._clearTimers(s);
+    s.gen += 1; // 使所有在途的恢复尝试失效，其结果不再被信任
+    this._log(`自动恢复失败达到上限，kind=${s.kind} failures=${s.failures}，停止自动恢复`);
+    if (s.kind === 'main') {
+      this._showErrorPage(win, s, true);
+      try { this.opts.onGaveUp && this.opts.onGaveUp(s.lastFailure); } catch {}
+      try {
+        this.opts.notify && this.opts.notify(
+          'DSH Desktop 界面多次异常退出',
+          '已暂停自动恢复并显示恢复页面。你的数据与后台任务不受影响，仍在继续运行。'
+        );
+      } catch {}
+    } else {
+      this._closeFloat(win);
+    }
+  }
+
+  _showErrorPage(win, s, force = false) {
+    if (win.isDestroyed()) return;
+    const now = Date.now();
+    if (!force && now - s.lastErrorPageAt < this.opts.ERROR_PAGE_RELOAD_MIN_INTERVAL_MS) return;
+    s.lastErrorPageAt = now;
+    this._log('加载本地恢复页面');
+    if (this.opts.recoveryPage) {
+      win.webContents.loadFile(this.opts.recoveryPage).catch(() => {});
+    }
+  }
+
+  _closeFloat(win) {
+    this._log('关闭无法恢复的浮窗');
+    try { if (!win.isDestroyed()) win.destroy(); } catch {}
+  }
+}
+
+module.exports = { RendererRecovery, computeBackoff, nextAction, DEFAULT_OPTS };

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -1,0 +1,458 @@
+'use strict';
+
+// ============================================================================
+// DSH Desktop — Issue #9 集成测试 harness
+//
+// 在真实 Electron 环境下验证「渲染进程崩溃/挂起自恢复」：
+//   · 每个场景独立目录：DSH_HOME / userData / 控制通道全部隔离，
+//     绝不触碰用户真实 ~/.dsh 与 %APPDATA%\DSH Desktop
+//   · 通过 DSH_DESKTOP_TEST 控制通道（文件轮询）向主进程下达命令，
+//     renderer 崩溃时通道依然可用
+//   · 断言依据：desktop.log 关键事件 + test-status.json 状态 + 退出码
+//     + run-state.json + 进程树清理
+//
+// 用法：
+//   node scripts/test/integration-runner.js <scenario>   单个场景
+//   node scripts/test/integration-runner.js --all         全部场景
+//   node scripts/test/integration-runner.js --list        列出场景
+// ============================================================================
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawn, execFileSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const mainJs = path.join(repoRoot, 'main.js');
+const electronPath = (() => {
+  try { return require('electron'); } catch { return path.join(repoRoot, 'node_modules', 'electron', 'dist', 'electron.exe'); }
+})();
+
+// ---------------------------------------------------------------------------
+// 小工具
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+let cmdSeq = 0;
+
+// URL 归一化比较：webUrl 无尾斜杠，页面实际 URL 通常带 '/'。
+const normUrl = (u) => String(u || '').replace(/\/+$/, '');
+const sameUrl = (a, b) => normUrl(a) === normUrl(b);
+
+function tasklistPids(image) {
+  try {
+    const out = execFileSync('tasklist', ['/FI', `IMAGENAME eq ${image}`, '/FO', 'CSV', '/NH'], { encoding: 'utf8', windowsHide: true });
+    const pids = new Set();
+    for (const line of out.split(/\r?\n/)) {
+      const m = /"([^"]+)","(\d+)"/.exec(line.trim());
+      if (m) pids.add(Number(m[2]));
+    }
+    return pids;
+  } catch {
+    return new Set();
+  }
+}
+
+class ScenarioContext {
+  constructor(name) {
+    this.name = name;
+    this.dir = fs.mkdtempSync(path.join(os.tmpdir(), `dsh-desk-test-${name}-`));
+    this.userData = path.join(this.dir, 'userdata');
+    this.dshHome = path.join(this.dir, 'dsh-home');
+    this.stdoutFile = path.join(this.dir, 'stdout.log');
+    this.desktopLog = path.join(this.userData, 'logs', 'desktop.log');
+    this.runState = path.join(this.userData, 'run-state.json');
+    this.controlFile = path.join(this.dir, 'test-control.json');
+    this.statusFile = path.join(this.dir, 'test-status.json');
+    fs.mkdirSync(this.dshHome, { recursive: true });
+    this.outFd = fs.openSync(this.stdoutFile, 'w');
+    this.logTail = {}; // file -> bytes 已扫描
+    this.proc = null;
+    this.exited = null;
+  }
+
+  spawn() {
+    const env = {
+      ...process.env,
+      DSH_HOME: this.dshHome,
+      DSH_DESKTOP_USERDATA: this.userData,
+      DSH_DESKTOP_SKIP_AUTO_UPDATE: '1',
+      DSH_DESKTOP_SKIP_CLIENT_UPDATE: '1',
+      DSH_DESKTOP_TEST: '1',
+      DSH_DESKTOP_TEST_DIR: this.dir,
+      DSH_DESKTOP_TEST_STABILITY_MS: '3000',
+      DSH_DESKTOP_DEBUG: '1',
+      NPM_CONFIG_REGISTRY: process.env.NPM_CONFIG_REGISTRY || 'https://registry.npmmirror.com',
+      ...(SCENARIO_ENV[this.name] || {}),
+    };
+    // 必须「删除」而非置空：Electron 43 只要检测到 ELECTRON_RUN_AS_NODE
+    // 变量存在（哪怕是空串）就切换 Node 模式并原生断言崩溃。
+    delete env.NODE_OPTIONS;
+    delete env.ELECTRON_RUN_AS_NODE;
+    this.proc = spawn(electronPath, [mainJs], {
+      cwd: repoRoot,
+      env,
+      stdio: ['ignore', this.outFd, this.outFd],
+      windowsHide: true,
+    });
+    this.proc.on('exit', (code, signal) => {
+      this.exited = { code, signal, at: Date.now() };
+    });
+    this._log(`已启动 Electron pid=${this.proc.pid} 场景=${this.name} dir=${this.dir}`);
+    return this.proc;
+  }
+
+  _log(msg) {
+    process.stdout.write(`[${this.name}] ${msg}\n`);
+  }
+
+  // 读取某个文件自上次扫描之后的新增内容
+  readNew(file) {
+    let buf = '';
+    try { buf = fs.readFileSync(file, 'utf8'); } catch { return ''; }
+    const prev = this.logTail[file] || 0;
+    if (buf.length <= prev) { this.logTail[file] = buf.length; return ''; }
+    const fresh = buf.slice(prev);
+    this.logTail[file] = buf.length;
+    return fresh;
+  }
+
+  // 等待任一来源出现匹配内容（desktop.log / stdout / 状态文件），返回匹配文本
+  async waitFor(pattern, timeoutMs, label) {
+    const rx = pattern instanceof RegExp ? pattern : new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      for (const f of [this.desktopLog, this.stdoutFile, this.statusFile]) {
+        const fresh = this.readNew(f);
+        const m = rx.exec(fresh);
+        if (m) return m[0];
+      }
+      await sleep(250);
+    }
+    throw new Error(`等待超时(${(timeoutMs / 1000).toFixed(0)}s): ${label} / ${pattern}`);
+  }
+
+  // 全文件检索（不受增量消费影响，用于紧跟 readNew 轮询之后的断言）
+  grepLog(pattern) {
+    const rx = pattern instanceof RegExp ? pattern : new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    for (const f of [this.desktopLog, this.stdoutFile]) {
+      try {
+        if (rx.test(fs.readFileSync(f, 'utf8'))) return true;
+      } catch {}
+    }
+    return false;
+  }
+
+  // 读取一次状态文件全文
+  readStatusFile() {
+    try { return JSON.parse(fs.readFileSync(this.statusFile, 'utf8')); } catch { return null; }
+  }
+
+  // 通过控制文件发送命令并等待状态回执
+  async send(cmd, args, timeoutMs = 30000) {
+    const id = `${cmd}-${++cmdSeq}-${Date.now()}`;
+    fs.writeFileSync(this.controlFile, JSON.stringify({ id, cmd, args }));
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const st = this.readStatusFile();
+      if (st && st.id === id) return st;
+      await sleep(150);
+    }
+    throw new Error(`命令 ${cmd} 未在 ${timeoutMs}ms 内回执`);
+  }
+
+  async state(timeoutMs = 30000) {
+    const st = await this.send('state', undefined, timeoutMs);
+    if (!st.ok) throw new Error('state 命令失败: ' + JSON.stringify(st));
+    return st.detail;
+  }
+
+  async quitAndCheck(timeoutMs = 20000) {
+    try { await this.send('quit'); } catch { /* 主进程可能已退出 */ }
+    const start = Date.now();
+    while (!this.exited && Date.now() - start < timeoutMs) await sleep(200);
+    if (!this.exited) {
+      this._log('应用未在限定时间内退出，强制终止进程树');
+      try { execFileSync('taskkill', ['/pid', String(this.proc.pid), '/T', '/F'], { windowsHide: true }); } catch {}
+      this.exited = { code: 'force-killed', signal: null, at: Date.now() };
+    }
+    await sleep(1500); // 等待 killTree 的异步收尾
+    // run-state 清理标记
+    let cleanExit = null;
+    try { cleanExit = JSON.parse(fs.readFileSync(this.runState, 'utf8')).cleanExit; } catch {}
+    return { exit: this.exited, cleanExit };
+  }
+
+  close() {
+    try { fs.closeSync(this.outFd); } catch {}
+    if (this.proc && !this.exited) {
+      try { execFileSync('taskkill', ['/pid', String(this.proc.pid), '/T', '/F'], { windowsHide: true }); } catch {}
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 场景
+// ---------------------------------------------------------------------------
+
+// 场景级环境变量（应用启动参数）。
+const SCENARIO_ENV = {
+  'unsafe-port': { DSH_DESKTOP_TEST_FORCE_UNSAFE: '1' },
+};
+
+const SCENARIOS = {};
+
+SCENARIOS['boot-healthy'] = async (t) => {
+  await t.waitFor('test-channel-ready', 60000, '测试通道就绪');
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl), `主窗应加载 Web UI，实际=${st.url}`);
+  t.assert(st.recovery && st.recovery.expectingWeb === true, '应处于 Web 监控态');
+  t.assert(st.recovery && st.recovery.gaveUp === false && st.recovery.failures === 0, '健康状态计数为 0');
+  const run = JSON.parse(fs.readFileSync(t.runState, 'utf8'));
+  t.assert(run.renderer && run.renderer.state === 'healthy', `run-state 应记录 healthy，实际=${JSON.stringify(run.renderer)}`);
+  const crashDumps = path.join(t.userData, 'crash-dumps');
+  t.assert(fs.existsSync(crashDumps), 'crash-dumps 目录应存在');
+  t.assert(!t.readNew(t.desktopLog).includes('渲染进程异常退出'), '健康启动不应出现崩溃事件');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0, `退出码应为 0，实际=${q.exit.code}`);
+  t.assert(q.cleanExit === true, 'run-state 应标记 cleanExit=true');
+};
+
+SCENARIOS['crash-recover'] = async (t) => {
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  await t.send('crash-main');
+  await t.waitFor('渲染进程异常退出: reason=crashed', 30000, '崩溃事件');
+  await t.waitFor('安排恢复', 30000, '恢复安排');
+  await t.waitFor('界面已稳定', 120000, '恢复后稳定');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl), `恢复后应回到 Web UI，实际=${st.url}`);
+  t.assert(st.recovery.failures === 0 && !st.recovery.gaveUp, '恢复后计数清零');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['crash-rebuild'] = async (t) => {
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  // 快速连续崩溃（间隔 ~1.5s，快于 3s 稳定期），第 3 次应触发重建
+  let rebuilt = false;
+  for (let i = 0; i < 8 && !rebuilt; i += 1) {
+    await t.send('crash-main');
+    for (let j = 0; j < 6 && !rebuilt; j += 1) {
+      await sleep(200);
+      const fresh = t.readNew(t.desktopLog) + t.readNew(t.stdoutFile);
+      if (fresh.includes('主窗口已重建')) rebuilt = true;
+    }
+  }
+  t.assert(rebuilt, '连续崩溃应触发主窗口重建');
+  await t.waitFor('界面已稳定', 120000, '重建后稳定');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl) && !st.recovery.gaveUp, '重建后应恢复正常');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['crash-giveup'] = async (t) => {
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  // 持续快速崩溃（间隔 ~1.2s）直到自动恢复放弃。重建后若 renderer 已死，
+  // 恢复退避期间（可达 ~20s）的崩溃注入是空操作，需要更多次注入跨过
+  // 「死窗口期」，让恢复加载后的稳定窗口内仍有新崩溃落进来。
+  let gaveUp = false;
+  for (let i = 0; i < 24 && !gaveUp; i += 1) {
+    await t.send('crash-main');
+    for (let j = 0; j < 6 && !gaveUp; j += 1) {
+      await sleep(200);
+      const fresh = t.readNew(t.desktopLog) + t.readNew(t.stdoutFile);
+      if (fresh.includes('自动恢复失败达到上限')) gaveUp = true;
+    }
+  }
+  t.assert(gaveUp, '连续崩溃应最终放弃自动恢复');
+  // 恢复页日志可能已被上一轮 readNew 消费，用全文件检索断言
+  let errPage = false;
+  for (let i = 0; i < 60 && !errPage; i += 1) {
+    await sleep(500);
+    errPage = t.grepLog('加载本地恢复页面');
+  }
+  t.assert(errPage, '应加载本地恢复页面');
+  await sleep(1500);
+  const st = await t.state();
+  t.assert(st.recovery.gaveUp === true, '应处于放弃状态');
+  t.assert(st.url.includes('recovery.html'), `应显示恢复页，实际=${st.url}`);
+  // 手动恢复按钮
+  await t.send('recovery-reload');
+  await t.waitFor('界面已稳定', 120000, '手动恢复后稳定');
+  const st2 = await t.state();
+  t.assert(sameUrl(st2.url, st2.webUrl), '手动恢复后应回到 Web UI');
+  t.assert(st2.recovery.gaveUp === false && st2.recovery.failures === 0, '手动恢复应清零状态');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['hang-unresponsive'] = async (t) => {
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  await t.send('hang-main');
+  await t.waitFor('检测到界面无响应', 180000, '挂起检测');
+  await t.waitFor('界面持续无响应', 60000, '宽限期到');
+  await t.waitFor('渲染进程异常退出', 30000, '强制终结崩溃事件');
+  await t.waitFor('界面已稳定', 120000, '挂起恢复后稳定');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl) && !st.recovery.gaveUp, '挂起恢复后应正常');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['server-restart'] = async (t) => {
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  // 模拟插件市场式原地重启：先静默终止服务（不弹对话框）
+  await t.send('kill-server-silent');
+  // 等待服务进程真正退出（优雅终止可能需数秒），再触发重载
+  let dead = false;
+  for (let i = 0; i < 40 && !dead; i += 1) {
+    await sleep(500);
+    const st = await t.state(5000).catch(() => null);
+    dead = !!(st && st.serverAlive === false);
+  }
+  t.assert(dead, '服务进程应已退出');
+  // 此时目标页必然加载失败 → 应识别「服务已退出」，交给既有重启流程，不进入崩溃恢复循环
+  await t.send('reload-main');
+  await t.waitFor('目标页加载失败', 30000, '目标页加载失败事件');
+  await t.waitFor('服务进程已退出，交由既有重启对话框处理', 15000, '服务退出分支');
+  await sleep(8000); // 观察期：不应出现恢复循环
+  const noise = t.readNew(t.desktopLog);
+  t.assert(!noise.includes('安排恢复'), '服务已退出时不应安排恢复循环');
+  // 重启服务（换新端口）→ 自动加载新地址并恢复稳定
+  await t.send('restart-server');
+  await t.waitFor('界面已稳定', 120000, '服务重启后恢复稳定');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl), `应加载到新端口的 Web UI，实际=${st.url}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['kill-renderer'] = async (t) => {
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  await t.send('kill-main');
+  await t.waitFor('渲染进程异常退出: reason=killed', 30000, '被终止事件');
+  await t.waitFor('界面已稳定', 120000, '恢复后稳定');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl), '被杀后应恢复');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['float-crash'] = async (t) => {
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  await t.send('crash-float');
+  await t.waitFor('kind=float', 30000, '浮窗崩溃事件');
+  await t.waitFor('界面已稳定', 120000, '浮窗恢复稳定');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl) && !st.recovery.gaveUp, '主窗应不受影响');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['early-crash'] = async (t) => {
+  // 窗口刚创建（loading.html 阶段）就崩溃，验证启动早期崩溃也能恢复
+  await t.waitFor('test-channel-ready', 60000, '测试通道就绪');
+  await t.send('crash-main');
+  await t.waitFor('boot-ready', 240000, '崩溃后仍能完成启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl), `启动后应加载 Web UI，实际=${st.url}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['unsafe-port'] = async (t) => {
+  // DSH_DESKTOP_TEST_FORCE_UNSAFE=1：第一次探测到的端口被强制视为
+  // Chromium 受限端口（6000），验证自动重启换端口后仍能正常完成启动。
+  await t.waitFor('test-channel-ready', 60000, '测试通道就绪');
+  await t.waitFor('重启服务换端口', 60000, '受限端口重启日志');
+  await t.waitFor('boot-ready', 240000, '换端口后 Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const st = await t.state();
+  t.assert(sameUrl(st.url, st.webUrl), '应加载到新端口的 Web UI');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+// ---------------------------------------------------------------------------
+// 运行入口
+// ---------------------------------------------------------------------------
+
+async function runScenario(name) {
+  const t = new ScenarioContext(name);
+  t.assert = (cond, msg) => {
+    if (!cond) throw new Error(`断言失败: ${msg}`);
+  };
+  const started = Date.now();
+  const baseline = { node: tasklistPids('node.exe'), electron: tasklistPids('electron.exe') };
+  let result = null;
+  try {
+    t.spawn();
+    await SCENARIOS[name](t);
+    result = { pass: true };
+  } catch (err) {
+    result = { pass: false, error: String((err && err.stack) || err) };
+  } finally {
+    try { await t.quitAndCheck().catch(() => {}); } catch {}
+    t.close();
+    // 进程清理检查：本次场景引入的 node/electron 进程应全部退出
+    await sleep(2000);
+    const after = { node: tasklistPids('node.exe'), electron: tasklistPids('electron.exe') };
+    for (const pid of baseline.node) after.node.delete(pid);
+    for (const pid of baseline.electron) after.electron.delete(pid);
+    if (after.node.size > 0 || after.electron.size > 0) {
+      result.pass = false;
+      result.error = (result.error ? result.error + '; ' : '') +
+        `进程泄漏: node.exe=${[...after.node].join(',')} electron.exe=${[...after.electron].join(',')}`;
+    }
+    result.durationMs = Date.now() - started;
+    result.dir = t.dir;
+  }
+  return result;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--list')) {
+    console.log(Object.keys(SCENARIOS).join('\n'));
+    return;
+  }
+  const names = args.includes('--all') ? Object.keys(SCENARIOS) : args.filter((a) => !a.startsWith('--'));
+  if (names.length === 0) {
+    console.error('用法: node scripts/test/integration-runner.js <scenario...> | --all | --list');
+    process.exit(2);
+  }
+  let failures = 0;
+  for (const name of names) {
+    if (!SCENARIOS[name]) {
+      console.log(`[${name}] 未知场景`);
+      failures += 1;
+      continue;
+    }
+    process.stdout.write(`[${name}] 开始…\n`);
+    const r = await runScenario(name);
+    process.stdout.write(`[${name}] ${r.pass ? 'PASS' : 'FAIL'} (${(r.durationMs / 1000).toFixed(1)}s)\n`);
+    if (!r.pass) {
+      failures += 1;
+      process.stdout.write(`[${name}] ${r.error}\n`);
+    }
+  }
+  console.log(JSON.stringify({ total: names.length, failures }, null, 2));
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/dsh-desktop/scripts/test/unit-recovery.test.js
+++ b/dsh-desktop/scripts/test/unit-recovery.test.js
@@ -1,0 +1,423 @@
+'use strict';
+
+// renderer-recovery.js 状态机单元测试（node --test，无需 Electron）。
+// 用法：node --test scripts/test/unit-recovery.test.js
+// 覆盖：退避计算、动作分级、干净退出忽略、退出中忽略、挂起宽限、
+//       心跳兜底、重建携带计数、放弃与手动恢复、稳定期清零、去重计数。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { pathToFileURL } = require('node:url');
+const {
+  RendererRecovery,
+  computeBackoff,
+  nextAction,
+  DEFAULT_OPTS,
+} = require('../../renderer-recovery');
+
+// ---------------------------------------------------------------------------
+// 纯函数
+// ---------------------------------------------------------------------------
+
+test('computeBackoff: 首次延迟固定，后续指数退避且有上限', () => {
+  assert.strictEqual(computeBackoff(1, {}), DEFAULT_OPTS.FIRST_DELAY_MS);
+  assert.strictEqual(computeBackoff(0, {}), DEFAULT_OPTS.FIRST_DELAY_MS);
+  const b2 = computeBackoff(2, { BACKOFF_BASE_MS: 1000, BACKOFF_MAX_MS: 8000 });
+  assert.ok(b2 >= 1000 * 2 * 1.15 && b2 <= 1000 * 2 * 1.35, `b2=${b2}`);
+  const bBig = computeBackoff(10, { BACKOFF_BASE_MS: 1000, BACKOFF_MAX_MS: 8000 });
+  assert.ok(bBig <= 8000 * 1.35, `bBig=${bBig}`);
+});
+
+test('nextAction: 分级决策符合设计', () => {
+  assert.strictEqual(nextAction(1, 'main', false), 'reload');
+  assert.strictEqual(nextAction(2, 'main', false), 'reload');
+  assert.strictEqual(nextAction(3, 'main', false), 'rebuild');
+  assert.strictEqual(nextAction(3, 'main', true), 'reload'); // 已重建过
+  assert.strictEqual(nextAction(3, 'float', false), 'reload'); // 浮窗不重建
+  assert.strictEqual(nextAction(4, 'main', false), 'reload');
+  assert.strictEqual(nextAction(5, 'main', false), 'give-up');
+});
+
+// ---------------------------------------------------------------------------
+// 行为测试
+// ---------------------------------------------------------------------------
+
+const FAST_OPTS = {
+  MAX_ATTEMPTS: 4,
+  ATTEMPT_WINDOW_MS: 60 * 1000,
+  STABILITY_MS: 30,
+  FIRST_DELAY_MS: 10,
+  BACKOFF_BASE_MS: 20,
+  BACKOFF_MAX_MS: 120,
+  LOAD_TIMEOUT_MS: 1500,
+  UNRESPONSIVE_GRACE_MS: 30,
+  HEARTBEAT_MISS_MS: 200,
+  ERROR_PAGE_RELOAD_MIN_INTERVAL_MS: 0,
+  SERVER_WAIT_MAX_MS: 200,
+};
+
+const WEB_URL = 'http://127.0.0.1:34567/';
+let seq = 0;
+
+function fakeWin() {
+  const wc = new EventEmitter();
+  wc.id = 'wc-' + (++seq);
+  wc._url = '';
+  wc._loadBehavior = 'ok'; // 'ok' | 'fail' | 'fail-with-event'
+  wc.getURL = () => wc._url;
+  wc.loadURL = (url) => {
+    if (wc._loadBehavior === 'fail') return Promise.reject(new Error('ERR_FAILED'));
+    if (wc._loadBehavior === 'fail-with-event') {
+      // 真实 Electron 顺序：did-fail-load 事件先触发，随后 loadURL Promise 拒绝
+      wc.emit('did-fail-load', {}, -102, 'ERR_CONNECTION_REFUSED', url, true);
+      return Promise.reject(new Error('ERR_FAILED'));
+    }
+    wc._url = url;
+    setImmediate(() => wc.emit('did-finish-load'));
+    return Promise.resolve();
+  };
+  wc.loadFile = (p) => {
+    wc._url = pathToFileURL(p).href;
+    setImmediate(() => wc.emit('did-finish-load'));
+    return Promise.resolve();
+  };
+  wc.forcefullyCrashRenderer = () => {
+    setImmediate(() => wc.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 }));
+  };
+  const win = new EventEmitter();
+  win.id = 'win-' + seq;
+  win.webContents = wc;
+  win._destroyed = false;
+  win.isDestroyed = () => win._destroyed;
+  win.destroy = () => {
+    if (win._destroyed) return;
+    win._destroyed = true;
+    wc.emit('destroyed');
+  };
+  win.isVisible = () => true;
+  return win;
+}
+
+function makeRecovery(overrides = {}) {
+  const logs = [];
+  const base = {
+    log: (m) => logs.push(m),
+    isQuitting: () => false,
+    isServerAlive: () => true,
+    getTarget: () => ({ kind: 'url', url: WEB_URL }),
+    loadingPage: 'C:/x/loading.html',
+    recoveryPage: 'C:/x/recovery.html',
+    rebuildMainWindow: () => { throw new Error('unexpected rebuild'); },
+    waitServerUp: () => Promise.reject(new Error('server down')),
+    onGaveUp: () => {},
+    onStable: () => {},
+    notify: () => {},
+  };
+  const r = new RendererRecovery({ ...FAST_OPTS, ...base, ...overrides });
+  return { r, logs };
+}
+
+const tick = (ms) => new Promise((res) => setTimeout(res, ms));
+
+test('崩溃后自动重载并在稳定期后清零', async () => {
+  const { r, logs } = makeRecovery();
+  let stable = 0;
+  r.opts.onStable = () => { stable += 1; };
+  const win = fakeWin();
+  r.attach(win, 'main');
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: -1073741819 });
+  assert.strictEqual(r.stateOf(win).failures, 1);
+  await tick(120); // 10ms 退避 + 30ms 稳定期
+  assert.strictEqual(r.stateOf(win).failures, 0);
+  assert.strictEqual(r.stateOf(win).gaveUp, false);
+  assert.strictEqual(win.webContents.getURL(), WEB_URL, '应重新加载到 Web UI');
+  assert.ok(logs.some((l) => l.includes('渲染进程异常退出')), '应记录崩溃');
+  assert.ok(logs.some((l) => l.includes('界面已稳定')), '应记录稳定');
+  assert.strictEqual(stable, 1);
+});
+
+test('clean-exit 与退出中不触发恢复', async () => {
+  const { r, logs } = makeRecovery();
+  const win = fakeWin();
+  r.attach(win, 'main');
+  win.webContents.emit('render-process-gone', {}, { reason: 'clean-exit', exitCode: 0 });
+  await tick(60);
+  assert.strictEqual(r.stateOf(win).failures, 0);
+  assert.ok(!logs.some((l) => l.includes('安排恢复')), 'clean-exit 不应安排恢复');
+
+  const { r: r2, logs: logs2 } = makeRecovery({ isQuitting: () => true });
+  const win2 = fakeWin();
+  r2.attach(win2, 'main');
+  win2.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+  await tick(60);
+  assert.strictEqual(r2.stateOf(win2).failures, 0);
+  assert.ok(!logs2.some((l) => l.includes('安排恢复')), '退出中不应安排恢复');
+});
+
+test('did-finish-load 单独不清零计数，稳定期结束才清零', async () => {
+  const { r } = makeRecovery();
+  const win = fakeWin();
+  r.attach(win, 'main');
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+  await tick(20); // 10ms 退避后加载成功，但未到 30ms 稳定期
+  assert.strictEqual(r.stateOf(win).failures, 1, '加载成功但未稳定前计数不应清零');
+  assert.strictEqual(win.webContents.getURL(), WEB_URL);
+  await tick(60); // 稳定期结束
+  assert.strictEqual(r.stateOf(win).failures, 0, '稳定期结束应清零');
+});
+
+test('稳定期内发生新故障则保留计数（防止慢速崩溃循环无限延续）', async () => {
+  const { r, logs } = makeRecovery();
+  const win = fakeWin();
+  r.attach(win, 'main');
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 }); // f=1
+  await tick(25); // 10ms 退避后加载完成（atLoad=1），稳定期 30ms 尚未到
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 }); // f=2
+  await tick(30); // 第一次稳定期已过 → 脏检查应保留计数
+  assert.strictEqual(r.stateOf(win).failures, 2, '稳定期内有新故障应保留计数');
+  assert.ok(logs.some((l) => l.includes('保留计数防止循环')), '应记录脏稳定日志');
+  await tick(250); // 后续恢复链完成并再次干净稳定
+  assert.strictEqual(r.stateOf(win).failures, 0);
+});
+
+test('顽固故障循环有界：连续崩溃最终放弃且不再安排恢复', async () => {
+  const { r } = makeRecovery();
+  const win = fakeWin();
+  win.webContents._loadBehavior = 'fail'; // 加载永远失败 → 无 did-finish-load → 计数不会被清零
+  r.attach(win, 'main');
+  for (let i = 0; i < 6; i += 1) {
+    win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+    await tick(15);
+  }
+  await tick(300);
+  const s = r.stateOf(win);
+  assert.ok(s.gaveUp, '应最终放弃');
+  assert.ok(s.failures >= 5, `failures=${s.failures}`);
+});
+
+test('连续失败：重建窗口继承故障计数，最终放弃并显示错误页', async () => {
+  let rebuilt = 0;
+  let newWin = null;
+  const oldWin = fakeWin();
+  oldWin.webContents._loadBehavior = 'fail';
+  const { r, logs } = makeRecovery({
+    rebuildMainWindow: () => {
+      // 忠实模拟 main.js 契约：销毁旧窗、创建新窗（新窗同样加载失败）
+      rebuilt += 1;
+      oldWin.destroy();
+      newWin = fakeWin();
+      newWin.webContents._loadBehavior = 'fail';
+      return newWin;
+    },
+  });
+  r.attach(oldWin, 'main');
+  for (let i = 0; i < 4; i += 1) {
+    oldWin.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+    await tick(15);
+  }
+  await tick(400);
+  assert.ok(rebuilt === 1, `应重建一次，实际=${rebuilt}`);
+  assert.ok(logs.some((l) => l.includes('主窗口已重建')), '应记录重建');
+  assert.ok(newWin, '重建应产生新窗口');
+  assert.strictEqual(r.stateOf(newWin).gaveUp, true, '重建后仍失败应最终放弃');
+  assert.strictEqual(newWin.webContents.getURL(), pathToFileURL('C:/x/recovery.html').href, '放弃后应显示错误页');
+  const countSchedules = () => logs.filter((l) => l.includes('安排恢复')).length;
+  const before = countSchedules();
+  newWin.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+  await tick(100);
+  assert.strictEqual(countSchedules(), before, '放弃后不应再安排自动恢复');
+});
+
+test('浮窗崩溃后重载；顽固失败直接关闭浮窗', async () => {
+  const { r } = makeRecovery();
+  const win = fakeWin();
+  r.attach(win, 'float');
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+  await tick(120);
+  assert.ok(!win.isDestroyed(), '单次崩溃应重载恢复而不是关闭');
+  assert.strictEqual(r.stateOf(win).failures, 0);
+
+  const win2 = fakeWin();
+  win2.webContents._loadBehavior = 'fail';
+  const { r: r2 } = makeRecovery();
+  r2.attach(win2, 'float');
+  for (let i = 0; i < 6; i += 1) {
+    win2.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+    await tick(15);
+  }
+  await tick(300);
+  assert.ok(win2.isDestroyed(), '浮窗顽固故障应被关闭');
+});
+
+test('挂起：宽限期内恢复响应则取消；持续无响应则强制终结并恢复', async () => {
+  const { r, logs } = makeRecovery();
+  const win = fakeWin();
+  win.webContents._url = WEB_URL;
+  r.attach(win, 'main');
+  win.webContents.emit('did-finish-load');
+  await tick(80); // 等稳定期结束（挂起判定通常发生在页面稳定之后）
+  // 场景 1：宽限期内恢复响应
+  win.webContents.emit('unresponsive');
+  assert.ok(logs.some((l) => l.includes('检测到界面无响应')));
+  await tick(10);
+  win.webContents.emit('responsive');
+  await tick(80);
+  assert.ok(!win.isDestroyed());
+  assert.ok(!logs.some((l) => l.includes('界面持续无响应')), '恢复响应后不应强制终结');
+
+  // 场景 2：持续无响应 → 强制终结 → render-process-gone → 重载恢复
+  const { r: r2, logs: logs2 } = makeRecovery();
+  const win2 = fakeWin();
+  win2.webContents._url = WEB_URL;
+  r2.attach(win2, 'main');
+  win2.webContents.emit('did-finish-load');
+  await tick(80); // 稳定期结束
+  win2.webContents.emit('unresponsive');
+  await tick(200); // 30ms 宽限 → 强制终结 → 重载 → 30ms 稳定
+  assert.ok(logs2.some((l) => l.includes('界面持续无响应')), '宽限期到应强制终结');
+  assert.ok(logs2.some((l) => l.includes('渲染进程异常退出')), '强制终结应产生崩溃事件');
+  assert.strictEqual(r2.stateOf(win2).failures, 0, '恢复成功后计数清零');
+  assert.strictEqual(win2.webContents.getURL(), WEB_URL);
+});
+
+test('心跳兜底：失联视为挂起，恢复心跳则取消', async () => {
+  const { r, logs } = makeRecovery();
+  const win = fakeWin();
+  win.webContents._url = WEB_URL;
+  r.attach(win, 'main');
+  win.emit('show'); // 窗口已显示（show 事件驱动可见性追踪）
+  win.webContents.emit('did-finish-load');
+  r.checkHeartbeats(); // 从未有心跳 → 不计（视为未初始化）
+  assert.ok(!logs.some((l) => l.includes('心跳丢失')));
+  r.noteHeartbeat(win.webContents.id);
+  await tick(300); // 超过 HEARTBEAT_MISS_MS=200
+  r.checkHeartbeats();
+  assert.ok(logs.some((l) => l.includes('心跳丢失')), '心跳超时应判定为挂起');
+  await tick(150);
+  assert.ok(logs.some((l) => l.includes('界面持续无响应')), '心跳失联最终强制恢复');
+  assert.strictEqual(r.stateOf(win).failures, 0, '强制恢复后应回归健康');
+
+  // 隐藏（托盘/最小化）窗口不判定
+  const { r: r2, logs: logs2 } = makeRecovery();
+  const win2 = fakeWin();
+  win2.webContents._url = WEB_URL;
+  r2.attach(win2, 'main');
+  win2.emit('show');
+  win2.emit('hide'); // 隐藏到托盘
+  win2.webContents.emit('did-finish-load');
+  r2.noteHeartbeat(win2.webContents.id);
+  await tick(300);
+  r2.checkHeartbeats();
+  assert.ok(!logs2.some((l) => l.includes('心跳丢失')), '隐藏窗口不应误判挂起');
+});
+
+test('did-fail-load：目标页加载失败计故障并恢复；服务已死时不动作', async () => {
+  const { r, logs } = makeRecovery();
+  const win = fakeWin();
+  win.webContents._url = WEB_URL;
+  r.attach(win, 'main');
+  win.webContents.emit('did-finish-load');
+  win.webContents.emit('did-fail-load', {}, -102, 'ERR_CONNECTION_REFUSED', WEB_URL, true);
+  await tick(150);
+  assert.ok(logs.some((l) => l.includes('目标页加载失败')));
+  assert.strictEqual(r.stateOf(win).failures, 0, '服务健在时重载成功应恢复');
+  assert.strictEqual(win.webContents.getURL(), WEB_URL);
+
+  // ERR_ABORTED 忽略
+  const { r: r2, logs: logs2 } = makeRecovery();
+  const win2 = fakeWin();
+  win2.webContents._url = WEB_URL;
+  r2.attach(win2, 'main');
+  win2.webContents.emit('did-finish-load');
+  win2.webContents.emit('did-fail-load', {}, -3, 'ERR_ABORTED', WEB_URL, true);
+  await tick(60);
+  assert.ok(!logs2.some((l) => l.includes('目标页加载失败')), 'ERR_ABORTED 应忽略');
+
+  // 服务已死：不动作（交给既有对话框）
+  const { r: r3, logs: logs3 } = makeRecovery({ isServerAlive: () => false });
+  const win3 = fakeWin();
+  win3.webContents._url = WEB_URL;
+  r3.attach(win3, 'main');
+  win3.webContents.emit('did-finish-load');
+  win3.webContents.emit('did-fail-load', {}, -102, 'ERR_CONNECTION_REFUSED', WEB_URL, true);
+  await tick(60);
+  assert.ok(!logs3.some((l) => l.includes('安排恢复')), '服务已死不应安排恢复');
+});
+
+test('did-fail-load 事件与 loadURL Promise 拒绝不重复计数', async () => {
+  const { r } = makeRecovery();
+  const win = fakeWin();
+  win.webContents._loadBehavior = 'fail-with-event';
+  r.attach(win, 'main');
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 }); // 计 1
+  await tick(40); // 10ms 退避 + 恢复加载失败（事件被在途标记吸收，Promise 拒绝计 1）
+  assert.strictEqual(r.stateOf(win).failures, 2, '崩溃 1 次 + 加载失败 1 次，事件不应重复计数');
+});
+
+test('retryNow 重置放弃状态并立即恢复', async () => {
+  const { r } = makeRecovery();
+  const win = fakeWin();
+  r.attach(win, 'main');
+  win.webContents._url = WEB_URL;
+  win.webContents.emit('did-finish-load');
+  r._states.get(win.id).gaveUp = true; // 人为置为放弃状态（白盒）
+  assert.ok(r.stateOf(win).gaveUp);
+  assert.strictEqual(r.retryNow(win), true);
+  await tick(120);
+  assert.ok(!r.stateOf(win).gaveUp, 'retryNow 应清除放弃状态');
+  assert.strictEqual(win.webContents.getURL(), WEB_URL);
+});
+
+test('放弃后迟到的 Web 加载不会撤销放弃状态', async () => {
+  const { r, logs } = makeRecovery();
+  const win = fakeWin();
+  win.webContents._loadBehavior = 'fail';
+  r.attach(win, 'main');
+  for (let i = 0; i < 6; i += 1) {
+    win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+    await tick(15);
+  }
+  await tick(300);
+  assert.ok(r.stateOf(win).gaveUp, '应处于放弃状态');
+  assert.strictEqual(win.webContents.getURL(), pathToFileURL('C:/x/recovery.html').href, '应显示恢复页');
+  // 模拟在途的旧恢复尝试在放弃后才完成 Web 加载
+  win.webContents._url = WEB_URL;
+  win.webContents.emit('did-finish-load');
+  await tick(60);
+  assert.ok(r.stateOf(win).gaveUp, '迟到的 Web 加载不应撤销放弃状态');
+  assert.ok(logs.some((l) => l.includes('忽略迟到的 Web 加载')), '应记录忽略日志');
+  assert.strictEqual(win.webContents.getURL(), pathToFileURL('C:/x/recovery.html').href, '应切回恢复页');
+});
+
+test('getTarget 为空（启动早期）时主窗回加载页，浮窗关闭', async () => {
+  const { r } = makeRecovery({ getTarget: () => null });
+  const win = fakeWin();
+  r.attach(win, 'main');
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+  await tick(120);
+  assert.strictEqual(win.webContents.getURL(), pathToFileURL('C:/x/loading.html').href, '应回加载页');
+
+  const fwin = fakeWin();
+  const { r: r2 } = makeRecovery({ getTarget: () => null });
+  r2.attach(fwin, 'float');
+  fwin.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 });
+  await tick(80);
+  assert.ok(fwin.isDestroyed(), '无目标时浮窗应直接关闭');
+});
+
+test('挂起计数不与强制崩溃事件重复计数', async () => {
+  const { r } = makeRecovery();
+  const win = fakeWin();
+  win.webContents._url = WEB_URL;
+  r.attach(win, 'main');
+  win.webContents.emit('did-finish-load');
+  await tick(80); // 稳定期结束
+  win.webContents.emit('unresponsive');
+  await tick(40); // 宽限 30ms 到 → 强制终结（setImmediate）
+  await tick(5); // render-process-gone 已发出，恢复动作尚未开始
+  const s = r.stateOf(win);
+  assert.strictEqual(s.failures, 1, '挂起 + 强制崩溃应只计一次故障');
+  await tick(150);
+  assert.strictEqual(r.stateOf(win).failures, 0);
+});


### PR DESCRIPTION
## 概述

针对 issue #9（renderer 以 0xC0000005 异常退出后窗口永久黑屏/白屏，只能强制退出）的实现。思路与 issue 中的分析建议一致。

## 问题与修复

- **崩溃后无恢复**：原实现三处 `render-process-gone` 处理器仅记录日志。新增 `renderer-recovery.js` 自恢复状态机：
  - 崩溃后指数退避自动重载（首次 0.8s，封顶约 15s，含抖动）
  - 连续失败第 3 次销毁重建主窗（保持隐藏/托盘状态）；会话浮窗直接关闭
  - 连续 5 次失败后停止自动恢复，主窗显示本地恢复页（重新加载 / 重启客户端 / 打开日志）并弹系统通知，避免无限崩溃循环
  - 页面加载成功且「稳定存活 30 秒、期间无新故障」才清零计数，避免慢速崩溃循环
  - clean-exit、退出中、窗口已销毁均不触发；服务进程退出时交由既有重启对话框处理，不双弹窗
- **挂起（AppHangB1）无恢复**：监听 `unresponsive`，20 秒宽限后强制终结 renderer 复用恢复路径；preload 每 5 秒心跳兜底，可见性以 show/hide 事件追踪（挂起场景下 `isVisible()` 实测不可靠）
- **加载失败白屏**：处理 `did-fail-load`，服务健在时退避重试（覆盖插件市场重启间隙），`ERR_ABORTED` 忽略
- **崩溃取证**：`crashDumps` 固定到数据目录、启用本地 Crashpad（不联网上传），便于后续定位 0xC0000005 底层来源；恢复状态写入 `run-state.json`
- **附带修复**：测试中发现 `dsh web` / 预览服务的随机端口可能命中 Chromium 受限端口（实测 4045，`ERR_UNSAFE_PORT`），页面永远无法加载；现命中即自动重启换端口（上限 4 次）

## 测试

- `scripts/test/unit-recovery.test.js`：node:test 状态机单元测试 17 例，`node --test scripts/test/unit-recovery.test.js`
- `scripts/test/integration-runner.js`：真实 Electron 集成测试 10 场景（健康启动 / 崩溃恢复 / 重建 / 放弃 / 挂起 / 服务重启 / 进程被杀 / 浮窗 / 启动早期崩溃 / 受限端口重启），每个场景隔离 DSH_HOME 与 userData，`node scripts/test/integration-runner.js --all`
- 本机环境（Windows 11、Electron 43.4.0、dsh 0.1.0-rc.6）全部通过

## 说明

- 集成测试命令经 `DSH_DESKTOP_TEST=1` 的文件通道注入，生产环境不加载
- 恢复页文案与日志标签均为中文，与现有风格保持一致
- 改动集中在新增模块与 main.js 接入；若需要，可拆分为「受限端口修复」与「自恢复机制」两个提交
