### PR TITLE
fix: 全新 DSH_HOME 首次启动失败（profile manifest 缺少核心 bundles）

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -1706,10 +1706,37 @@ function syncCompanionPlugins() {
     const manifestFile = path.join(profileDir, 'package.json');
     let manifest = {};
     try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch { manifest = { name: 'dsh-profile-web', private: true }; }
-    manifest.dsh ??= {};
-    manifest.dsh.profile ??= {};
-    manifest.dsh.profile.bundles ??= [];
+    if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) manifest = { name: 'dsh-profile-web', private: true };
+    if (!manifest.dsh || typeof manifest.dsh !== 'object') manifest.dsh = {};
+    if (!manifest.dsh.profile || typeof manifest.dsh.profile !== 'object') manifest.dsh.profile = {};
+    // 全新 profile（dsh 尚未初始化）时 manifest 不存在、也没有 bundles。
+    // 此时壳层不能凭空新建只含自己 bundle 的 manifest：那会顶替 dsh 的
+    // 初始化，profile 里没有提供核心服务的插件，插件树无法激活，
+    // 全新 DSH_HOME 首次启动必然失败。
+    // 处理：核心 bundles 必须在安装中实测可解析（与 dsh-app-boot 的
+    // PROFILE_TEMPLATES.web 同名）才写入；解析不到（模板未来改名）则不写
+    // manifest，交由 dsh 自行初始化，bundle 插件留待下一次启动注册。
+    let bundlesUsable = Array.isArray(manifest.dsh.profile.bundles);
+    if (!bundlesUsable) {
+      const coreBundles = [];
+      // 以「实际将运行的 dsh 包」（内置或用户目录 overlay）为解析锚点，
+      // 确保写入的模板与真正启动的 dsh 版本一致；解析不到则不写。
+      const installAnchor = path.dirname(dshPackageJson());
+      for (const name of ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app']) {
+        try {
+          require.resolve(name + '/package.json', { paths: [installAnchor] });
+          coreBundles.push(name);
+        } catch { /* 该 dsh 安装中缺失，交由 dsh 初始化 */ }
+      }
+      if (coreBundles.length === 2) {
+        manifest.dsh.profile.bundles = coreBundles;
+        bundlesUsable = true;
+      } else {
+        log('boot', 'dsh 出厂核心 bundles 未在安装中解析到，跳过 manifest 预写，交由 dsh 初始化');
+      }
+    }
     for (const name of bundleNames) {
+      if (!bundlesUsable) break;
       if (!manifest.dsh.profile.bundles.includes(name)) {
         manifest.dsh.profile.bundles.push(name);
         fs.writeFileSync(manifestFile, JSON.stringify(manifest, null, 2) + '\n');


### PR DESCRIPTION
## 概述

修复 issue #13：v0.3.3 在全新 DSH_HOME 上首次启动必然失败（dsh web 退出码 1）。

## 根因

`syncCompanionPlugins` 在 dsh 初始化 profile 之前运行。`profiles/web/package.json` 不存在时，代码新建 manifest 并只写入 bundle 插件（`@dsh-external/dsh-super-injector`）。dsh 启动时发现 manifest 已存在便不再初始化，profile 缺少出厂模板核心 bundles（`@deepseek-ai/dsh-base`、`@deepseek-ai/dsh-web-app`），提供核心服务的插件不在树中，全部配套插件等待服务 → 插件树无法激活 → 启动失败。详细证据见 issue #13。

## 修复

- manifest 缺少 `dsh.profile.bundles` 时，先写入 dsh 出厂模板核心 bundles（与 `@deepseek-ai/dsh-app-boot` 的 `PROFILE_TEMPLATES.web` 一致），再追加 bundle 插件
- 核心 bundles 以「实际将运行的 dsh 包」（内置或用户目录 overlay，复用 `dshPackageJson()`）为解析锚点实测可解析才写入；解析不到（模板未来改名）则不写 manifest，交由 dsh 自行初始化，bundle 插件留待下一次启动注册
- manifest 已含 bundles 时行为不变（仅追加，不覆盖用户自定义）
- 加固 manifest 解析的类型防御：内容为 null / 非对象 / JSON 数组、`dsh` 或 `profile` 字段损坏时按全新 profile 处理，不再抛异常

## 验证

- 复现实验：全新 DSH_HOME 必现首启失败；将失败场景的 manifest 修正为含核心 bundles 后立即启动成功
- 本机全量回归（修复后的 v0.3.3 上）：
  - 单元测试 17/17 通过
  - 真实 Electron 集成测试 10/10 通过，且每个场景都使用全新 DSH_HOME（健康启动 / 崩溃恢复 / 重建 / 放弃 / 挂起 / 服务重启 / 进程被杀 / 浮窗 / 启动早期崩溃 / 受限端口重启），同时覆盖了本修复的首启路径
