### PR TITLE
fix: 根治退出/重启进程树清理与端口稳定性；预览静态服务接入会话文件围栏

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -65,10 +65,16 @@ function fileRoots() {
 
 function isUnderFileRoots(p) {
   const resolved = path.resolve(p);
-  return fileRoots().some((r) => {
+  const check = () => fileRoots().some((r) => {
     const rp = path.resolve(r);
     return resolved === rp || resolved.startsWith(rp + path.sep);
   });
+  if (check()) return true;
+  // 缓存可能滞后于新会话：5 分钟 TTL 内新建的会话，其 cwd 尚未进入缓存。
+  // 首次判定不通过时强制刷新一次再判，避免误拒新会话的项目文件（预览/还原/打开）。
+  // 刷新后的缓存再保持 5 分钟，攻击性探测最多触发每 5 分钟一次重扫。
+  fileRootsCache.at = 0;
+  return check();
 }
 
 const IS_WIN = process.platform === 'win32';
@@ -2550,6 +2556,15 @@ function startPreviewStaticServer() {
       res.end();
       return;
     }
+    // H2/H3 文件围栏：与 dsh:file-open / dsh:file-revert 一致，只允许读取
+    // 「会话 cwd」之下的项目文件。否则本服务会成为任意本地文件读取通道：
+    // 预览 iframe 与本服务同源（allow-same-origin），可读取并外传
+    // settings / 凭据等敏感文件（实测 C:\Windows、userData 等均可读出）。
+    if (!isUnderFileRoots(p)) {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
     try {
       const st = fs.statSync(p);
       if (!st.isFile()) {
@@ -2639,6 +2654,8 @@ function setupTestChannel() {
         restartingServer = false;
       }
     },
+    // 与 chrome:restart-service IPC 完全一致的路径（供集成测试复现端口稳定性）。
+    'restart-service': () => restartService(),
     'reload-main': () => {
       if (!mainWindow || mainWindow.isDestroyed()) throw new Error('no main window');
       mainWindow.reload();

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -288,6 +288,9 @@ process.on('exit', (code) => {
     fs.mkdirSync(path.dirname(lp), { recursive: true });
     fs.appendFileSync(lp, line);
   } catch {}
+  // 兜底：无论走哪条退出路径（含 app.exit 与异常退出），都同步终结 dsh
+  // 进程树，兑现「退出即清理、不留孤儿进程」。正常退出路径此时已是空操作。
+  killTreeSync(serverProc);
 });
 
 function nodeExe() {
@@ -319,29 +322,65 @@ function dshVersionSource() {
   return updater.overlayVersion(updCtx()) ? '用户目录（已更新）' : '内置';
 }
 
-function killTree(proc) {
-  if (!proc || !proc.pid) return;
+// ---------------------------------------------------------------------------
+// dsh 进程树终结
+//
+// Windows 下 taskkill 不带 /F 只能向 GUI 进程发送 WM_CLOSE，对 node.exe 这类
+// 控制台进程完全无效（实测报错 "can only be terminated forcefully"）。旧实现
+// 「先优雅（无 /F）、1.5s 后再 /F 强杀」对 dsh web 从未优雅成功过：实际生效的
+// 始终是 1.5s 后的 /F。由此产生两个真实缺陷：
+//   1. 原地重启（插件市场）：优雅尝试无效，旧进程在「探测端口」时仍存活并
+//      占着端口 → chooseStableWebPort 探测失败 → 换新端口 → origin 漂移 →
+//      localStorage（会话分组/主题/隐藏输出等偏好）全部丢失；
+//   2. 退出路径：主进程退出耗时通常远小于 1.5s（本机实测约 300ms），计时器
+//      随主进程消亡永不触发，进程树清理完全依赖 Electron 的隐式行为，无任何保证。
+// 因此拆分为两个 API：
+//   · killTree —— 异步：立即以 /T /F 终结进程树并等待直接子进程 exit（3s
+//     超时兜底）。供「原地重启」路径使用，调用方必须在探测端口前等待其完成。
+//   · killTreeSync —— 同步强杀：供应用退出路径使用，保证主进程退出前
+//     dsh 进程树已被终结，不依赖计时器或 Electron 隐式行为。
+// 两处最终都是 /T /F 强杀，与旧实现实际生效的终结方式一致；只移除了无效的
+// 优雅等待与竞态窗口，不改变「dsh 最终收到强杀」这一既有事实。
+// ---------------------------------------------------------------------------
+function killTreeSync(proc) {
+  if (!proc || !proc.pid || proc.exitCode !== null || proc.signalCode !== null) return;
   try {
     if (IS_WIN) {
-      // M2 修复：先优雅（无 /F）给进程收尾机会（避免撕裂 session.jsonl.zstd），
-      // 短等待后仍存活再强杀。
-      spawn('taskkill', ['/pid', String(proc.pid), '/T'], { windowsHide: true, stdio: 'ignore' });
-      const pid = proc.pid;
-      setTimeout(() => {
-        try {
-          const query = 'tasklist /FI "PID eq ' + pid + '" /FO CSV /NH';
-          const alive = require('node:child_process').execSync(query, { encoding: 'utf8', windowsHide: true });
-          if (alive.includes(String(pid))) {
-            spawn('taskkill', ['/pid', String(pid), '/T', '/F'], { windowsHide: true, stdio: 'ignore' });
-          }
-        } catch { /* 进程已退出或查询失败 */ }
-      }, 1500);
+      spawnSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { windowsHide: true, stdio: 'ignore', timeout: 10000 });
     } else {
-      try { process.kill(-proc.pid, 'SIGTERM'); } catch { proc.kill('SIGTERM'); }
+      try { process.kill(-proc.pid, 'SIGKILL'); } catch { try { proc.kill('SIGKILL'); } catch {} }
     }
   } catch (err) {
     log('killTree', String(err));
   }
+}
+
+function killTree(proc) {
+  return new Promise((resolve) => {
+    if (!proc || !proc.pid || proc.exitCode !== null || proc.signalCode !== null) return resolve();
+    const finish = () => {
+      proc.removeListener('exit', finish);
+      resolve();
+    };
+    proc.once('exit', finish);
+    if (!IS_WIN) {
+      // 非 Windows：保持原有语义（SIGTERM），等待进程退出（超时兜底）。
+      try { process.kill(-proc.pid, 'SIGTERM'); } catch { try { proc.kill('SIGTERM'); } catch {} }
+      const timer = setTimeout(finish, 3000);
+      if (timer.unref) timer.unref();
+      return;
+    }
+    try {
+      spawn('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { windowsHide: true, stdio: 'ignore' });
+    } catch (err) {
+      log('killTree', String(err));
+      finish();
+      return;
+    }
+    // 兜底：taskkill 异常或进程未按时退出时，不得让重启流程永久挂起。
+    const timer = setTimeout(finish, 3000);
+    if (timer.unref) timer.unref();
+  });
 }
 
 // Environment for the dsh child: drop harness/session leftovers so the
@@ -642,14 +681,18 @@ function chooseStableWebPort() {
 // ---------------------------------------------------------------------------
 
 async function startServer(unsafePortRetries = 4, overlays = []) {
+  // M1 修复：重入前先终结旧进程并等待其真正退出，避免孤儿 harness 同时写
+  // 同一 DSH_HOME。等待必须在端口探测之前完成：taskkill /F 异步生效，若旧
+  // 进程仍占着端口，chooseStableWebPort 会探测失败并换新端口，导致 origin
+  // 漂移（localStorage 偏好丢失）。旧的「先选端口、后杀进程」顺序正是
+  // 插件市场每次重启都换端口的根因。
+  if (serverProc && !serverProc.killed && !quitting) {
+    log('dsh', 'startServer 重入：先终结旧进程再启动');
+    await killTree(serverProc);
+    serverProc = null;
+  }
   const webPort = await chooseStableWebPort();
   return new Promise((resolve, reject) => {
-    // M1 修复：重入前先终结旧进程，避免孤儿 harness 同时写同一 DSH_HOME。
-    if (serverProc && !serverProc.killed && !quitting) {
-      log('dsh', 'startServer 重入：先终结旧进程再启动');
-      killTree(serverProc);
-      serverProc = null;
-    }
     const nodeBin = nodeExe();
     const bin = dshBin();
     if (!fs.existsSync(nodeBin)) {
@@ -787,6 +830,27 @@ function startAndShow(overlays = []) {
       if (mainWindow && !mainWindow.isDestroyed()) return mainWindow.loadURL(url).then(() => url);
       return url;
     });
+}
+
+// 插件市场式原地重启：终结旧 dsh web 进程树并等待其真正退出，再重新启动。
+// 等待是必需的：taskkill /F 异步生效，旧进程退出前仍占着端口，端口探测会
+// 失败并换新端口（origin 漂移 → localStorage 偏好丢失）。集成测试通道的
+// 'restart-service' 命令与 chrome:restart-service IPC 共用本函数。
+async function restartService() {
+  if (!serverProc || restartingServer) return { ok: false, error: 'not-running' };
+  log('service', '请求重启 dsh web 服务');
+  restartingServer = true;
+  try {
+    await killTree(serverProc);
+    const url = await startAndShow();
+    log('service', 'dsh web 服务已重启: ' + url);
+    return { ok: true, url };
+  } catch (err) {
+    log('service', '重启失败: ' + ((err && err.message) || err));
+    return { ok: false, error: String((err && err.message) || err) };
+  } finally {
+    restartingServer = false;
+  }
 }
 
 function handleBootFailure(err, overlays = []) {
@@ -1255,6 +1319,7 @@ function fatal(title, err) {
   if (!mainWindow || mainWindow.isDestroyed()) {
     dialog.showErrorBox(title, detail);
     markCleanExit();
+    killTreeSync(serverProc); // app.exit 不触发 before-quit，这里保证进程树被终结
     app.exit(1);
     return;
   }
@@ -1370,7 +1435,7 @@ async function runUpdateFlow(manual) {
     if (r2 === 0) {
       quitting = true;
       markCleanExit();
-      killTree(serverProc);
+      killTreeSync(serverProc);
       app.relaunch();
       app.exit(0);
     }
@@ -1537,7 +1602,7 @@ function registerChromeIpc() {
     quitting = true;
     forceQuit = true;
     markCleanExit();
-    killTree(serverProc);
+    killTreeSync(serverProc);
     app.relaunch();
     app.exit(0);
     return { ok: true };
@@ -1591,23 +1656,11 @@ function registerChromeIpc() {
   });
 
   // 插件市场：原地重启 dsh web 服务（安装/卸载插件后生效，窗口重载到新端口）。
+  // 测试通道 'restart-service' 复用同一实现，保证集成测试覆盖真实 IPC 路径。
   ipcMain.handle('chrome:restart-service', async (event, payload = {}) => {
     if (payload?.intent !== 'restart-service') return { ok: false, error: 'missing-intent' };
     if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
-    if (!serverProc || restartingServer) return { ok: false, error: 'not-running' };
-    log('service', '请求重启 dsh web 服务');
-    restartingServer = true;
-    try {
-      killTree(serverProc);
-      const url = await startAndShow();
-      log('service', 'dsh web 服务已重启: ' + url);
-      return { ok: true, url };
-    } catch (err) {
-      log('service', '重启失败: ' + ((err && err.message) || err));
-      return { ok: false, error: String((err && err.message) || err) };
-    } finally {
-      restartingServer = false;
-    }
+    return restartService();
   });
 
   // 会话浮窗：主窗请求把某个会话弹出到独立窗口（校验来源与数量上限）。
@@ -2248,7 +2301,7 @@ function quitForClientUpdate(ctx, pending) {
     log('client-update', '清理待安装标记失败: ' + err.message);
   }
   try {
-    killTree(serverProc);
+    killTreeSync(serverProc);
   } catch (err) {
     log('client-update', '停止 dsh 服务失败: ' + err.message);
   }
@@ -2573,7 +2626,7 @@ function setupTestChannel() {
     'kill-server-silent': () => {
       // 模拟插件市场式原地重启的前半程：退出处理器不弹窗。
       // 不置空 serverProc：让 isServerAlive() 依据真实退出状态，
-      // 优雅终止完成（exit 事件）后自然变为 false。
+      // 强杀完成（exit 事件）后自然变为 false。
       restartingServer = true;
       killTree(serverProc);
     },
@@ -2766,7 +2819,7 @@ if (!gotLock) {
     markCleanExit();
     log('boot', '正在退出，销毁会话浮窗并停止 dsh web 进程树…');
     closeAllFloatWindows();
-    killTree(serverProc);
+    killTreeSync(serverProc);
     updater.abort();
     if (recovery) recovery.dispose();
     if (sessionWatcher) sessionWatcher.stop();

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -20,6 +20,8 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const http = require('node:http');
+const zlib = require('node:zlib');
 const { spawn, execFileSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -331,6 +333,64 @@ SCENARIOS['server-restart'] = async (t) => {
   await t.waitFor('界面已稳定', 120000, '服务重启后恢复稳定');
   const st = await t.state();
   t.assert(sameUrl(st.url, st.webUrl), `应加载到新端口的 Web UI，实际=${st.url}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['restart-service'] = async (t) => {
+  // 复现 chrome:restart-service（插件市场原地重启）的完整路径：
+  // killTree 后立即 startAndShow。断言重启前后端口不变（稳定 origin）。
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const portOf = (u) => { try { return new URL(u).port || ''; } catch { return ''; } };
+  const before = await t.state();
+  const portBefore = portOf(before.webUrl);
+  t.assert(portBefore, '启动后应取得 web 端口');
+  const st = await t.send('restart-service', undefined, 120000);
+  t.assert(st.ok, '重启命令应成功: ' + JSON.stringify(st));
+  await t.waitFor('dsh web 服务已重启', 120000, '服务重启完成');
+  await t.waitFor('界面已稳定', 120000, '重启后稳定');
+  const after = await t.state();
+  t.assert(sameUrl(after.url, after.webUrl), '重启后主窗应加载新 webUrl');
+  const portAfter = portOf(after.webUrl);
+  t.assert(portAfter === portBefore, `服务重启应复用原端口（稳定 origin），实际 ${portBefore} -> ${portAfter}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['preview-fence'] = async (t) => {
+  // 预览静态服务必须与 dsh:file-open / dsh:file-revert 共用同一文件围栏：
+  // 只允许读取「会话 cwd」之下的项目文件，杜绝任意本地文件读取。
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  const log = fs.readFileSync(t.desktopLog, 'utf8');
+  const m = /预览静态服务已启动: http:\/\/127\.0\.0\.1:(\d+)/.exec(log);
+  t.assert(m, '预览静态服务端口应出现在日志');
+  const base = 'http://127.0.0.1:' + Number(m[1]);
+  const enc = (p) => String(p).replace(/\\/g, '/').split('/').filter(Boolean).map(encodeURIComponent).join('/');
+  const get = (p) => new Promise((resolve, reject) => {
+    const req = http.get(base + '/' + enc(p), { timeout: 5000 }, (res) => { res.resume(); resolve(res.statusCode); });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('preview get timeout')); });
+  });
+  // 1) 会话根之外：DSH_HOME 与 userData 的文件必须被拒绝。
+  const secret = path.join(t.dshHome, 'secret-marker.txt');
+  fs.writeFileSync(secret, 'PREVIEW_LEAK_MARKER');
+  t.assert(await get(secret) === 403, '会话根之外（DSH_HOME）文件应 403');
+  t.assert(await get(path.join(t.userData, 'settings.json')) === 403, '会话根之外（userData）文件应 403');
+  // 2) 会话 cwd 之内：先被拒（无会话）→ 创建会话日志后立即可读。
+  //    第二次请求同时验证「文件围栏缓存刷新」：第一次请求已把空根集写入
+  //    5 分钟缓存，若缓存不刷新，新会话的项目文件会被误拒。
+  const proj = path.join(t.dir, 'proj');
+  fs.mkdirSync(proj, { recursive: true });
+  const file = path.join(proj, 'index.html');
+  fs.writeFileSync(file, '<h1>hello</h1>');
+  t.assert(await get(file) === 403, '无会话时项目文件也应 403');
+  const header = { type: 'session', version: 0, id: 'sess-preview', createdAt: Date.now(), cwd: proj, delegationDepth: 0 };
+  const frame = zlib.zstdCompressSync(Buffer.from(JSON.stringify(header) + '\n'));
+  const sessDir = path.join(t.dshHome, 'sessions', 'sess-preview');
+  fs.mkdirSync(sessDir, { recursive: true });
+  fs.writeFileSync(path.join(sessDir, 'session.jsonl.zstd'), frame);
+  t.assert(await get(file) === 200, '会话 cwd 内文件应可预览（缓存应刷新）');
   const q = await t.quitAndCheck();
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };


### PR DESCRIPTION
## 概述

本 PR 修复桌面壳层两个严重缺陷系列（均在真实 Electron 环境实测复现）：

1. **退出/重启时的 dsh 进程树清理与端口稳定性**：插件市场式原地重启（`chrome:restart-service`）每次都换新端口，导致 origin 漂移、localStorage（会话分组/主题/隐藏输出等偏好）丢失；退出路径的进程树清理依赖 1.5s 延迟计时器，而主进程退出耗时远小于该值（本机实测约 300ms），清理实际无保证。
2. **预览静态服务任意本地文件读取**：壳层预览静态服务对任意绝对路径返回文件内容，绕过 `dsh:file-open` / `dsh:file-revert` 已有的 H2/H3 文件围栏（仅会话 cwd 之下）。

## 根因

### 进程树清理与端口稳定性

- Windows 下 `taskkill` 不带 `/F` 只能向 GUI 进程发送 WM_CLOSE，对 node.exe 这类控制台进程完全无效（实测报错 `This process can only be terminated forcefully`）。旧 `killTree` 的「先优雅（无 /F）、1.5s 后再 /F 强杀」对 dsh web 从未优雅成功过，实际生效的始终是 1.5s 后的 /F。
- 原地重启时旧进程在「探测端口」阶段仍存活并占着端口 → `chooseStableWebPort` 探测失败 → 换新端口。集成测试实测端口 **12286 → 7186**，且每次重启必现。
- 退出路径下 1.5s 计时器随主进程消亡永不触发，进程树清理完全依赖 Electron 的隐式行为（非 detached 子进程随主进程退出），无任何代码保证。

### 预览静态服务文件读取

- 服务对 `http://127.0.0.1:<port>/<绝对路径>` 无条件读取并返回（实测 DSH_HOME 文件、userData/settings.json、C:\Windows\win.ini 均返回 200）。
- 预览 iframe 与该服务同源（sandbox 含 `allow-same-origin`），页面内脚本可读取任意本地文件并外传，构成任意本地文件读取通道。

## 修复

### 提交 1：进程树清理与端口稳定性

- `killTree` 拆分为两个 API，最终都使用 `/T /F` 强杀（与旧实现实际生效的终结方式一致，不改变「dsh 最终收到强杀」这一既有事实）：
  - `killTree`（异步）：立即强杀并等待直接子进程 exit（3s 超时兜底），供原地重启路径使用；
  - `killTreeSync`（同步）：供应用退出路径使用，保证主进程退出前进程树已被终结，不依赖计时器或 Electron 隐式行为。
- `startServer` 重入时先 `await` 旧进程真正退出、再探测端口：修复「先选端口、后杀进程」的竞态，插件市场重启复用原端口。
- 抽出共享的 `restartService()`：`chrome:restart-service` IPC 与集成测试通道复用同一实现。
- 所有退出路径（`before-quit` / 客户端更新 / agent 更新重启 / 恢复页重启 / `fatal` / `process exit` 兜底）统一改用 `killTreeSync`。
- 移除旧实现中 `tasklist` 文本包含匹配（PID 子串误判）与失效的优雅等待。

### 提交 2：预览服务文件围栏

- 预览静态服务与 `dsh:file-open` / `dsh:file-revert` 共用同一围栏 `isUnderFileRoots()`：只允许读取「会话 cwd」之下的项目文件，其余返回 403。
- `isUnderFileRoots()` 判定不通过时强制刷新一次文件根缓存再判：修复 5 分钟 TTL 内新建会话的项目文件被误拒的问题（预览/还原/打开共用，一并受益）；刷新后的缓存再保持 5 分钟，攻击性探测最多触发每 5 分钟一次重扫。

## 验证

- 新增两个集成场景（真实 Electron + 隔离 DSH_HOME，每场景含进程泄漏检查）：
  - `restart-service`：与 `chrome:restart-service` IPC 完全一致的路径，断言重启前后端口不变。修复前失败（12286 → 7186），修复后通过（7227 → 7227）。
  - `preview-fence`：会话根之外（DSH_HOME / userData）文件 403；会话 cwd 内文件先 403（无会话）→ 写入会话日志后立即 200（同时验证文件根缓存刷新）。
- 全量回归：单元测试 17/17 通过；集成测试 12/12 通过（含既有 10 个场景），无进程泄漏。

## 兼容性

- 不改变任何 IPC/插件接口与设置格式。
- `killTree` 最终行为（/T /F）与旧实现相同，仅移除无效的优雅等待与竞态窗口；非 Windows 分支保持原有 SIGTERM 语义。
- 预览面板的合法用途（会话项目内的 HTML 及其相对资源）不受影响；端口预览（直连 `http://127.0.0.1:<port>`）不经本服务，不受影响。
