### PR TITLE
fix: 存量坏 manifest 自愈（issue #16）—— 补齐缺失的核心 bundles

### DIFF
--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -28,6 +28,7 @@ files:
   - session-watcher.js
   - preload.js
   - renderer-recovery.js
+  - profile-manifest.js
   - wsl-backend.js
   - watchdog.js
   - assets/**/*

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -28,6 +28,7 @@ const balance = require('./balance');
 const wslBackend = require('./wsl-backend');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
+const { ensureCoreBundles, CORE_BUNDLE_NAMES } = require('./profile-manifest');
 const zlib = require('node:zlib');
 
 // ---------------------------------------------------------------------------
@@ -2338,6 +2339,23 @@ function healProfilePatch() {
     log('boot', 'profile patch 自愈失败: ' + err.message);
   }
 }
+/**
+ * 在「实际将运行的 dsh 包」（内置或用户目录 overlay）中解析核心 bundles，
+ * 只返回真实可解析的模板名；解析不到的名字绝不写入，避免与真正启动的
+ * dsh 版本漂移后写入无效 bundle 名。
+ */
+function resolvableCoreBundles() {
+  const installAnchor = path.dirname(dshPackageJson());
+  return CORE_BUNDLE_NAMES.filter((name) => {
+    try {
+      require.resolve(name + '/package.json', { paths: [installAnchor] });
+      return true;
+    } catch {
+      return false; // 该 dsh 安装中缺失，交由 dsh 初始化
+    }
+  });
+}
+
 function syncCompanionPlugins() {
   if (!IS_WIN) return;
   try {
@@ -2415,21 +2433,26 @@ function syncCompanionPlugins() {
     // manifest，交由 dsh 自行初始化，bundle 插件留待下一次启动注册。
     let bundlesUsable = Array.isArray(manifest.dsh.profile.bundles);
     if (!bundlesUsable) {
-      const coreBundles = [];
-      // 以「实际将运行的 dsh 包」（内置或用户目录 overlay）为解析锚点，
-      // 确保写入的模板与真正启动的 dsh 版本一致；解析不到则不写。
-      const installAnchor = path.dirname(dshPackageJson());
-      for (const name of ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app']) {
-        try {
-          require.resolve(name + '/package.json', { paths: [installAnchor] });
-          coreBundles.push(name);
-        } catch { /* 该 dsh 安装中缺失，交由 dsh 初始化 */ }
-      }
-      if (coreBundles.length === 2) {
+      const coreBundles = resolvableCoreBundles();
+      if (coreBundles.length === CORE_BUNDLE_NAMES.length) {
         manifest.dsh.profile.bundles = coreBundles;
         bundlesUsable = true;
       } else {
         log('boot', 'dsh 出厂核心 bundles 未在安装中解析到，跳过 manifest 预写，交由 dsh 初始化');
+      }
+    } else {
+      // issue #16 存量自愈：旧版本（0.3.3/0.3.4，#13 的 bug 场景）写坏的
+      // manifest 里 bundles 只有配套 bundle、缺少核心 bundles。dsh 启动时
+      // 核心服务（webServer/subprocess/settings/llm 等）无人提供，插件树
+      // 无法激活（N entries did not activate），且该状态永远无法自愈。
+      // 这里把缺失且可解析的核心 bundles 补到列表最前（保持与模板一致的
+      // 先后顺序），其余条目（含用户自行添加的）原样保留；健康 manifest
+      // 零写入（幂等）。写入用原子写，避免与 dsh 的观察者撕裂读。
+      const healed = ensureCoreBundles(manifest.dsh.profile.bundles, resolvableCoreBundles());
+      if (healed) {
+        manifest.dsh.profile.bundles = healed.next;
+        writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+        log('boot', 'profile manifest 自愈: 旧版本写坏的 bundles 缺少核心 ' + healed.added.join(', ') + '，已补齐到最前');
       }
     }
     for (const name of bundleNames) {

--- a/dsh-desktop/profile-manifest.js
+++ b/dsh-desktop/profile-manifest.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// profile manifest bundles 自愈核心（纯函数、无 electron 依赖，便于 node:test 单测）。
+//
+// 背景（issue #16）：旧版本（0.3.3/0.3.4，即 #13 的 bug 场景）会把
+// profiles/web/package.json 的 dsh.profile.bundles 写成「只有配套 bundle、
+// 缺少核心 bundles」的坏状态。dsh 启动时核心服务（webServer/subprocess/
+// settings/llm 等）无人提供，插件树无法激活（N entries did not activate），
+// 且该状态在后续版本中无法自愈。
+//
+// 这里提供纯函数化的「校验 + 补齐」逻辑：把缺失的核心 bundles 补到列表
+// 最前（保持与 dsh-app-boot PROFILE_TEMPLATES.web 一致的先后顺序），
+// 其余条目（含用户自行添加的）原样保留；无需修复时返回 null（零写入）。
+
+// 与 dsh-app-boot 的 PROFILE_TEMPLATES.web 一致的核心 bundles（先后顺序有意义）。
+const CORE_BUNDLE_NAMES = ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'];
+
+/**
+ * 补齐 bundles 中缺失的核心 bundles。
+ * @param {Array} bundles 现有 dsh.profile.bundles 数组（可能含非字符串条目，原样保留）
+ * @param {Array<string>} resolvableCores 当前 dsh 安装中可解析的核心 bundle 名；
+ *   只接受出现在 CORE_BUNDLE_NAMES 中的名字，解析不到的名字绝不写入。
+ * @returns {{ next: Array, added: string[] } | null} 有缺失时返回补好后的新数组
+ *   与新增项；无缺失（或无可解析核心）时返回 null，调用方零写入。
+ */
+function ensureCoreBundles(bundles, resolvableCores) {
+  const usable = [...new Set(
+    (Array.isArray(resolvableCores) ? resolvableCores : []).filter((c) => CORE_BUNDLE_NAMES.includes(c))
+  )];
+  const added = usable.filter((c) => !bundles.includes(c));
+  if (added.length === 0) return null;
+  return { next: [...added, ...bundles], added };
+}
+
+module.exports = { ensureCoreBundles, CORE_BUNDLE_NAMES };

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -20,6 +20,7 @@ const entryFiles = [
   'balance.js',
   'session-watcher.js',
   'renderer-recovery.js',
+  'profile-manifest.js',
   'wsl-backend.js',
   'watchdog.js',
 ];

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -395,6 +395,32 @@ SCENARIOS['preview-fence'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['heal-stale-manifest'] = async (t) => {
+  // issue #16：旧版本（0.3.3/0.3.4，#13 场景）写坏的存量 manifest ——
+  // bundles 只有配套 bundle、缺少核心 bundles —— 必须在本轮启动中自愈，
+  // 否则 dsh web 每次都以「plugin tree failed to load」退出码 1 失败。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const badManifest = {
+    name: 'dsh-profile-web',
+    private: true,
+    dsh: { profile: { bundles: ['@dsh-external/dsh-super-injector', 'zat-dsh-engine'] } },
+  };
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify(badManifest, null, 2) + '\n');
+  await t.waitFor('boot-ready', 240000, '坏 manifest 应被自愈后正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('profile manifest 自愈'), '应记录 manifest 自愈日志');
+  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  const bundles = manifest && manifest.dsh && manifest.dsh.profile && manifest.dsh.profile.bundles;
+  t.assert(Array.isArray(bundles), 'manifest bundles 应为数组');
+  t.assert(bundles[0] === '@deepseek-ai/dsh-base' && bundles[1] === '@deepseek-ai/dsh-web-app',
+    `核心 bundles 应补齐到最前，实际=${JSON.stringify(bundles)}`);
+  t.assert(bundles.includes('@dsh-external/dsh-super-injector') && bundles.includes('zat-dsh-engine'),
+    '既有配套 bundle 应原样保留');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
 SCENARIOS['kill-renderer'] = async (t) => {
   await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');

--- a/dsh-desktop/scripts/test/unit-manifest.test.js
+++ b/dsh-desktop/scripts/test/unit-manifest.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// profile-manifest.js 纯函数单元测试（node --test，无需 Electron）。
+// 用法：node --test scripts/test/unit-manifest.test.js
+// 覆盖：双缺失/单缺失补齐、模板顺序、幂等零写入、空数组、无可解析核心、
+//       非字符串条目容错、重复项防护。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { ensureCoreBundles, CORE_BUNDLE_NAMES } = require('../../profile-manifest');
+
+const CORES = [...CORE_BUNDLE_NAMES];
+
+test('双缺失：核心 bundles 补齐到最前，既有条目顺序保留', () => {
+  const r = ensureCoreBundles(['@dsh-external/dsh-super-injector', 'zat-dsh-engine'], CORES);
+  assert.deepStrictEqual(r.next, [...CORES, '@dsh-external/dsh-super-injector', 'zat-dsh-engine']);
+  assert.deepStrictEqual(r.added, CORES);
+});
+
+test('单缺失：只补缺失的那个，且保持模板先后顺序', () => {
+  const r = ensureCoreBundles(['@deepseek-ai/dsh-web-app', 'x-custom'], CORES);
+  assert.deepStrictEqual(r.next, ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', 'x-custom']);
+  assert.deepStrictEqual(r.added, ['@deepseek-ai/dsh-base']);
+});
+
+test('健康（核心齐全）：返回 null，零写入', () => {
+  assert.strictEqual(ensureCoreBundles([...CORES, 'zat-dsh-engine'], CORES), null);
+  // 顺序不同但齐全 → 不重排、不写入
+  assert.strictEqual(ensureCoreBundles(['@deepseek-ai/dsh-web-app', '@deepseek-ai/dsh-base'], CORES), null);
+});
+
+test('空数组：补齐全部核心', () => {
+  const r = ensureCoreBundles([], CORES);
+  assert.deepStrictEqual(r.next, CORES);
+  assert.deepStrictEqual(r.added, CORES);
+});
+
+test('无可解析核心：返回 null，绝不写入无法解析的名字', () => {
+  assert.strictEqual(ensureCoreBundles(['zat-dsh-engine'], []), null);
+  assert.strictEqual(ensureCoreBundles([], []), null);
+  // 解析名单里混入非模板名 → 过滤后无可补项
+  assert.strictEqual(ensureCoreBundles([], ['some-other-bundle']), null);
+});
+
+test('非字符串条目容错：不抛异常、原样保留', () => {
+  const r = ensureCoreBundles([null, 42, 'zat-dsh-engine'], CORES);
+  assert.deepStrictEqual(r.next, [...CORES, null, 42, 'zat-dsh-engine']);
+});
+
+test('既有条目含重复/核心重复：核心不重复补齐，原内容原样保留', () => {
+  const r = ensureCoreBundles(['zat-dsh-engine', 'zat-dsh-engine'], CORES);
+  assert.deepStrictEqual(r.next, [...CORES, 'zat-dsh-engine', 'zat-dsh-engine']);
+  // 核心之一重复但仍缺另一个 → 只补缺失的那个
+  const r2 = ensureCoreBundles([CORES[0], CORES[0], 'zat-dsh-engine'], CORES);
+  assert.deepStrictEqual(r2.next, [CORES[1], CORES[0], CORES[0], 'zat-dsh-engine']);
+  assert.deepStrictEqual(r2.added, [CORES[1]]);
+  // 核心齐全（即使有重复）→ 不再补
+  assert.strictEqual(ensureCoreBundles([CORES[0], CORES[0], CORES[1], 'zat-dsh-engine'], CORES), null);
+});
+
+test('resolvableCores 含重复：新增列表去重', () => {
+  const r = ensureCoreBundles([], [CORES[0], CORES[0], CORES[1]]);
+  assert.deepStrictEqual(r.added, CORES);
+  assert.deepStrictEqual(r.next, CORES);
+});


### PR DESCRIPTION
## 概述

Fixes #16

本 PR 只包含 issue #16 的根治修复。原先一并修复的 v0.3.7 启动阻断（悬空 `async`、`applySettingsSectionGuard` 缺少 `home` 声明）已由上游在 v0.3.8 自行修复（`888b6fe`、`c031747`），故相关提交已从本 PR 移除，避免重复与合并噪音。

## 结论（针对「最新版本是否已修复 #16」的核查）

- 最新版本 v0.3.8（`c031747`）中 `syncCompanionPlugins` 对已存在的 `dsh.profile.bundles` 数组仍无任何校验（`Array.isArray` 即视为可用），**issue #16 未被修复**，issue 仍处于 open 状态。
- 真实环境复现（v0.3.8 + 隔离 DSH_HOME，预置 issue 中的坏 manifest）：应用 240 秒无法启动，dsh-web.log 报 `assertEntriesActivated` 失败、各配套插件 `pending (waiting for services: ...)`，与 issue 描述完全一致。

## 根因

旧版本（0.3.3/0.3.4，#13 的 bug 场景）把 `profiles/web/package.json` 的 `dsh.profile.bundles` 写成「只有配套 bundle、缺少核心 bundles」的坏状态。dsh 启动时核心服务（webServer/subprocess/settings/llm 等）无人提供 → 插件树无法激活（N entries did not activate）→ 退出码 1。该坏状态被持久化在用户配置目录，而 v0.3.5+ 的同步逻辑只对「全新 profile」做了防写坏保护（#14），对「已存在的坏 manifest」从不校验或修复，因此升级后永远无法启动。

## 修复

- 新增纯函数模块 `profile-manifest.js`（无 electron 依赖，便于 node:test 单测）：`ensureCoreBundles` 把缺失的核心 bundles 补到列表最前（保持与 `PROFILE_TEMPLATES.web` 一致的先后顺序），其余条目（含用户自行添加的）原样保留；无需修复时返回 null（调用方零写入）。
- `syncCompanionPlugins` 对已存在的 bundles 数组执行「校验 + 补齐」：
  - 只补在当前「实际将运行的 dsh 包」（内置或用户目录 overlay）中实测可解析的核心名，解析不到绝不写入（版本漂移安全）；
  - 原子写（临时文件 + rename）防撕裂读；
  - 健康 manifest 零写入（幂等）；
  - 全新 profile 的既有防写坏逻辑保持不变。
- electron-builder `files` 清单与 check-syntax 入口清单同步补充 `profile-manifest.js`（打包产物与构建前语法预检都必须包含）。

## 验证

- 集成场景 `heal-stale-manifest`（真实 Electron + 隔离 DSH_HOME，预置 issue #16 的坏 manifest）：
  - 修复前（v0.3.8 原版）：240 秒无法启动，与 issue 现象一致（RED）；
  - 修复后：坏 manifest 在启动过程中被自愈，正常就绪，实测补齐为
    `[@deepseek-ai/dsh-base, @deepseek-ai/dsh-web-app, @dsh-external/dsh-super-injector, zat-dsh-engine, dsh-better-sidebar, harness-pet]`（GREEN）。
- 单元测试 `unit-manifest.test.js` 8/8：双缺失/单缺失补齐、健康零写入、空数组、无可解析核心、非字符串条目容错、重复防护、解析名单去重。
- 基于 v0.3.8 的全量回归：集成测试 13/13 通过（含既有 12 个场景与进程泄漏检查），单元测试 25/25 通过。

## 兼容性

- 不改变任何 IPC/插件接口与设置格式；健康 profile 零写入；
- WSL 托管模式共用同一同步逻辑（UNC 写入），不受影响；
- 与上游 v0.3.8 的其它修复（async/home、profile patch 自愈等）无冲突，本分支已 rebase 至最新 main。
