### PR TITLE
fix: web-search-deepseek「接口地址」契约与拼接修复（issue #20）

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -28,6 +28,7 @@ const balance = require('./balance');
 const wslBackend = require('./wsl-backend');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
+const { patchWebSearchBaseUrl } = require('./scripts/patch-web-search-baseurl');
 const zlib = require('node:zlib');
 
 // ---------------------------------------------------------------------------
@@ -1649,7 +1650,8 @@ async function runUpdateFlow(manual) {
       applyVisionKeyFix();
       applyProfilePatchGuard();
       applySettingsSectionGuard();
-  applyWorkspaceSearchRailFix();
+      applyWorkspaceSearchRailFix();
+      applyWebSearchBaseUrlFix();
     }
     const { response: r2 } = await showBox({
       type: 'info',
@@ -2894,6 +2896,30 @@ function applyWorkspaceSearchRailFix() {
     }
   }
 }
+// ---------------------------------------------------------------------------
+// issue #20 运行时补丁：dsh-web-search-deepseek 的「接口地址」契约与拼接修复。
+// 补丁本体在 scripts/patch-web-search-baseurl.js（与打包补丁共用同一实现，
+// 避免两处漂移）；这里覆盖三处运行副本：profile fallback（junction 写穿）、
+// 内置 app 副本、用户更新过的 agent overlay。锚点不匹配（上游将来修复后）
+// 自动跳过，绝不损坏文件。
+// ---------------------------------------------------------------------------
+function applyWebSearchBaseUrlFix() {
+  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+  const targets = [
+    path.join(home, 'profiles', 'node_modules'),
+    path.join(__dirname, 'node_modules'),
+    path.join(userDataDir, 'agent', 'node_modules'),
+  ];
+  for (const root of targets) {
+    if (!root || !fs.existsSync(root)) continue;
+    try {
+      const n = patchWebSearchBaseUrl(root, (m) => log('boot', m));
+      if (n > 0) log('boot', 'web-search baseURL 补丁: 已应用到 ' + root);
+    } catch (err) {
+      log('boot', 'web-search baseURL 补丁失败(' + root + '): ' + err.message);
+    }
+  }
+}
 // 快捷方式维护：修复「没有桌面快捷方式 / 快捷方式指向的文件消失」，
 // 并让快捷方式图标跟随图标设计更新（.lnk 单独指定 icon.ico）。
 // ---------------------------------------------------------------------------
@@ -3487,7 +3513,8 @@ async function boot() {
     applyVisionKeyFix();
     applyProfilePatchGuard();
     applySettingsSectionGuard();
-  applyWorkspaceSearchRailFix();
+    applyWorkspaceSearchRailFix();
+    applyWebSearchBaseUrlFix();
   } else {
     // 先修复 profile fallback 联接再同步/补丁依赖文件：EPERM 环境下补丁写不进去。
     await repairProfileFallback(home);
@@ -3498,7 +3525,8 @@ async function boot() {
     applyVisionKeyFix();
     applyProfilePatchGuard();
     applySettingsSectionGuard();
-  applyWorkspaceSearchRailFix();
+    applyWorkspaceSearchRailFix();
+    applyWebSearchBaseUrlFix();
     initRendererRecovery();
     createWindow();
     wireWindowRecovery();

--- a/dsh-desktop/scripts/after-pack.js
+++ b/dsh-desktop/scripts/after-pack.js
@@ -28,6 +28,7 @@ require('./patch-portable-template');
 // harness and not marked ignorable" breaks session history loading.
 const { patchDshSessionVocabulary } = require('./patch-event-vocabulary');
 const { installBuiltinPresets } = require('./install-minimal-win-preset');
+const { patchWebSearchBaseUrl } = require('./patch-web-search-baseurl');
 
 // Regexes for files that are safe to delete (pure metadata / dev artifacts).
 const DROP_BASENAME = /^(LICENSE.*|README.*|CHANGELOG.*|HISTORY.*|COPYING.*|NOTICE.*|AUTHORS.*|SECURITY.*|CONTRIBUTING.*|\.gitignore|\.npmignore|\.editorconfig|\.eslintrc.*|\.prettierrc.*|\.babelrc.*)$/i;
@@ -103,5 +104,16 @@ module.exports = async function afterPack(context) {
     console.log(`afterPack: builtin presets installed (${presetDirs.length}): ${presetDirs.map((p) => path.basename(p)).join(", ")}`);
   } else {
     console.warn('afterPack: bundled dsh package not found — minimal-win preset skipped');
+  }
+
+  // Patch the bundled dsh-web-search-deepseek baseURL handling (issue #20,
+  // idempotent). Runs after pruning so the .js files it modifies are the final
+  // copies; the same implementation is re-applied at boot for the overlay copy.
+  const appNm = path.join(appOutDir, 'resources', 'app', 'node_modules');
+  if (fs.existsSync(appNm)) {
+    const wsChanged = patchWebSearchBaseUrl(appNm, (m) => console.log('afterPack: ' + m));
+    console.log(`afterPack: web-search baseURL ${wsChanged > 0 ? `patched (${wsChanged} files)` : 'already up to date'}`);
+  } else {
+    console.warn('afterPack: bundled app node_modules not found — web-search baseURL patch skipped');
   }
 };

--- a/dsh-desktop/scripts/patch-web-search-baseurl.js
+++ b/dsh-desktop/scripts/patch-web-search-baseurl.js
@@ -1,0 +1,168 @@
+'use strict';
+
+// 修复 issue #20：dsh-web-search-deepseek 的「接口地址」契约与拼接缺陷。
+//
+// 现象：用户在 Web 搜索设置「接口地址」填写第三方服务（如 https://api.exa.ai/search）
+// 后，provider 仍无条件把 /messages 拼到基址后，并按 DeepSeek 的 Anthropic 兼容
+// Messages 协议（x-api-key / anthropic-version / web_search_20250305）发请求 →
+// 404；错误信息只有服务端原文，用户无从判断原因。
+//
+// 修复内容（幂等、anchor 不匹配时跳过且绝不损坏文件）：
+//  1. provider（lib/index.js）：
+//     · 基址归一化后再拼 /messages：尾斜杠不产生双斜杠；基址已以 /messages
+//       结尾时不再重复拼接（允许用户直接填完整端点）；
+//     · HTTP 失败信息附上实际请求地址与本提供方的协议契约，把裸 404 变成
+//       可自解的指引（该提供方只支持 DeepSeek Anthropic 兼容 Messages API，
+//       其它协议的搜索服务需使用对应提供方）。
+//  2. 设置页文案（dsh-client-ui-settings-plugins/lib/client.js，中英文）：
+//     「接口地址」提示改为明确说明协议契约（POST <基址>/messages），避免用户
+//     误以为可以填写任意搜索服务地址。
+//
+// 用法：
+//   node scripts/patch-web-search-baseurl.js [<node_modules 根目录>]
+// 同时导出 patchWebSearchBaseUrl(nmRoot, log) 供 main.js 运行时补丁与
+// after-pack.js 打包补丁复用（覆盖内置副本 / profile fallback / agent overlay）。
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const MARKER = 'dsh-desktop patch (issue #20)';
+
+// ---------------------------------------------------------------------------
+// provider 补丁（@deepseek-ai/dsh-web-search-deepseek/lib/index.js）
+// ---------------------------------------------------------------------------
+
+const PROVIDER_OLD_ENDPOINT = 'const endpoint = `${options.baseURL}/messages`;';
+const PROVIDER_NEW_ENDPOINT_LINES = [
+  '// dsh-desktop patch (issue #20): 归一化基址后再拼 /messages ——',
+  '// 尾斜杠不产生双斜杠；基址已含 /messages 时不再重复拼接。',
+  'const normalizedBase = options.baseURL.replace(/\\/+$/, "");',
+  'const endpoint = /\\/messages\\/?$/.test(normalizedBase) ? normalizedBase : `${normalizedBase}/messages`;',
+];
+const PROVIDER_OLD_MESSAGE = 'let message = `DeepSeek API error (HTTP ${response.status})`;';
+const PROVIDER_NEW_MESSAGE = 'let message = `DeepSeek API error (HTTP ${response.status}) at ${endpoint}`;';
+const PROVIDER_OLD_THROW = 'throw new WebError(message, "WEB_PROVIDER_ERROR");';
+const PROVIDER_NEW_THROW_LINES = [
+  '// dsh-desktop patch (issue #20): 附上请求地址与协议契约，裸 404 也能自解。',
+  'const guidance = " 本搜索提供方仅支持 DeepSeek 的 Anthropic 兼容 Messages API（POST <基址>/messages，x-api-key 鉴权）。请将「接口地址」填为该协议的基址（留空 = 官方默认地址）；其它协议的搜索服务（如 Exa）需要对应的提供方插件。";',
+  'throw new WebError(message + guidance, "WEB_PROVIDER_ERROR");',
+];
+
+// ---------------------------------------------------------------------------
+// 设置页文案补丁（@deepseek-ai/dsh-client-ui-settings-plugins/lib/client.js）
+// ---------------------------------------------------------------------------
+
+const CLIENT_PAIRS = [
+  [
+    'webSearchDescription: "The DeepSeek search provider.",',
+    'webSearchDescription: "DeepSeek search provider (Anthropic-compatible Messages API).",',
+  ],
+  [
+    'webSearchBaseUrlHint: "Leave blank to use the provider default.",',
+    'webSearchBaseUrlHint: "This provider calls the Anthropic-compatible Messages API (POST <base>/messages). Enter that API\'s base URL; leave blank for the DeepSeek official default.",',
+  ],
+  [
+    'webSearchDescription: "DeepSeek 搜索提供方。",',
+    'webSearchDescription: "DeepSeek 搜索提供方（Anthropic 兼容 Messages API）。",',
+  ],
+  [
+    'webSearchBaseUrlHint: "留空则使用提供方默认地址。",',
+    'webSearchBaseUrlHint: "该提供方通过 Anthropic 兼容 Messages API 请求（POST <基址>/messages）。请填该协议的基址；留空则使用 DeepSeek 官方默认地址。",',
+  ],
+];
+
+// ---------------------------------------------------------------------------
+// 工具
+// ---------------------------------------------------------------------------
+
+/** 用「原行缩进」把多行替换体拼好，保持文件风格一致。 */
+function indentedBlock(src, anchor, lines) {
+  const idx = src.indexOf(anchor);
+  if (idx === -1) return null;
+  const lineStart = src.lastIndexOf('\n', idx) + 1;
+  const indent = /^[ \t]*/.exec(src.slice(lineStart))[0];
+  return lines.join('\n' + indent);
+}
+
+function patchProvider(src) {
+  if (src.includes(MARKER)) return { changed: false, skipped: false, src };
+  const replacements = [
+    [PROVIDER_OLD_ENDPOINT, indentedBlock(src, PROVIDER_OLD_ENDPOINT, PROVIDER_NEW_ENDPOINT_LINES)],
+    [PROVIDER_OLD_MESSAGE, indentedBlock(src, PROVIDER_OLD_MESSAGE, [PROVIDER_NEW_MESSAGE])],
+    [PROVIDER_OLD_THROW, indentedBlock(src, PROVIDER_OLD_THROW, PROVIDER_NEW_THROW_LINES)],
+  ];
+  let out = src;
+  for (const [oldText, newBlock] of replacements) {
+    if (newBlock === null) {
+      // 任一 anchor 不匹配：跳过整份文件，绝不写出半成品（dsh 版本可能已变化）。
+      return { changed: false, skipped: true, src };
+    }
+    out = out.replace(oldText, newBlock);
+  }
+  return { changed: true, skipped: false, src: out };
+}
+
+function patchClient(src) {
+  if (src.includes(MARKER)) return { changed: false, skipped: false, src };
+  let out = src;
+  let changed = 0;
+  for (const [oldText, newText] of CLIENT_PAIRS) {
+    if (out.includes(newText)) continue; // 该项已应用
+    if (!out.includes(oldText)) return { changed: false, skipped: true, src }; // anchor 缺失，整份跳过
+    out = out.replace(oldText, newText);
+    changed += 1;
+  }
+  // 写入 MARKER 注释标记已打补丁（幂等判断用）。
+  out = '// ' + MARKER + ': web-search baseURL 契约文案已修正\n' + out;
+  return { changed: changed > 0, skipped: false, src: out };
+}
+
+/**
+ * 对某个 node_modules 根目录应用 issue #20 补丁（幂等）。
+ * @param {string} nmRoot node_modules 根目录
+ * @param {(msg: string) => void} [log]
+ * @returns {number} 实际发生修改的文件数
+ */
+function patchWebSearchBaseUrl(nmRoot, log = () => {}) {
+  const targets = [
+    path.join(nmRoot, '@deepseek-ai', 'dsh-web-search-deepseek', 'lib', 'index.js'),
+    path.join(nmRoot, '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
+  ];
+  let changedFiles = 0;
+  for (const file of targets) {
+    if (!fs.existsSync(file)) continue;
+    let src;
+    try {
+      src = fs.readFileSync(file, 'utf8');
+    } catch (err) {
+      log('web-search baseURL 补丁: 读取失败 ' + file + ': ' + err.message);
+      continue;
+    }
+    const patch = file.includes('dsh-web-search-deepseek') ? patchProvider : patchClient;
+    const result = patch(src);
+    if (result.skipped) {
+      log('web-search baseURL 补丁: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file);
+      continue;
+    }
+    if (!result.changed) {
+      log('web-search baseURL 补丁: 已应用，跳过 ' + file);
+      continue; // 已应用（幂等）
+    }
+    try {
+      fs.writeFileSync(file, result.src, 'utf8');
+      changedFiles += 1;
+      log('web-search baseURL 补丁: 已应用 ' + file);
+    } catch (err) {
+      log('web-search baseURL 补丁: 写入失败 ' + file + ': ' + err.message);
+    }
+  }
+  return changedFiles;
+}
+
+module.exports = { patchWebSearchBaseUrl, MARKER };
+
+if (require.main === module) {
+  const root = process.argv[2] ? path.resolve(process.argv[2]) : path.resolve(__dirname, '..', 'node_modules');
+  const n = patchWebSearchBaseUrl(root, (m) => console.log(m));
+  console.log(n > 0 ? `patched ${n} file(s) — restart DSH Desktop to pick it up` : 'nothing to patch (already up to date)');
+}

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -395,6 +395,27 @@ SCENARIOS['preview-fence'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['web-search-patch'] = async (t) => {
+  // issue #20：启动时必须把 web-search baseURL 契约补丁落到生效的 profile
+  // fallback 副本（junction 写穿内置包），并记录日志。
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('web-search baseURL 补丁'), '应记录 web-search baseURL 补丁日志');
+  const providerFile = path.join(t.dshHome, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-web-search-deepseek', 'lib', 'index.js');
+  t.assert(fs.existsSync(providerFile), 'profile fallback 应存在 provider 副本');
+  const src = fs.readFileSync(providerFile, 'utf8');
+  t.assert(src.includes('normalizedBase'), 'provider 应已写入归一化拼接补丁');
+  t.assert(src.includes('Anthropic 兼容 Messages API'), 'provider 应已写入协议契约指引');
+  const clientFile = path.join(t.dshHome, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js');
+  if (fs.existsSync(clientFile)) {
+    t.assert(fs.readFileSync(clientFile, 'utf8').includes('该提供方通过 Anthropic 兼容 Messages API 请求'), '设置页文案补丁应落盘');
+  } else {
+    t.assert(true, 'client 副本不在 profile fallback（不影响 provider 修复断言）');
+  }
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
 SCENARIOS['kill-renderer'] = async (t) => {
   await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');

--- a/dsh-desktop/scripts/test/unit-web-search.test.js
+++ b/dsh-desktop/scripts/test/unit-web-search.test.js
@@ -1,0 +1,201 @@
+'use strict';
+
+// issue #20 补丁的单元与功能测试（node --test）：
+//  A. 补丁脚本纯逻辑：幂等、anchor 缺失跳过且不损坏、文案替换；
+//  B. 打补丁后的 provider 真实 HTTP 行为（本地 mock 服务）：
+//     默认基址/尾斜杠/已含 /messages 的拼接回归、Exa 场景的错误指引、
+//     Anthropic 响应映射回归。
+// 用法：node --test scripts/test/unit-web-search.test.js
+
+const test = require('node:test');
+const { before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { patchWebSearchBaseUrl, MARKER } = require('../patch-web-search-baseurl');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const providerFile = path.join(repoRoot, 'node_modules', '@deepseek-ai', 'dsh-web-search-deepseek', 'lib', 'index.js');
+
+// ---------------------------------------------------------------------------
+// A. 补丁脚本纯逻辑
+// ---------------------------------------------------------------------------
+
+function buildFakeTree(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-ws-patch-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const provider = path.join(root, '@deepseek-ai', 'dsh-web-search-deepseek', 'lib', 'index.js');
+  const client = path.join(root, '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js');
+  fs.mkdirSync(path.dirname(provider), { recursive: true });
+  fs.mkdirSync(path.dirname(client), { recursive: true });
+  const providerSrc = [
+    'export const x = 1;',
+    'async search(request, signal) {',
+    '\t\tconst endpoint = `${options.baseURL}/messages`;',
+    '\t\tlet message = `DeepSeek API error (HTTP ${response.status})`;',
+    '\t\tthrow new WebError(message, "WEB_PROVIDER_ERROR");',
+    '}',
+  ].join('\n');
+  const clientSrc = [
+    'window.__ModuleLoader__.load({',
+    '\twebSearchDescription: "The DeepSeek search provider.",',
+    '\twebSearchBaseUrlHint: "Leave blank to use the provider default.",',
+    '\twebSearchDescription: "DeepSeek 搜索提供方。",',
+    '\twebSearchBaseUrlHint: "留空则使用提供方默认地址。",',
+    '});',
+  ].join('\n');
+  fs.writeFileSync(provider, providerSrc);
+  fs.writeFileSync(client, clientSrc);
+  return { root, provider, client, providerSrc, clientSrc };
+}
+
+test('补丁脚本：一次应用、二次幂等、anchor 缺失跳过且不损坏', (t) => {
+  const tree = buildFakeTree(t);
+  let n = patchWebSearchBaseUrl(tree.root);
+  assert.strictEqual(n, 2, '两份文件都应被补');
+  const provider = fs.readFileSync(tree.provider, 'utf8');
+  const client = fs.readFileSync(tree.client, 'utf8');
+  assert.ok(provider.includes(MARKER) && provider.includes('normalizedBase'), 'provider 补丁落盘');
+  assert.ok(client.includes(MARKER) && client.includes('Anthropic 兼容 Messages API'), 'client 文案补丁落盘');
+  assert.ok(client.includes('DeepSeek 官方默认地址'), '中文提示已替换');
+  assert.ok(client.includes("Enter that API's base URL"), '英文提示已替换');
+  // 幂等：第二次零写入
+  n = patchWebSearchBaseUrl(tree.root);
+  assert.strictEqual(n, 0, '第二次运行应零写入');
+  assert.strictEqual(fs.readFileSync(tree.provider, 'utf8'), provider, 'provider 内容不变');
+  assert.strictEqual(fs.readFileSync(tree.client, 'utf8'), client, 'client 内容不变');
+  // anchor 缺失：跳过且字节级不损坏
+  fs.writeFileSync(tree.provider, 'export const changed = true;\n完全不同的内容\n');
+  fs.writeFileSync(tree.client, 'export const changed = true;\n完全不同的内容\n');
+  const beforeP = fs.readFileSync(tree.provider);
+  const beforeC = fs.readFileSync(tree.client);
+  n = patchWebSearchBaseUrl(tree.root);
+  assert.strictEqual(n, 0, 'anchor 不匹配应跳过');
+  assert.deepStrictEqual(fs.readFileSync(tree.provider), beforeP, 'provider 字节级不变');
+  assert.deepStrictEqual(fs.readFileSync(tree.client), beforeC, 'client 字节级不变');
+});
+
+// ---------------------------------------------------------------------------
+// B. 打补丁后 provider 的真实 HTTP 行为
+// ---------------------------------------------------------------------------
+
+const received = [];
+const mock = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => { body += c; });
+  req.on('end', () => {
+    received.push({ method: req.method, url: req.url, headers: req.headers, body });
+    if (req.url === '/anthropic/v1/messages') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        content: [
+          { type: 'web_search_tool_result', content: [{ type: 'web_search_result', url: 'https://example.com/a', title: '标题A' }] },
+          { type: 'text', text: 'x', citations: [{ url: 'https://example.com/a', cited_text: '摘录文本' }] },
+        ],
+      }));
+      return;
+    }
+    // Exa 行为：/search 存在、/search/messages 不存在
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Cannot POST /search/messages' }));
+  });
+});
+
+function makeProvider(baseURL) {
+  return new Promise((resolve, reject) => {
+    import(pathToFileURL(providerFile).href).then((mod) => {
+      resolve(new mod.DeepSeekSearchProvider(() => ({
+        apiKey: 'sk-test',
+        baseURL,
+        model: 'deepseek-v4-flash',
+        apiVersion: '2023-06-01',
+        maxTokens: 4096,
+        maxUses: 5,
+      })));
+    }, reject);
+  });
+}
+
+test('拼接回归：默认形态基址 → <基址>/messages，映射结果正确', async () => {
+  const base = 'http://127.0.0.1:' + mock.address().port + '/anthropic/v1';
+  const provider = await makeProvider(base);
+  const result = await provider.search({ query: 'q' }, undefined);
+  assert.strictEqual(received.at(-1).url, '/anthropic/v1/messages', '默认形态应拼 /messages');
+  assert.ok(received.at(-1).headers['x-api-key'] === 'sk-test' && received.at(-1).headers['anthropic-version'] === '2023-06-01', '协议头保持不变');
+  assert.deepStrictEqual(result.sources, [{ url: 'https://example.com/a', title: '标题A', snippet: '摘录文本' }], 'Anthropic 响应映射回归');
+  assert.strictEqual(result.truncated, false);
+});
+
+test('拼接回归：尾斜杠基址 → 无双斜杠', async () => {
+  const base = 'http://127.0.0.1:' + mock.address().port + '/anthropic/v1/';
+  const provider = await makeProvider(base);
+  await provider.search({ query: 'q' }, undefined);
+  assert.strictEqual(received.at(-1).url, '/anthropic/v1/messages', '尾斜杠不应产生 //');
+});
+
+test('拼接修复：基址已含 /messages → 不再重复拼接', async () => {
+  const base = 'http://127.0.0.1:' + mock.address().port + '/anthropic/v1/messages';
+  const provider = await makeProvider(base);
+  await provider.search({ query: 'q' }, undefined);
+  assert.strictEqual(received.at(-1).url, '/anthropic/v1/messages', '完整端点应原样使用');
+});
+
+test('issue #20 场景：Exa 式基址 404 时错误信息含请求地址与协议契约指引', async () => {
+  const base = 'http://127.0.0.1:' + mock.address().port + '/search';
+  const provider = await makeProvider(base);
+  let caught = null;
+  try {
+    await provider.search({ query: 'q' }, undefined);
+  } catch (err) {
+    caught = err;
+  }
+  assert.ok(caught, '应抛出错误');
+  assert.strictEqual(received.at(-1).url, '/search/messages', '仍按协议拼 /messages（该协议下不可避免）');
+  assert.ok(caught.message.includes('/search/messages'), '错误信息应包含实际请求地址: ' + caught.message);
+  assert.ok(caught.message.includes('Anthropic 兼容 Messages API'), '错误信息应包含协议契约指引');
+  assert.ok(caught.message.includes('Exa'), '错误信息应给出其它协议服务的指引');
+  assert.ok(caught.message.includes('接口地址'), '错误信息应指向「接口地址」设置项');
+});
+
+test('happy-path 回归：web_search_tool_result 缺块时仍抛 WebError', async () => {
+  // 通过 mock 返回一个「无结果块」的响应（走 mapAnthropicResponse 的失败分支）
+  const weird = http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ content: [{ type: 'text', text: 'no search' }] }));
+    });
+  });
+  await new Promise((resolve) => weird.listen(0, '127.0.0.1', resolve));
+  try {
+    const base = 'http://127.0.0.1:' + weird.address().port + '/anthropic/v1';
+    const provider = await makeProvider(base);
+    let caught = null;
+    try {
+      await provider.search({ query: 'q' }, undefined);
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught && /no web_search_tool_result/.test(caught.message), '缺结果块应报既有 WebError');
+  } finally {
+    await new Promise((resolve) => weird.close(resolve));
+  }
+});
+
+// 启动 mock、确保 checkout 内的 provider 已打补丁（幂等）。
+before(async () => {
+  await new Promise((resolve) => mock.listen(0, '127.0.0.1', resolve));
+  patchWebSearchBaseUrl(path.join(repoRoot, 'node_modules'));
+  const patched = fs.readFileSync(providerFile, 'utf8');
+  if (!patched.includes(MARKER)) {
+    // 防御：跑测试前必须已打补丁（保证测试的是修复后的行为）。
+    throw new Error('checkout provider 未打补丁，无法测试修复后行为');
+  }
+});
+
+after(async () => {
+  await new Promise((resolve) => mock.close(resolve));
+});


### PR DESCRIPTION
## 概述

Fixes #20

修复 dsh-web-search-deepseek 的「接口地址」契约与 URL 拼接缺陷：用户在设置页填写第三方搜索服务地址（如 `https://api.exa.ai/search`）后，请求仍被拼成 `/search/messages` 并按 DeepSeek Anthropic 兼容 Messages 协议发送 → HTTP 404，且错误信息无法自解。

## 归属说明

- 缺陷代码位于上游 deepseek-harness 的 `packages/web/web-search-deepseek` 与 `dsh-client-ui-settings-plugins`（本仓库捆绑 `@deepseek-ai/dsh@0.1.0-rc.6`，npm 最新版本即此）。
- 上游自 rc.5 后对该模块无任何修复提交，短期内不会发布修复。
- 本修复沿用本仓库对捆绑 dsh 包的既有补丁模式（`patch-deps.js` / `applyPromptExposeFix` / `applySettingsSectionGuard` 等），锚点式、幂等、上游文件变化后自动跳过——上游将来真正修复并发布新版本后，本补丁自动失效，不会与官方实现分叉。

## 根因与实测证据

- `search()` 无条件执行 `` `${options.baseURL}/messages` ``，且协议固定为 DeepSeek Anthropic 兼容 Messages（`x-api-key`、`anthropic-version`、`web_search_20250305` 工具）。
- 设置页「接口地址」提示仅为「留空则使用提供方默认地址」，未说明协议契约，用户误以为可填写任意搜索服务地址。
- 真实环境复现（本地 mock 服务扮演 Exa）：填写 `http://127.0.0.1:<port>/search` 后，实际请求 `/search/messages`，错误信息仅 `Cannot POST /search/messages`。

## 修复

- 新增 `scripts/patch-web-search-baseurl.js`（运行时与打包共用同一实现）：
  1. **provider**：基址归一化后再拼 `/messages`——尾斜杠不产生双斜杠；基址已以 `/messages` 结尾时不再重复拼接（允许填写完整端点）；HTTP 失败信息附上实际请求地址与协议契约指引（该提供方仅支持 DeepSeek Anthropic 兼容 Messages API，其它协议的服务需使用对应提供方插件）。
  2. **设置页文案**（中英文）：「接口地址」提示与提供方描述改为明确协议契约（POST `<基址>/messages`）。
- `main.js`：启动时对三处运行副本应用补丁（profile fallback / 内置副本 / agent overlay）；官方 dsh 更新完成后立即重打（`runUpdateFlow`），避免「稍后重启」场景回归。
- `after-pack.js`：打包时同步应用到成品副本。

## 验证

- 单元测试 `unit-web-search.test.js` 6/6：
  - 补丁幂等（二次运行零写入）、anchor 缺失时跳过且字节级不损坏；
  - 默认形态 / 尾斜杠 / 完整端点三种拼接回归；
  - Exa 场景：404 错误信息包含实际请求地址、协议契约与「接口地址」指引；
  - Anthropic `web_search_tool_result` 响应映射回归（sources/snippet 解析不变）。
- 集成场景 `web-search-patch`：真实 Electron + 隔离 DSH_HOME 下，启动补丁落到 profile fallback 副本并记录日志。
- 全量回归：集成测试 13/13、单元测试 23/23 通过（每场景含进程泄漏检查）。

## 兼容性

- 默认基址（`https://api.deepseek.com/anthropic/v1`）的请求行为逐字节不变，健康用户零影响；
- 不改变任何 IPC/插件接口与设置格式；
- 上游发布修复后锚点失配，补丁自动失效，零分叉风险。
