### PR TITLE
fix: profile patch 重复/双登记 loader 条目自愈（issue #17 及 bundle 迁移同族）

### DIFF
--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -28,6 +28,7 @@ files:
   - session-watcher.js
   - preload.js
   - renderer-recovery.js
+  - profile-patch-heal.js
   - wsl-backend.js
   - watchdog.js
   - assets/**/*

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -28,6 +28,7 @@ const balance = require('./balance');
 const wslBackend = require('./wsl-backend');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
+const { dedupePatchEntries, dropBlocksByIds, parseFailedLoaderIds, mapPackagesToPatchIds } = require('./profile-patch-heal');
 const zlib = require('node:zlib');
 
 // ---------------------------------------------------------------------------
@@ -532,32 +533,32 @@ function logTailSnippet(maxLines = 20) {
   return tail ? '\n\n最近日志：\n' + tail : '';
 }
 
-function parseFailedLoaderIds(text) {
-  const ids = new Set();
-  const re = /failed to apply loader entry\s+([A-Za-z0-9_-]+)\s*\(/g;
-  let m;
-  while ((m = re.exec(text)) !== null) {
-    if (m[1] !== 'include') ids.add(m[1]);
-  }
-  return [...ids];
+// loader 失败条目的三种 id 形态解析已收口到 profile-patch-heal.js
+// （parseFailedLoaderIds，含 issue #17 的 "duplicate loader entry id: X" 与
+// 括号包名形态），这里不再保留本地实现。
+
+function profilePatchText() {
+  const patchFile = path.join(dshHome || path.join(os.homedir(), '.dsh'), 'profiles', 'web', 'cordis.patch.yml');
+  try { return fs.readFileSync(patchFile, 'utf8'); } catch { return ''; }
 }
 
 function profilePatchIds() {
-  const patchFile = path.join(dshHome || path.join(os.homedir(), '.dsh'), 'profiles', 'web', 'cordis.patch.yml');
+  const text = profilePatchText();
   const ids = new Set();
-  try {
-    const text = fs.readFileSync(patchFile, 'utf8');
-    const re = /(?:^|\n)\s*-\s*id:\s*([A-Za-z0-9_-]+)/g;
-    let m;
-    while ((m = re.exec(text)) !== null) ids.add(m[1]);
-  } catch {}
+  const re = /(?:^|\n)\s*-\s*id:\s*([A-Za-z0-9_-]+)/g;
+  let m;
+  while ((m = re.exec(text)) !== null) ids.add(m[1]);
   return [...ids];
 }
 
 function findFailedPatchPlugins() {
-  const failed = parseFailedLoaderIds(readDshWebLogTail(120));
+  const tokens = parseFailedLoaderIds(readDshWebLogTail(120));
   const known = new Set(profilePatchIds());
-  return failed.filter((id) => known.has(id));
+  // 括号包名（@scope/pkg）不是 patch id：先映射回条目 id 再参与 overlay 判定；
+  // 其余 token（hash 形态与 duplicate loader entry id: X 形态）按既有逻辑过滤。
+  const packages = tokens.filter((t) => t.includes('/'));
+  const mapped = mapPackagesToPatchIds(profilePatchText(), packages);
+  return [...new Set([...tokens.filter((t) => !t.includes('/')), ...mapped])].filter((id) => known.has(id));
 }
 
 function safeBootOverlayPath() {
@@ -2270,12 +2271,16 @@ function removeLegacyMarketplace(profileWebModules, profileDir) {
 }
 
 // ---------------------------------------------------------------------------
-// profile patch 自愈：cordis.patch.yml 损坏（典型：顶层 `[]` 与 `- insert:` 列表
-// 混存——同一 YAML 文档两个顶层值）会让 dsh web 装配 profile 时抛 YAMLException
-// 并以 exit 1 退出，桌面端「启动失败」。每次启动 dsh web 前调用本函数：
+// profile patch 自愈：cordis.patch.yml 损坏会让 dsh web 装配 profile 时抛错并
+// 以 exit 1 退出，桌面端「启动失败」。每次启动 dsh web 前调用本函数：
 //   1. 顶层孤立 `[]` 与列表条目混存 → 移除 `[]` 行（修复为单一顶层列表）；
-//   2. 仍无法解析（其它损坏形态）→ 备份为 cordis.patch.yml.broken-<ts> 并重置为
-//      最小合法文件，日志告警，备份保留用户内容供恢复。健康文件零写入（幂等）。
+//   2. issue #17 存量：同一 loader id 被注册多次（旧版本插件安装写入的重复
+//      insert 条目 → cordis loader "duplicate loader entry id: X"）→ 注册行级
+//      去重，保留首次注册、备份原文件；config 覆盖/disabled 禁用条目是用户
+//      配置，绝不改动；
+//   3. 仍无法解析（其它损坏形态）→ 备份为 cordis.patch.yml.broken-<ts> 并
+//      重置为最小合法文件，日志告警，备份保留用户内容供恢复。
+//   健康文件零写入（幂等）。
 // ---------------------------------------------------------------------------
 function profilePatchFile() {
   const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
@@ -2328,6 +2333,20 @@ function healProfilePatch() {
     let parsed;
     let error = null;
     try { parsed = yaml.load(text); } catch (err) { error = err; }
+    if (!error && Array.isArray(parsed)) {
+      // issue #17 存量自愈：注册行级去重。重复注册（旧版本插件安装
+      // 写入的第二个同 id insert 条目）会让 cordis loader 抛
+      // "duplicate loader entry id: X"，且该状态永远无法自愈；只删重复
+      // 注册行，用户手写的 config/disabled 覆盖条目原样保留。
+      const dedupe = dedupePatchEntries(text);
+      if (dedupe.removed.length > 0) {
+        const backup = file + '.dup-' + Date.now();
+        try { fs.copyFileSync(file, backup); } catch {}
+        writePatchAtomic(file, dedupe.text);
+        log('boot', 'profile patch 自愈: 移除了重复注册的 loader 条目 ' + [...new Set(dedupe.removed)].join(', ') + '，原文件已备份到 ' + backup);
+        text = dedupe.text;
+      }
+    }
     if (error || !Array.isArray(parsed)) {
       const backup = file + '.broken-' + Date.now();
       try { fs.renameSync(file, backup); } catch { fs.copyFileSync(file, backup); }
@@ -2446,6 +2465,23 @@ function syncCompanionPlugins() {
     let patch = '';
     try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { patch = ''; }
     let changed = false;
+    // bundle 迁移自愈（issue #17 同族）：旧版本把后来升级为 bundle 的配套插件
+    // 当非 bundle 写进了 patch（insert 行）；插件现经 dsh.profile.bundles 装配，
+    // 残留注册行会造成同 id 双登记 → cordis loader "duplicate loader entry id" →
+    // 整树加载失败（更新后首次启动崩溃）。幂等移除命中的注册行/块；用户手写
+    // 的 config 覆盖/disabled 禁用条目原样保留。
+    const bundleIds = new Set();
+    for (const p of COMPANION_PLUGINS) {
+      if (bundleNames.has(p.name)) bundleIds.add(p.id);
+    }
+    if (bundleIds.size > 0 && patch.includes('- id:')) {
+      const migration = dropBlocksByIds(patch, [...bundleIds]);
+      if (migration.removed.length > 0) {
+        patch = migration.text;
+        changed = true;
+        log('boot', '已把 bundle 插件移出 profile patch（避免双登记）: ' + [...new Set(migration.removed)].join(', '));
+      }
+    }
     for (const p of COMPANION_PLUGINS) {
       if (bundleNames.has(p.name)) continue;
       // 该 id 在 patch 里已存在：若它现在的 name 与当前版本不一致（例如终端

--- a/dsh-desktop/profile-patch-heal.js
+++ b/dsh-desktop/profile-patch-heal.js
@@ -1,0 +1,273 @@
+'use strict';
+
+// profile cordis.patch.yml 的「重复 loader 条目」识别与自愈核心（纯函数、无
+// electron 依赖，便于 node:test 单测）。
+//
+// 背景（issue #17）：旧版本（如 v0.3.4）的插件安装路径会向 cordis.patch.yml
+// 写入与桌面端配套插件相同的 `- insert: - id: balance` 条目，同一 id 被
+// 注册两次。cordis loader 装配时抛
+//   duplicate loader entry id: balance
+//   或 failed to apply loader entry <hash> (@scope/pkg): list slot ... already
+//   has an entry with id ... at priority 0
+// 且该存量状态无法自愈，用户「进不来主界面」。
+//
+// 语义边界（依据 dsh-app-boot 的 applyEntryPatches 与 cordis.patch.yml 文件头
+// 注释）：patch 顶层数组包含三类条目——insert 注册列表、id 定向 config 覆盖、
+// disabled 禁用。只有 insert 列表内的行是「注册」；config/disabled 覆盖条目
+// 不注册任何东西，`duplicate loader entry id` 只可能来自注册行。因此自愈
+// 只允许删「注册行」，绝不触碰 config/disabled 覆盖条目（用户配置数据）。
+//
+// 这里提供：
+//   · dedupePatchEntries —— 注册行级去重：同一 id 的第二次及以后注册行
+//     （连同其同缩进兄弟行，如 name/config）被移除，保留首次注册；insert
+//     块内部分重复时只删重复行、保留新注册；config/disabled/定向 insert
+//     块永不改动；无重复时零写入；
+//   · dropBlocksByIds —— bundle 迁移自愈：移除命中移除集的注册行（insert
+//     块内行级删除、整块命中时整块删除）；顶层的 name-only 直注册行（旧版
+//     遗留、无 config/disabled）整块移除；config/disabled 覆盖条目原样保留；
+//   · parseFailedLoaderIds —— 识别 loader 失败日志中的三种 id 形态
+//     （旧 hash 形态 / duplicate loader entry id: X 形态 / 括号包名形态）；
+//   · mapPackagesToPatchIds —— 把括号中的包名映射回 patch 条目 id
+//     （供安全启动 overlay 兜底禁用）。
+
+const idRowRe = /^(\s*)-\s*id:\s*([A-Za-z0-9_-]+)/;
+
+/**
+ * 把文本切分为顶层条目块。顶层条目 = 行首（列 0）以 `- ` 开头的行，
+ * 其后到下一个顶层条目之前的所有行属于该块。块的 insert 属性表示
+ * 块首行为 `- insert:`（注册列表块）；其余（`- id: X` 直条目等）为
+ * 非注册块。
+ * @param {string[]} lines 文件按行切分（已去行尾符）
+ * @returns {{begin:number,end:number,lines:string[],insert:boolean}[]}
+ */
+function topLevelBlocks(lines) {
+  const starts = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^-(\s|$)/.test(lines[i])) starts.push(i);
+  }
+  const blocks = [];
+  for (let s = 0; s < starts.length; s += 1) {
+    const begin = starts[s];
+    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
+    blocks.push({
+      begin,
+      end,
+      lines: lines.slice(begin, end),
+      insert: /^-\s*insert\s*:/.test(lines[begin]),
+    });
+  }
+  return blocks;
+}
+
+/**
+ * 输出兜底：若修复后的文本只剩注释/空行（没有任何顶层条目），补一个空
+ * 数组 `[]`，保证文件仍是合法的顶层数组（YAML 可解析为 []），避免被
+ * 下次启动误判为「解析失败」而重置。
+ * @param {string[]} lines 修复后的行集合
+ * @returns {string[]} 补兜底后的行集合
+ */
+function ensurePatchArray(lines) {
+  if (!lines.some((l) => /^-(\s|$)/.test(l))) lines.push('[]');
+  return lines;
+}
+
+/**
+ * 移除「重复注册」的 loader 条目（issue #17 存量自愈）。
+ * 只针对 insert 注册块做行级去重：同一 id 的第二次及以后注册行（连同其
+ * 同缩进兄弟行）被移除，保留首次注册；insert 块内部分重复时只删重复行、
+ * 保留新注册。config 覆盖、disabled 禁用、定向 insert（`- id: X` +
+ * `insert:`）等非注册条目永不改动。
+ * @param {string} text cordis.patch.yml 原文
+ * @returns {{ text: string, removed: string[] }} 修复后的文本与被移除的重复 id；
+ *   无重复时返回原文本与空数组（零写入）。
+ */
+function dedupePatchEntries(text) {
+  const lines = text.split(/\r?\n/);
+  const blocks = topLevelBlocks(lines);
+  const registered = new Set();
+  const removed = [];
+  const out = [];
+  if (blocks.length > 0 && blocks[0].begin > 0) out.push(...lines.slice(0, blocks[0].begin));
+  for (const block of blocks) {
+    if (!block.insert) {
+      // 非注册块（config 覆盖 / disabled / 定向 insert / 无 id 条目）：
+      // 绝不删除。
+      out.push(...block.lines);
+      continue;
+    }
+    // insert 注册块：行级去重，只删「重复注册」行及其同缩进兄弟行。
+    const kept = [block.lines[0]];
+    let blockDupCount = 0;
+    let i = 1;
+    while (i < block.lines.length) {
+      const m = idRowRe.exec(block.lines[i]);
+      if (!m) {
+        // 非 id 行（name 等兄弟行、嵌套列表值、空行）：跟随其前一行保留。
+        kept.push(block.lines[i]);
+        i += 1;
+        continue;
+      }
+      const id = m[2];
+      if (registered.has(id)) {
+        removed.push(id);
+        blockDupCount += 1;
+        i += 1;
+        const indent = m[1].length;
+        while (i < block.lines.length) {
+          const l = block.lines[i];
+          const li = /^\s*/.exec(l)[0].length;
+          if (l.trim() === '' || (li > indent && !/^\s*-\s+/.test(l))) {
+            i += 1;
+            continue;
+          }
+          break;
+        }
+        continue;
+      }
+      registered.add(id);
+      kept.push(block.lines[i]);
+      i += 1;
+    }
+    // 本块确有重复注册行被删且只剩块头（`- insert:`）→ 丢弃空块；
+    // 无重复的块（含 `- insert: []`）原样保留（保证零写入）。
+    if (blockDupCount > 0 && kept.length === 1) continue;
+    out.push(...kept);
+  }
+  if (removed.length === 0) return { text, removed: [] };
+  return { text: ensurePatchArray(out).join('\n'), removed };
+}
+
+/**
+ * 移除「已迁移为 bundle 的插件」在 patch 层残留的旧注册条目（双登记自愈）。
+ * 旧版本客户端把某些配套插件当非 bundle 写入 cordis.patch.yml（insert 块）；
+ * 插件升级为 bundle（经 dsh.profile.bundles 装配）后，残留注册行会让
+ * cordis loader 抛 `duplicate loader entry id: X` 且整树加载失败（更新后
+ * 首次启动崩溃的根因）。
+ *
+ * 处理规则：
+ *   · insert 注册块声明的 id 全部命中移除集 → 整块删除；
+ *   · insert 注册块内仅部分 id 命中 → 只删除命中的「- id: X」行及其同缩进
+ *     兄弟行（name 等），其余注册原样保留 —— 绝不整块误删；
+ *   · 顶层的纯注册直条目（除 id 行外只有 name 行，旧版遗留）→ 整块移除；
+ *   · config 覆盖 / disabled 禁用 / 携带任意自定义键的覆盖条目是用户配置，
+ *     绝不删除；
+ *   · 其余内容（注释/空行/非命中条目）原样保留。
+ * 无命中时返回原文本（零写入）。
+ * @param {string} text cordis.patch.yml 原文
+ * @param {string[]} ids 需要从 patch 层移除的 loader id 集合
+ * @returns {{ text: string, removed: string[] }} 修复后的文本与被移除的 id
+ */
+function dropBlocksByIds(text, ids) {
+  const removal = new Set((ids || []).filter((i) => typeof i === 'string' && i));
+  if (removal.size === 0) return { text, removed: [] };
+  const lines = text.split(/\r?\n/);
+  const blocks = topLevelBlocks(lines);
+  if (blocks.length === 0) return { text, removed: [] };
+  const removed = [];
+  const out = [];
+  if (blocks[0].begin > 0) out.push(...lines.slice(0, blocks[0].begin));
+  for (const block of blocks) {
+    const idRows = block.lines
+      .map((line, idx) => ({ line, idx, m: idRowRe.exec(line) }))
+      .filter((r) => r.m !== null)
+      .map((r) => ({ ...r, id: r.m[2] }));
+    const hitIds = idRows.filter((r) => removal.has(r.id)).map((r) => r.id);
+    if (hitIds.length === 0) {
+      out.push(...block.lines);
+      continue;
+    }
+    if (!block.insert) {
+      // 非 insert 块：仅当是「旧版遗留的纯注册直条目」——除 id 行外只有
+      // name 行（无 config/disabled/insert 等任何其它键）——才允许整块
+      // 移除；其余形态（config 覆盖、disabled 禁用、定向 insert、携带任意
+      // 自定义键的覆盖条目）都是用户配置，绝不删除。
+      const bodyLines = block.lines.slice(1).filter((l) => l.trim() !== '');
+      const nameOnly = bodyLines.length > 0 && bodyLines.every((l) => /^\s*name\s*:/.test(l));
+      if (nameOnly) {
+        removed.push(...hitIds);
+        continue;
+      }
+      out.push(...block.lines);
+      continue;
+    }
+    if (hitIds.length === idRows.length) {
+      // 全部命中：整块删除。
+      removed.push(...hitIds);
+      continue;
+    }
+    // 部分命中：行级删除命中的「- id: X」注册行及其同缩进兄弟行（name 等），
+    // 保留块内其余注册。兄弟行判定：缩进大于 id 行、且不以「- 」开头。
+    const keep = block.lines.map((line) => ({ line, drop: false }));
+    for (const r of idRows) {
+      if (!removal.has(r.id)) continue;
+      removed.push(r.id);
+      const indent = /^\s*/.exec(r.line)[0].length;
+      keep[r.idx].drop = true;
+      let j = r.idx + 1;
+      while (j < block.lines.length) {
+        const l = block.lines[j];
+        const li = /^\s*/.exec(l)[0].length;
+        if (l.trim() === '' || (li > indent && !/^\s*-\s+/.test(l))) {
+          keep[j].drop = true;
+          j += 1;
+          continue;
+        }
+        break;
+      }
+    }
+    for (const k of keep) if (!k.drop) out.push(k.line);
+  }
+  if (removed.length === 0) return { text, removed: [] };
+  return { text: ensurePatchArray(out).join('\n'), removed };
+}
+
+/**
+ * 从 dsh-web.log 尾部识别 loader 失败条目 id。覆盖三种形态：
+ *   1. failed to apply loader entry <hash> (@scope/pkg): ...（旧形态，hash 是
+ *      条目实例 id，对 overlay 无用但保留兼容）；
+ *   2. duplicate loader entry id: X（cordis-plugin-loader 的重复注册 TypeError）；
+ *   3. 括号中的包名 @scope/pkg（交由 mapPackagesToPatchIds 映射回 patch id）。
+ * @param {string} text 日志文本
+ * @returns {string[]} 去重后的 id/包名 token 列表
+ */
+function parseFailedLoaderIds(text) {
+  const ids = new Set();
+  const hashRe = /failed to apply loader entry\s+([A-Za-z0-9_-]+)\s*\(/g;
+  let m;
+  while ((m = hashRe.exec(text)) !== null) {
+    if (m[1] !== 'include') ids.add(m[1]);
+  }
+  const dupRe = /duplicate loader entry id:\s*([A-Za-z0-9_-]+)/g;
+  while ((m = dupRe.exec(text)) !== null) ids.add(m[1]);
+  const pkgRe = /failed to apply loader entry[\s\S]{0,120}?\((@[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\)/g;
+  while ((m = pkgRe.exec(text)) !== null) ids.add(m[1]);
+  return [...ids];
+}
+
+/**
+ * 把 loader 日志中的包名（@scope/pkg）映射回 cordis.patch.yml 条目 id。
+ * 按「- id: X 之后紧邻的 name: '包名'」扫描；一个包名可能对应多个条目
+ * （重复注册场景），全部返回供 overlay 一并禁用。
+ * @param {string} patchText cordis.patch.yml 原文
+ * @param {string[]} packages 包名列表（可含 @scope/）
+ * @returns {string[]} 匹配到的 patch 条目 id
+ */
+function mapPackagesToPatchIds(patchText, packages) {
+  const wanted = new Set((packages || []).filter((p) => typeof p === 'string' && p));
+  if (wanted.size === 0) return [];
+  const ids = [];
+  const entryRe = /(?:^|\n)\s*-\s*id:\s*([A-Za-z0-9_-]+)([\s\S]*?)(?=(?:\n\s*-\s*id:)|\n\s*-\s+(?:insert|id)|\s*$)/g;
+  let m;
+  while ((m = entryRe.exec(patchText)) !== null) {
+    const id = m[1];
+    const body = m[2];
+    const nameRe = /(?:^|\n)\s*name:\s*['"]?(@[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)['"]?/g;
+    let nm;
+    while ((nm = nameRe.exec(body)) !== null) {
+      if (wanted.has(nm[1])) ids.push(id);
+    }
+  }
+  return ids;
+}
+
+module.exports = { dedupePatchEntries, dropBlocksByIds, parseFailedLoaderIds, mapPackagesToPatchIds };

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -20,6 +20,7 @@ const entryFiles = [
   'balance.js',
   'session-watcher.js',
   'renderer-recovery.js',
+  'profile-patch-heal.js',
   'wsl-backend.js',
   'watchdog.js',
 ];

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -395,6 +395,101 @@ SCENARIOS['preview-fence'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['heal-dup-patch'] = async (t) => {
+  // issue #17：旧版本插件安装写入的「同 id 重复注册」存量（cordis.patch.yml
+  // 含两个 id: balance 的 insert 块）会让 cordis loader 抛
+  // "duplicate loader entry id: X" 且永远无法启动。本场景验证启动自愈：
+  // 去重为单一条目、原文件备份、正常进入 Web UI。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const dupPatch = [
+    '# 模拟 v0.3.4 存量：两个 insert 块重复注册 id: balance',
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '',
+  ].join('\n');
+  const patchFile = path.join(profileDir, 'cordis.patch.yml');
+  fs.writeFileSync(patchFile, dupPatch);
+  await t.waitFor('boot-ready', 240000, '重复注册的 patch 应被自愈后正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('移除了重复注册的 loader 条目'), '应记录重复条目自愈日志');
+  const healed = fs.readFileSync(patchFile, 'utf8');
+  t.assert((healed.match(/^\s*- id: balance$/gm) || []).length === 1, `balance 条目应去重为 1 个，实际=${healed}`);
+  const backups = fs.readdirSync(profileDir).filter((f) => f.startsWith('cordis.patch.yml.dup-'));
+  t.assert(backups.length >= 1, '原文件应被备份为 cordis.patch.yml.dup-<ts>');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-bundle-patch'] = async (t) => {
+  // bundle 迁移双登记自愈（issue #17 同族）：旧版本把后来升级为 bundle 的
+  // 配套插件写进了 cordis.patch.yml（insert 行），现经 dsh.profile.bundles
+  // 装配 → 同 id 双登记 → duplicate loader entry → 启动失败。启动时应自动
+  // 移除 patch 中的残留行并正常进入 Web UI。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const stalePatch = [
+    '# 旧版本遗留：better-sidebar 还被当作非 bundle 写入 patch',
+    '- insert:',
+    '    - id: better-sidebar',
+    "      name: 'dsh-better-sidebar'",
+    '',
+  ].join('\n');
+  const patchFile = path.join(profileDir, 'cordis.patch.yml');
+  fs.writeFileSync(patchFile, stalePatch);
+  await t.waitFor('boot-ready', 240000, 'bundle 双登记应被自愈后正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('已把 bundle 插件移出 profile patch'), '应记录 bundle 迁移自愈日志');
+  const healed = fs.readFileSync(patchFile, 'utf8');
+  t.assert(!/id: better-sidebar/.test(healed), `patch 中的 better-sidebar 残留行应被移除，实际=${healed}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-dup-patch-keeps-config'] = async (t) => {
+  // 回归防线：自愈只允许删「重复注册行」，绝不删除用户手写的
+  // config 覆盖 / disabled 禁用条目（cordis.patch.yml 官方文件头声明的
+  // 顶层条目形态）。同 id 的重复 insert 注册 + disabled/config 覆盖共存时，
+  // 应去重注册行并原样保留用户配置条目后正常启动。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const patch = [
+    '# 重复注册 balance + 用户手写的 disabled/config 覆盖条目',
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: balance',
+    '  disabled: true',
+    '- insert:',
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+    '- id: terminal',
+    '  config: {}',
+    '',
+  ].join('\n');
+  const patchFile = path.join(profileDir, 'cordis.patch.yml');
+  fs.writeFileSync(patchFile, patch);
+  await t.waitFor('boot-ready', 240000, '重复注册应被自愈，且用户配置条目保留');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('移除了重复注册的 loader 条目'), '应记录重复条目自愈日志');
+  const healed = fs.readFileSync(patchFile, 'utf8');
+  t.assert((healed.match(/^\s*- id: balance$/gm) || []).length === 2, `balance 应只剩 1 条注册 + 1 条 disabled 覆盖，实际=${healed}`);
+  t.assert((healed.match(/^\s*- id: terminal$/gm) || []).length === 2, `terminal 应只剩 1 条注册 + 1 条 config 覆盖，实际=${healed}`);
+  t.assert(/disabled: true/.test(healed), '用户 disabled 条目应保留');
+  t.assert(/config: \{\}/.test(healed), '用户 config 覆盖条目应保留');
+  const backups = fs.readdirSync(profileDir).filter((f) => f.startsWith('cordis.patch.yml.dup-'));
+  t.assert(backups.length >= 1, '原文件应被备份为 cordis.patch.yml.dup-<ts>');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
 SCENARIOS['kill-renderer'] = async (t) => {
   await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');

--- a/dsh-desktop/scripts/test/unit-patch-heal-fuzz.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-heal-fuzz.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+// profile-patch-heal.js 的确定性模糊/性质测试（node --test）。
+// 对 dedupePatchEntries / dropBlocksByIds 做 3000 组确定性随机输入验证。
+// 性质：
+//   1. 输出 YAML 必须可解析为顶层数组（同 dsh 方言，JSON_SCHEMA + !!js 标量）；
+//   2. 幂等：二次调用 removed 为空且文本逐字节不变；
+//   3. 每个 id 在 insert 注册块中的出现次数 → 恰好 1（输入 ≥1 时）；
+//   4. 非 insert 块（config/disabled/注释）逐字节保留（dedupe 全部保留；
+//      dropBlocks 仅允许删除 name-only 直注册块）；
+//   5. 无重复时零修改（逐字节相等）。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { dedupePatchEntries, dropBlocksByIds } = require('../../profile-patch-heal.js');
+const yaml = require('../../node_modules/js-yaml');
+
+const jsType = new yaml.Type('tag:yaml.org,2002:js', {
+  kind: 'scalar',
+  resolve: () => true,
+  construct: (d) => ({ __jsExpr: d }),
+});
+const load = (c) => yaml.load(c, { schema: yaml.JSON_SCHEMA.extend(jsType) });
+
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+const IDS = ['a', 'b', 'c', 'd'];
+
+function topBlocks(lines) {
+  const starts = [];
+  for (let i = 0; i < lines.length; i += 1) if (/^-(\s|$)/.test(lines[i])) starts.push(i);
+  const blocks = [];
+  for (let s = 0; s < starts.length; s += 1) {
+    const begin = starts[s];
+    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
+    blocks.push({
+      lines: lines.slice(begin, end),
+      insert: /^-\s*insert\s*:/.test(lines[begin]),
+    });
+  }
+  return blocks;
+}
+
+function registrationCount(text) {
+  const counts = new Map();
+  for (const b of topBlocks(text.split(/\r?\n/))) {
+    if (!b.insert) continue;
+    for (const line of b.lines) {
+      const m = /^\s*-\s*id:\s*([A-Za-z0-9_-]+)/.exec(line);
+      if (m) counts.set(m[1], (counts.get(m[1]) || 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function nonInsertBlocks(text) {
+  return topBlocks(text.split(/\r?\n/)).filter((b) => !b.insert).map((b) => b.lines.join('\n'));
+}
+
+function genPatch(rand) {
+  const blocks = [];
+  const n = 2 + Math.floor(rand() * 5);
+  for (let i = 0; i < n; i += 1) {
+    const kind = i === 0 ? 0.1 : rand(); // 首块固定为 insert：保证输入是合法顶层数组
+    if (kind < 0.5) {
+      const rows = 1 + Math.floor(rand() * 3);
+      const lines = ['- insert:'];
+      for (let j = 0; j < rows; j += 1) {
+        const id = IDS[Math.floor(rand() * IDS.length)];
+        lines.push('    - id: ' + id);
+        lines.push("      name: 'pkg-" + id + "'");
+      }
+      blocks.push(lines.join('\n'));
+    } else if (kind < 0.7) {
+      blocks.push('- id: ' + IDS[Math.floor(rand() * IDS.length)] + '\n  disabled: true');
+    } else if (kind < 0.9) {
+      blocks.push('- id: ' + IDS[Math.floor(rand() * IDS.length)] + '\n  config:\n    k: v');
+    } else {
+      blocks.push('# comment block');
+    }
+  }
+  return '# head\n' + blocks.join('\n') + '\n';
+}
+
+test('fuzz 性质验证：3000 组确定性随机输入（dedupe/drop 幂等、可解析、注册唯一、非注册块保留、零写入）', () => {
+  let crlfChecked = false;
+  for (let seed = 1; seed <= 3000; seed += 1) {
+    const rand = rng(seed * 7919);
+    const p = genPatch(rand);
+    const tag = `seed=${seed}`;
+    assert.ok(Array.isArray(load(p)), `${tag} 输入可解析为数组`);
+    if (!crlfChecked) {
+      const crlf = p.replace(/\n/g, '\r\n');
+      assert.ok(Array.isArray(load(dedupePatchEntries(crlf).text)), 'CRLF 输入输出可解析');
+      crlfChecked = true;
+    }
+
+    // ---- dedupe 性质 ----
+    const before = registrationCount(p);
+    const nonBefore = nonInsertBlocks(p);
+    const r1 = dedupePatchEntries(p);
+    assert.ok(Array.isArray(load(r1.text)), `${tag} dedupe 输出可解析`);
+    const r2 = dedupePatchEntries(r1.text);
+    assert.ok(r2.removed.length === 0 && r2.text === r1.text, `${tag} dedupe 幂等`);
+    if (r1.removed.length === 0) assert.strictEqual(r1.text, p, `${tag} 无重复零修改`);
+    const after = registrationCount(r1.text);
+    for (const [id, n] of before) {
+      assert.strictEqual(after.get(id) || 0, n > 0 ? 1 : 0, `${tag} id=${id} 注册行唯一`);
+    }
+    assert.deepStrictEqual(nonInsertBlocks(r1.text), nonBefore, `${tag} dedupe 非 insert 块逐字节保留`);
+
+    // ---- dropBlocks 性质 ----
+    const dropIds = IDS.filter(() => rand() < 0.5);
+    const d1 = dropBlocksByIds(p, dropIds);
+    assert.ok(Array.isArray(load(d1.text)), `${tag} drop 输出可解析`);
+    const d2 = dropBlocksByIds(d1.text, dropIds);
+    assert.ok(d2.removed.length === 0 && d2.text === d1.text, `${tag} drop 幂等`);
+    if (dropIds.length === 0) assert.strictEqual(d1.text, p, `${tag} 空移除集零修改`);
+    const dAfter = registrationCount(d1.text);
+    for (const id of IDS) {
+      if (dropIds.includes(id)) {
+        assert.strictEqual(dAfter.get(id) || 0, 0, `${tag} drop 移除注册行 id=${id}`);
+      } else {
+        assert.strictEqual(dAfter.get(id) || 0, before.get(id) || 0, `${tag} drop 保留未命中注册行 id=${id}`);
+      }
+    }
+    const removable = (b) => {
+      const hit = /^\s*-\s*id:\s*([A-Za-z0-9_-]+)/m.exec(b);
+      if (!hit || !dropIds.includes(hit[1])) return false;
+      const body = b.split(/\r?\n/).slice(1).filter((l) => l.trim() !== '');
+      return body.length > 0 && body.every((l) => /^\s*name\s*:/.test(l));
+    };
+    const nonDAfter = nonInsertBlocks(d1.text).filter((b) => !removable(b));
+    const nonDBefore = nonBefore.filter((b) => !removable(b));
+    assert.deepStrictEqual(nonDAfter, nonDBefore, `${tag} drop 非注册配置块逐字节保留`);
+  }
+});

--- a/dsh-desktop/scripts/test/unit-patch-heal.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-heal.test.js
@@ -1,0 +1,294 @@
+'use strict';
+
+// profile-patch-heal.js 纯函数单元测试（node --test）。
+// 用法：node --test scripts/test/unit-patch-heal.test.js
+// 覆盖：注册行级去重（双缺/三同名/零修改/注释保留/块内重复/部分重复行级手术）、
+//       config 覆盖与 disabled 禁用条目绝不删除、定向 insert 块不动、
+//       loader 日志三种 id 形态解析、包名→patch id 映射、
+//       bundle 迁移双登记移除（整块/部分行级/直注册条目/用户配置保留/零修改）。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { dedupePatchEntries, dropBlocksByIds, parseFailedLoaderIds, mapPackagesToPatchIds } = require('../../profile-patch-heal');
+
+test('dedupePatchEntries: 两个重复 insert 块 → 移除后出现的块', () => {
+  const input = [
+    '# 头部注释',
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- insert:',
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+    '# 尾部注释',
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, ['balance']);
+  assert.ok(r.text.includes('# 头部注释'), '头部注释保留');
+  assert.ok(r.text.includes('# 尾部注释'), '尾部注释保留');
+  assert.strictEqual((r.text.match(/- id: balance/g) || []).length, 1, 'balance 只剩一个');
+  assert.ok(r.text.includes('id: terminal'), '其它条目保留');
+  // 顺序：terminal 仍在 balance 之后、原相对顺序不变
+  assert.ok(r.text.indexOf('id: balance') < r.text.indexOf('id: terminal'));
+});
+
+test('dedupePatchEntries: 无重复 → 零修改（返回原文本）', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: terminal',
+    "  name: '@deepseek-ai/dsh-terminal-tab'",
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.strictEqual(r.text, input);
+  assert.deepStrictEqual(r.removed, []);
+});
+
+test('dedupePatchEntries: 无 id 条目与纯注释文件原样保留', () => {
+  const comments = '# 只有注释\n# 没有条目\n';
+  assert.strictEqual(dedupePatchEntries(comments).text, comments);
+  const bare = '- insert: []\n';
+  assert.strictEqual(dedupePatchEntries(bare).text, bare);
+});
+
+test('dedupePatchEntries: 三个同名块 → 只保留第一个', () => {
+  const blocks = [];
+  for (let i = 0; i < 3; i += 1) {
+    blocks.push('- insert:', '    - id: balance', "      name: '@deepseek-ai/dsh-balance'");
+  }
+  const r = dedupePatchEntries(blocks.join('\n'));
+  assert.deepStrictEqual(r.removed, ['balance', 'balance']);
+  assert.strictEqual((r.text.match(/- id: balance/g) || []).length, 1);
+});
+
+test('dedupePatchEntries: insert 块部分重复 → 只删重复注册行，保留块内新注册', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, ['balance']);
+  assert.strictEqual((r.text.match(/- id: balance/g) || []).length, 1, '重复注册的 balance 行只剩首次注册');
+  assert.strictEqual((r.text.match(/- id: terminal/g) || []).length, 1, '新注册 terminal 保留');
+  assert.ok(r.text.includes('- insert:'), '块头保留');
+  assert.ok(r.text.includes("name: '@deepseek-ai/dsh-terminal-tab'"), 'terminal 的 name 保留');
+});
+
+test('dedupePatchEntries: config 覆盖与 disabled 禁用条目绝不删除（用户配置保留）', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: balance',
+    '  disabled: true',
+    '- insert:',
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+    '- id: terminal',
+    '  config:',
+    '    width: 320',
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '无重复注册 → 零写入（config/disabled 覆盖条目原样保留）');
+});
+
+test('dedupePatchEntries: 同一 insert 块内重复注册（罕见形态）→ 行级去重', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, ['balance']);
+  assert.strictEqual((r.text.match(/- id: balance/g) || []).length, 1, '块内重复注册行移除');
+  assert.strictEqual((r.text.match(/- id: terminal/g) || []).length, 1, 'terminal 保留');
+});
+
+test('dedupePatchEntries: 定向 insert 块（- id: X + insert:）不参与去重', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: extra-group',
+    '  insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '定向 insert 块原样保留');
+});
+
+test('parseFailedLoaderIds: 三种日志形态', () => {
+  const logText = [
+    'failed to apply loader entry 7ee99b10 (@deepseek-ai/dsh-balance): list slot "conversation.composer.dock" already has an entry',
+    '[cause]: TypeError: duplicate loader entry id: balance',
+    'failed to apply loader entry abc123 (include): something else',
+  ].join('\n');
+  const ids = parseFailedLoaderIds(logText);
+  assert.ok(ids.includes('7ee99b10'), '旧 hash 形态保留');
+  assert.ok(ids.includes('balance'), 'duplicate loader entry id 形态识别');
+  assert.ok(ids.includes('@deepseek-ai/dsh-balance'), '括号包名形态识别');
+  assert.ok(!ids.includes('include'), 'include 条目排除');
+});
+
+test('mapPackagesToPatchIds: 包名映射回条目 id（含重复注册场景）', () => {
+  const patch = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: terminal',
+    "  name: '@deepseek-ai/dsh-terminal-tab'",
+  ].join('\n');
+  const ids = mapPackagesToPatchIds(patch, ['@deepseek-ai/dsh-balance']);
+  assert.deepStrictEqual(ids, ['balance', 'balance'], '重复注册返回全部对应 id');
+  assert.deepStrictEqual(mapPackagesToPatchIds(patch, ['@deepseek-ai/other']), []);
+  assert.deepStrictEqual(mapPackagesToPatchIds(patch, []), []);
+});
+
+test('dropBlocksByIds: 命中 insert 块整块删除，其余条目与注释保留', () => {
+  const input = [
+    '# 头部注释',
+    '- insert:',
+    '    - id: better-sidebar',
+    "      name: 'dsh-better-sidebar'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '# 尾部注释',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, ['better-sidebar']);
+  assert.ok(!r.text.includes('id: better-sidebar'), '命中块已移除');
+  assert.ok(r.text.includes('id: balance'), '未命中条目保留');
+  assert.ok(r.text.includes('# 头部注释') && r.text.includes('# 尾部注释'), '注释保留');
+});
+
+test('dropBlocksByIds: 直接条目命中 → 连同兄弟行一起删除', () => {
+  const input = [
+    '- id: better-sidebar',
+    "  name: 'dsh-better-sidebar'",
+    '- id: balance',
+    "  name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, ['better-sidebar']);
+  assert.ok(!r.text.includes('better-sidebar'), '直接条目已删除');
+  assert.ok(r.text.includes('id: balance'), '其它条目保留');
+});
+
+test('dropBlocksByIds: insert 块部分命中 → 只删命中行与兄弟行，保留块内其它条目', () => {
+  const input = [
+    '- insert:',
+    '    - id: better-sidebar',
+    "      name: 'dsh-better-sidebar'",
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, ['better-sidebar']);
+  assert.ok(!r.text.includes('better-sidebar'), '命中行已删除');
+  assert.ok(r.text.includes('- insert:'), '块头保留');
+  assert.ok(r.text.includes('id: balance') && r.text.includes('@deepseek-ai/dsh-balance'), '同块其它条目原样保留');
+});
+
+test('dropBlocksByIds: 无命中 → 返回原文本（零写入）', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.strictEqual(r.text, input);
+  assert.deepStrictEqual(r.removed, []);
+  const r2 = dropBlocksByIds(input, []);
+  assert.strictEqual(r2.text, input);
+});
+
+test('dropBlocksByIds: 多个命中块全部移除', () => {
+  const input = [
+    '- insert:',
+    '    - id: better-sidebar',
+    "      name: 'dsh-better-sidebar'",
+    '- insert:',
+    '    - id: harness-pet',
+    "      name: 'harness-pet'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar', 'harness-pet']);
+  assert.deepStrictEqual(r.removed, ['better-sidebar', 'harness-pet']);
+  assert.ok(r.text.includes('id: balance'), '未命中条目保留');
+  assert.strictEqual((r.text.match(/id: balance/g) || []).length, 1);
+});
+
+test('dropBlocksByIds: config 覆盖与 disabled 禁用条目绝不删除（bundle 迁移保留用户配置）', () => {
+  const input = [
+    '- insert:',
+    '    - id: better-sidebar',
+    "      name: 'dsh-better-sidebar'",
+    '- id: better-sidebar',
+    '  disabled: true',
+    '- id: better-sidebar',
+    '  config:',
+    '    width: 320',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, ['better-sidebar']);
+  assert.strictEqual((r.text.match(/- id: better-sidebar/g) || []).length, 2, 'disabled 与 config 覆盖条目保留');
+  assert.ok(!r.text.includes("name: 'dsh-better-sidebar'"), '注册行（insert 块）已移除');
+  assert.ok(r.text.includes('disabled: true') && r.text.includes('width: 320'), '用户配置原样保留');
+});
+
+test('dropBlocksByIds: 直注册条目带 config 时不删除（用户配置保留）', () => {
+  const input = [
+    '- id: better-sidebar',
+    "  name: 'dsh-better-sidebar'",
+    '  config:',
+    '    width: 320',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '含 config 的直条目保留');
+});
+
+test('dropBlocksByIds: 直注册条目带 disabled 时不删除（用户禁用意图保留）', () => {
+  const input = [
+    '- id: better-sidebar',
+    "  name: 'dsh-better-sidebar'",
+    '  disabled: true',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '含 disabled 的直条目保留');
+});
+
+test('dropBlocksByIds: 直注册条目带任意自定义键时不删除（用户覆盖条目保留）', () => {
+  const input = [
+    '- id: better-sidebar',
+    "  name: 'dsh-better-sidebar'",
+    '  width: 320',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '携带自定义键的直条目保留');
+});


### PR DESCRIPTION
## 概述

Fixes #17（增量修正：针对 main 已合入初版的缺陷）

main 已合入 issue #17 自愈的初版（ed040ad）。对初版做最严格审核后发现并实测复现一个破坏性缺陷：按「id 已出现过」对顶层条目做块级去重，会把用户手写的 - id: X + config 覆盖 / disabled 禁用条目一并删除（每次启动静默丢失用户配置），与 cordis.patch.yml 文件头声明的顶层条目形态（config overrides / disables / insert lists）矛盾；「部分重叠交 overlay 兜底」亦不可行（EntryGroup.update 的重复检查先于 disabled 处理，overlay 无法救回该形态）。

本 PR 相对当前 main 提供以下修正（其余内容与 main 一致，不重复；本 PR 初版此前已被上游以 ed040ad 手动合入）。

## 修复

- dedupePatchEntries 改为注册行级去重（依据 dsh-app-boot pplyEntryPatches 语义：只有 insert 列表内的行是注册，config/disabled 覆盖条目不产生重复注册）：
  - 只删 insert 块内第二次及以后的注册行（连同同缩进兄弟行），保留首次注册；
  - 块内部分重复/块内重复时行级手术；
  - config 覆盖 / disabled 禁用 / 定向 insert / 携带自定义键的覆盖条目逐字节保留；
  - 无重复零写入（幂等）。
- dropBlocksByIds 同样只删注册行：insert 块内行级、整块命中整块删除；顶层直条目仅当「除 id 行外只有 name 行」才整块移除，其余形态绝不删除。
- nsurePatchArray 输出兜底：条目全部移除后补 []，保证文件仍是合法顶层数组（避免下次启动被误判「解析失败」而重置）。
- main.js 自愈注释同步为注册行级语义。
- 新增集成场景 heal-dup-patch-keeps-config（回归防线：用户 config/disabled 条目保留）与 3000 组确定性随机性质单测（幂等、输出可解析、注册唯一、非注册块逐字节保留、零写入）。

## 验证（真实 Electron + 隔离 DSH_HOME，不影响运行中的 dsh）

- 缺陷复现（main 53b0260 实测）：含 - id: balance + disabled: true 与 - id: terminal + config: 的合法 patch，dedupePatchEntries 输出 removed=["balance","terminal"]（用户配置被删）；本 PR 修复后 removed=[]、条目逐字节保留。
- 集成：heal-dup-patch / heal-bundle-patch / heal-dup-patch-keeps-config 三个场景 GREEN（约 46-47s 自愈启动；残留注册行移除、备份生成、用户 config/disabled 条目保留）。
- 全量回归：集成测试 18/18（main 既有 17 场景 + 新场景）、单元测试 55/55（patch-heal 19、fuzz 1、recovery 17、manifest 8、web-search 6、gpu 4）、check-syntax 全入口通过（每集成场景含进程泄漏检查）。

## 兼容性

- 健康 patch 零写入（幂等）；只删重复注册行，用户手写内容（config 覆盖、disabled 禁用、注释、非命中条目）原样保留；
- 不改变任何 IPC/插件接口与设置格式；main 中其它合入内容（#21/#22/#32 等）不受影响。