### PR TITLE
fix: 客户端更新脚本带 UTF-8 BOM 写出并 ASCII 化模板，修复中文 Windows 更新解析崩溃

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -5,6 +5,11 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 
 
 
+## [Unreleased]
+
+### 修复
+- **客户端自更新在中文 Windows 上解析失败**（`apply-update.ps1` 报 `Unexpected token '}'`，issue #23）：更新脚本改为带 UTF-8 BOM 写出，Windows PowerShell 5.1 不再按系统 ANSI 代码页（GBK）误读中文注释导致换行符被吞、语法乱码；`buildNsisPs1()` 模板注释同步 ASCII 化，脚本在任何代码页与换行风格下均安全
+
 ## [0.3.8] — 2026-08-15
 
 ### 修复

--- a/dsh-desktop/client-updater.js
+++ b/dsh-desktop/client-updater.js
@@ -357,9 +357,11 @@ try {
 } catch {
   Log ("setup launch failed: " + $_.Exception.Message)
 }
-# 安装器即使配置了自动启动，也可能被安全软件拦截或在旧版 NSIS
-# 模板里不拉起应用。这里最多等 15 秒；若新版本仍未运行，则从
-# 卸载注册表定位安装目录并显式启动，解决“更新完只退出、不重启”。
+# The installer may be blocked by security software, and old NSIS
+# templates may not relaunch the app even when configured to. Wait up to
+# 15s; if the new build is still not running, locate the install dir from
+# the uninstall registry and start it explicitly, fixing "update exits
+# but never restarts".
 $launched = $false
 $deadline = (Get-Date).AddSeconds(15)
 while ((Get-Date) -lt $deadline) {
@@ -407,8 +409,9 @@ if (-not $launched -and $setupSucceeded) {
 } elseif (-not $setupSucceeded) {
   Log "setup did not complete"
 }
-# 兜底：无论安装器成功还是失败/被取消，都不要让用户面对「点了立即重启，
-# 应用却消失了」。找不到新版本时就重新拉起旧版本，保留可见状态。
+# Fallback: whether the installer succeeded or was cancelled/failed, never
+# leave the user staring at "I clicked restart and the app disappeared".
+# If the new build cannot be found, relaunch the previous build instead.
 if (-not $launched) {
   if (Test-Path -LiteralPath $OldExe) {
     Log ("restarting previous build: " + $OldExe)
@@ -469,7 +472,12 @@ function applyUpdate(ctx, pending) {
   } else {
     const ps1 = path.join(dir, 'apply-update.ps1');
     script = path.join(dir, 'apply-update.cmd');
-    fs.writeFileSync(ps1, buildNsisPs1(), 'utf8');
+    // 必须带 BOM 写 UTF-8：Windows PowerShell 5.1 对无 BOM 的 .ps1 按系统
+    // ANSI 代码页（中文系统 = GBK）解码，模板中的中文注释被误读且可能吞掉
+    // 换行符，脚本在解析阶段报 Unexpected token '}' 直接退出（客户端更新
+    // “下载完重启无反应”的根因之一，见 issue #23）。模板本身已 ASCII 化，
+    // BOM 保证将来再写入非 ASCII 注释也不会重蹈覆辙。
+    fs.writeFileSync(ps1, '\uFEFF' + buildNsisPs1(), 'utf8');
     fs.writeFileSync(script, buildNsisCmd());
     ctx.log('client-update', `启动安装版更新脚本: ${script}→${path.basename(ps1)}（安装包: ${newExe}，进程: ${procName}，旧版: ${oldExe}）日志: ${logFile}`);
     // 同便携版：/c 的第一个参数不能是含空格的完整路径，否则脚本根本不执行。


### PR DESCRIPTION
# 修复客户端自更新「下载完重启无反应」（issue #23）

## 问题

安装版客户端更新「下载安装包 → 立即重启」后没有任何效果：运行时生成的更新脚本 `%APPDATA%\DSH Desktop\updates\apply-update.ps1` 在中文 Windows 的 PowerShell 5.1 下**解析阶段就失败**（一闪而过的红色报错 `Unexpected token '}'`），安装器从未被拉起，更新日志只有 `apply-update start (nsis)` 开头甚至为空。

## 根因

1. `client-updater.js` 用 `fs.writeFileSync(ps1, buildNsisPs1(), 'utf8')` 写出**无 BOM 的 UTF-8** 文件；
2. Windows PowerShell 5.1 对无 BOM 的 `.ps1` 按系统 ANSI 代码页解码（中文系统 = GBK）；
3. 模板里的中文注释被 GBK 误读：UTF-8 多字节序列的末字节恰好是合法 GBK 前导字节，与紧随的换行符组成非法双字节对，**换行符被吞掉**，下一行代码被吸进注释（`$launched = $false`、`if (-not $launched) {` 等），留下游离的 `}` → 解析器报 `Unexpected token '}'`，脚本从未真正执行。

## 复现（本机 ACP=936，PowerShell 5.1）

| 模板 | PS 5.1 解析结果 |
|---|---|
| v0.3.5 时代模板 | `Unexpected token '}'` |
| 当前 main 模板（转成 LF 换行） | `Unexpected token '}'`（当前 main 只是靠 CRLF 侥幸通过，脆弱点仍在） |

## 修复

1. **带 UTF-8 BOM 写出**：`fs.writeFileSync(ps1, '\uFEFF' + buildNsisPs1(), 'utf8')`，PowerShell 5.1 识别 BOM 后按 UTF-8 正确解码，中文注释不再乱码；
2. **模板注释 ASCII 化**：`buildNsisPs1()` 内中文注释改为英文，即使 BOM 丢失 / 换行风格变化也不会再触发此类解析崩溃——与文件头部「纯 ASCII 脚本」的设计意图、v0.3.6 对 merge.bat 的 CRLF + ASCII 处理保持一致。

## 验证

- 修复后 + BOM（实际新写法）：PS 5.1 解析通过 ✓
- 修复后 + 无 BOM + LF（最恶劣回归场景）：PS 5.1 解析通过 ✓
- `node scripts/check-syntax.js`：全部入口文件通过 ✓

Fixes #23
