### PR TITLE
feat: 设置页新增「上下文管理」栏，可配置自动压缩并写入全部 agent 预设

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -5,6 +5,11 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 
 
 
+## [Unreleased]
+
+### 新增
+- **设置页「上下文管理」栏**：自动上下文压缩配置入口（`dsh-compaction-settings` 配套插件）。可设置自动压缩开关（auto）、触发阈值（thresholdRatio，默认 0.8）与压缩后保留 token 数（maxTokens，默认 8192），保存后写入应用 `settings.json` 并幂等改写全部 agent 预设（`agent.cordis.yml` 的 `compaction-basic` 配置，覆盖内置/fallback/overlay 三处副本与 WSL 模式），新会话生效；boot 与 dsh 更新后自动重打，设置不丢失。纯逻辑抽在 `scripts/apply-compaction-settings.js`（含 `node --test` 单测）
+
 ## [0.3.8] — 2026-08-15
 
 ### 修复

--- a/dsh-desktop/assets/plugins/dsh-compaction-settings/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-compaction-settings/lib/client.js
@@ -1,0 +1,163 @@
+window.__ModuleLoader__.load({
+	id: "@deepseek-ai/dsh-compaction-settings",
+	factory: (require) => {
+		var module = { exports: {} };
+		var exports = module.exports;
+		Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+
+		const react = require("react");
+		const { jsx, jsxs } = require("react/jsx-runtime");
+		const { Button } = require("@deepseek-ai/dsh-client-ui-primitives");
+
+		const L = {
+			nav: "上下文管理",
+			navSub: "自动压缩对话上下文，避免长会话超出模型上下文窗口。保存后写入所有 agent 预设，新会话生效。",
+			autoLabel: "自动压缩",
+			autoHint: "上下文占用达到阈值时自动触发压缩（compaction-basic 的 auto 开关）",
+			ratioLabel: "触发阈值",
+			ratioHint: "上下文占用比例，达到该值自动压缩（0.1 – 1.0，默认 0.8 = 80%）",
+			maxTokensLabel: "压缩后保留",
+			maxTokensHint: "压缩后保留的 token 数（默认 8192）",
+			save: "保存",
+			saving: "保存中…",
+			saved: "已保存，新会话生效；完全生效请重启应用",
+			saveError: "保存失败",
+			loading: "加载中…",
+			unavailable: "仅在 DSH Desktop 客户端中可用",
+			invalid: "请输入有效数值（阈值 0.1–1.0，保留量 1024–1048576）"
+		};
+
+		function bridge() {
+			const b = window.dshDesktop;
+			if (!b || !b.compaction || typeof b.compaction.getConfig !== "function") return null;
+			return b.compaction;
+		}
+
+		function fieldRow(label, hint, input) {
+			return jsxs("div", {
+				style: { display: "flex", flexDirection: "column", gap: 4 },
+				children: [
+					jsx("span", { children: label }),
+					input,
+					hint ? jsx("span", { style: { fontSize: 12, opacity: 0.65 }, children: hint }) : null
+				]
+			});
+		}
+
+		function CompactionSettingsCard() {
+			const b = bridge();
+			const [auto, setAuto] = react.useState(true);
+			const [ratio, setRatio] = react.useState("0.8");
+			const [maxTokens, setMaxTokens] = react.useState("8192");
+			const [busy, setBusy] = react.useState(false);
+			const [saved, setSaved] = react.useState(false);
+			const [error, setError] = react.useState("");
+			const [dirty, setDirty] = react.useState(false);
+
+			react.useEffect(() => {
+				if (!b) return;
+				let cancelled = false;
+				b.getConfig()
+					.then((c) => {
+						if (!c || cancelled) return;
+						setAuto(c.auto !== false);
+						setRatio(String(c.thresholdRatio ?? 0.8));
+						setMaxTokens(String(c.maxTokens ?? 8192));
+					})
+					.catch((e) => { if (!cancelled) setError(String((e && e.message) || e)); });
+				return () => { cancelled = true; };
+			}, []);
+
+			if (!b) {
+				return jsx("div", { style: { fontSize: 12.5, opacity: 0.7 }, children: L.unavailable });
+			}
+
+			const save = async () => {
+				const r = Number(ratio);
+				const m = Number(maxTokens);
+				if (!Number.isFinite(r) || r <= 0 || r > 1 || !Number.isInteger(m) || m < 1024 || m > 1048576) {
+					setError(L.invalid);
+					return;
+				}
+				setBusy(true);
+				setError("");
+				setSaved(false);
+				try {
+					const res = await b.saveConfig({ auto, thresholdRatio: r, maxTokens: m });
+					if (!res || res.ok !== true) {
+						setError((res && res.error) || L.saveError);
+						return;
+					}
+					setSaved(true);
+					setDirty(false);
+				} catch (e) {
+					setError(String((e && e.message) || e));
+				} finally {
+					setBusy(false);
+				}
+			};
+
+			return jsxs("div", {
+				style: { display: "flex", flexDirection: "column", gap: 10 },
+				children: [
+					jsx("span", { style: { fontSize: 12, opacity: 0.65 }, children: L.navSub }),
+					fieldRow(L.autoLabel, L.autoHint, jsx("input", {
+						type: "checkbox",
+						checked: auto,
+						onChange: (e) => { setAuto(e.target.checked); setDirty(true); setSaved(false); }
+					})),
+					fieldRow(L.ratioLabel, L.ratioHint, jsx("input", {
+						type: "number",
+						min: 0.1,
+						max: 1,
+						step: 0.05,
+						value: ratio,
+						onChange: (e) => { setRatio(e.target.value); setDirty(true); setSaved(false); }
+					})),
+					fieldRow(L.maxTokensLabel, L.maxTokensHint, jsx("input", {
+						type: "number",
+						min: 1024,
+						max: 1048576,
+						step: 1024,
+						value: maxTokens,
+						onChange: (e) => { setMaxTokens(e.target.value); setDirty(true); setSaved(false); }
+					})),
+					jsxs("div", {
+						style: { display: "flex", alignItems: "center", gap: 10 },
+						children: [
+							jsx(Button, {
+								variant: "primary",
+								size: "sm",
+								disabled: busy || !dirty,
+								onClick: save,
+								children: busy ? L.saving : L.save
+							}),
+							saved ? jsx("span", { style: { fontSize: 12, opacity: 0.75 }, children: L.saved }) : null,
+							dirty && !saved ? jsx("span", { style: { fontSize: 12, opacity: 0.65 }, children: "有未保存的改动" }) : null
+						]
+					}),
+					error ? jsx("div", {
+						style: { fontSize: 12, color: "var(--dsw-alias-state-error-primary, #ff7a85)" },
+						children: error
+					}) : null
+				]
+			});
+		}
+
+		function apply(ctx) {
+			const injected = () => ({});
+			ctx.slots.inject("settings.section", () => ctx.slots.register({
+				name: "settings.section",
+				id: "dsh-compaction",
+				order: 66,
+				label: () => L.nav,
+				inject: injected
+			}, CompactionSettingsCard), "dsh-compaction-settings: settings section entry");
+		}
+
+		const inject = ["slots"];
+		exports.apply = apply;
+		exports.inject = inject;
+		return module.exports;
+	}
+});

--- a/dsh-desktop/assets/plugins/dsh-compaction-settings/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-compaction-settings/lib/index.js
@@ -1,0 +1,12 @@
+// Host-side entry: this companion package has no server half — the compaction
+// settings (auto / thresholdRatio / maxTokens) live in the DSH Desktop shell's
+// settings.json and are read/written through the preload bridge
+// (window.dshDesktop.compaction). The main process additionally rewrites every
+// agent preset's compaction-basic config from these values
+// (see scripts/apply-compaction-settings.js). The loader rejects an empty
+// default export, so the host half is a valid no-op Cordis plugin (same
+// pattern as dsh-wsl-settings / dsh-balance).
+const name = 'dsh-compaction-settings';
+const inject = [];
+function apply() {}
+export { apply, inject, name };

--- a/dsh-desktop/assets/plugins/dsh-compaction-settings/package.json
+++ b/dsh-desktop/assets/plugins/dsh-compaction-settings/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@deepseek-ai/dsh-compaction-settings",
+  "version": "0.1.0",
+  "private": true,
+  "description": "DSH Desktop 配套插件：设置页「上下文管理」栏，配置自动上下文压缩（auto / thresholdRatio / maxTokens），保存后写入所有 agent 预设的 compaction-basic 配置",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": { "default": "./lib/index.js" },
+    "./client": { "default": "./lib/client.js" },
+    "./package.json": "./package.json"
+  },
+  "license": "MIT",
+  "dsh": {
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-runtime",
+        "@deepseek-ai/dsh-client-ui-settings"
+      ],
+      "platform": "web"
+    }
+  },
+  "peerDependencies": {
+    "@deepseek-ai/dsh-client-ui-settings": "*",
+    "@deepseek-ai/dsh-client-ui-primitives": "*",
+    "react": ">=18"
+  }
+}

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -26,6 +26,7 @@ const updater = require('./updater');
 const clientUpdater = require('./client-updater');
 const balance = require('./balance');
 const wslBackend = require('./wsl-backend');
+const { normalizeSettings, patchPresetFile } = require('./scripts/apply-compaction-settings');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
 const zlib = require('node:zlib');
@@ -1649,6 +1650,7 @@ async function runUpdateFlow(manual) {
       applyVisionKeyFix();
       applyProfilePatchGuard();
       applySettingsSectionGuard();
+      applyCompactionSettingsPatch();
   applyWorkspaceSearchRailFix();
     }
     const { response: r2 } = await showBox({
@@ -2089,6 +2091,33 @@ function registerChromeIpc() {
       status: wslStatusSnapshot({ force: true }),
     };
   });
+
+  // -------------------------------------------------------------------------
+  // 上下文管理配置（设置页 dsh-compaction-settings 插件消费）：
+  //   get  —— 当前已保存（规范化后）的压缩设置
+  //   save —— 校验并持久化到 settings.json，同时立即改写所有 agent 预设的
+  //           compaction-basic 配置（新会话生效；完全生效请重启应用）
+  // -------------------------------------------------------------------------
+  ipcMain.handle('dsh:compaction-config', async (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return null;
+    return normalizeSettings(updater.loadSettings(updCtx()).compaction);
+  });
+
+  ipcMain.handle('dsh:compaction-config-save', async (event, { cfg } = {}) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
+    if (!cfg || typeof cfg !== 'object') return { ok: false, error: 'bad-payload' };
+    const norm = normalizeSettings(cfg);
+    const s = updater.loadSettings(updCtx());
+    s.compaction = norm;
+    updater.saveSettings(updCtx(), s);
+    log('compaction-settings', '已保存上下文管理设置: ' + JSON.stringify(norm));
+    try {
+      applyCompactionSettingsPatch();
+    } catch (err) {
+      log('compaction-settings', '预设改写失败: ' + ((err && err.message) || err));
+    }
+    return { ok: true, config: norm, applied: true, restartHint: '新会话生效；完全生效请重启应用' };
+  });
 }
 
 let trayHintShown = false;
@@ -2215,6 +2244,7 @@ const COMPANION_PLUGINS = [
   { id: 'prompt-custom', name: '@deepseek-ai/dsh-prompt-custom' },
   { id: 'third-party-thinking', name: '@deepseek-ai/dsh-third-party-thinking' },
   { id: 'wsl-settings', name: '@deepseek-ai/dsh-wsl-settings' },
+  { id: 'compaction-settings', name: '@deepseek-ai/dsh-compaction-settings' },
   { id: 'dsh-vision', name: '@dsh-external/dsh-vision' },
 ];
 
@@ -2571,6 +2601,59 @@ function applyPromptExposeFix() {
       log('boot', '提示词暴露补丁失败(' + file + '): ' + err.message);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// 上下文管理设置补丁：设置页「上下文管理」保存的 auto / thresholdRatio /
+// maxTokens 幂等写入所有含 compaction-basic 的 agent 预设（agent.cordis.yml）。
+// 覆盖运行副本（与提示词暴露补丁相同的三处副本 + WSL 模式）：设置页保存后
+// 新会话立即生效；应用重启 / dsh 更新后由 boot 批次重新施加，保证不丢。
+// ---------------------------------------------------------------------------
+function applyCompactionSettingsPatch() {
+  const wslHome = effectiveDshHome();
+  const pkg = ['@deepseek-ai', 'dsh'];
+  const targets = isWslMode()
+    ? [
+        path.join(wslHome, 'profiles', 'node_modules', ...pkg),
+        path.join(wslHome, 'agent', 'node_modules', ...pkg),
+      ]
+    : [
+        path.join(dshHome || path.join(os.homedir(), '.dsh'), 'profiles', 'node_modules', ...pkg),
+        path.join(__dirname, 'node_modules', ...pkg),
+        path.join(userDataDir, 'agent', 'node_modules', ...pkg),
+      ];
+  const settings = normalizeSettings(updater.loadSettings(updCtx()).compaction);
+  let patched = 0;
+  for (const pkgRoot of targets) {
+    if (!pkgRoot) continue;
+    const presetRoot = path.join(pkgRoot, 'config', 'agent-presets');
+    if (!fs.existsSync(presetRoot)) continue;
+    let dirs;
+    try {
+      dirs = fs.readdirSync(presetRoot, { withFileTypes: true });
+    } catch (err) {
+      log('compaction-settings', '读取预设目录失败(' + presetRoot + '): ' + err.message);
+      continue;
+    }
+    for (const d of dirs) {
+      if (!d.isDirectory()) continue;
+      const file = path.join(presetRoot, d.name, 'agent.cordis.yml');
+      if (!fs.existsSync(file)) continue;
+      try {
+        const src = fs.readFileSync(file, 'utf8');
+        const out = patchPresetFile(src, settings);
+        if (out !== src) {
+          fs.writeFileSync(file, out, { encoding: 'utf8' });
+          patched++;
+          log('compaction-settings', '已写入压缩设置 ' + file + '（auto=' + settings.auto +
+            ', thresholdRatio=' + settings.thresholdRatio + ', maxTokens=' + settings.maxTokens + '）');
+        }
+      } catch (err) {
+        log('compaction-settings', '预设改写失败(' + file + '): ' + err.message);
+      }
+    }
+  }
+  log('compaction-settings', '上下文管理补丁完成（改写 ' + patched + ' 个预设文件）');
 }
 
 // ---------------------------------------------------------------------------
@@ -3487,6 +3570,7 @@ async function boot() {
     applyVisionKeyFix();
     applyProfilePatchGuard();
     applySettingsSectionGuard();
+    applyCompactionSettingsPatch();
   applyWorkspaceSearchRailFix();
   } else {
     // 先修复 profile fallback 联接再同步/补丁依赖文件：EPERM 环境下补丁写不进去。
@@ -3498,6 +3582,7 @@ async function boot() {
     applyVisionKeyFix();
     applyProfilePatchGuard();
     applySettingsSectionGuard();
+    applyCompactionSettingsPatch();
   applyWorkspaceSearchRailFix();
     initRendererRecovery();
     createWindow();

--- a/dsh-desktop/preload.js
+++ b/dsh-desktop/preload.js
@@ -47,6 +47,11 @@ const dshDesktop = {
     saveConfig: (cfg) => ipcRenderer.invoke('dsh:wsl-config-save', { cfg }),
     recheck: () => ipcRenderer.invoke('dsh:wsl-recheck'),
   },
+  // 上下文管理配置（设置页 dsh-compaction-settings 插件消费）。
+  compaction: {
+    getConfig: () => ipcRenderer.invoke('dsh:compaction-config'),
+    saveConfig: (cfg) => ipcRenderer.invoke('dsh:compaction-config-save', { cfg }),
+  },
   // 插件市场：请求主进程原地重启 dsh web 服务（安装/卸载插件后生效）。
   restartService: () => ipcRenderer.invoke('chrome:restart-service', { intent: 'restart-service' }),
   // 「文件」视图的还原请求：changes = [{path, op, oldText, newText}]（逆序）。

--- a/dsh-desktop/scripts/apply-compaction-settings.js
+++ b/dsh-desktop/scripts/apply-compaction-settings.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// DSH Desktop 设置页「上下文管理」→ agent 预设压缩配置改写（幂等）。
+//
+// 背景：自动上下文压缩（@deepseek-ai/dsh-compaction-basic）的配置
+// （auto / thresholdRatio / maxTokens）只存在于各 agent 预设的
+// agent.cordis.yml 里，设置页没有入口。本模块把设置页保存的值幂等地
+// 写进每个含 compaction-basic 的预设文件，供主进程在启动时和保存时调用。
+//
+// 独立成模块（而不是内联在 main.js）：主进程文件依赖 electron，无法脱离
+// 应用单独测试；本模块是纯函数，可用 node 直接单测。
+
+const COMPACTION_MARKER = '# DSH Desktop 上下文管理设置（设置页生成，请勿手改）';
+
+/** 默认值：与 @deepseek-ai/dsh-compaction-basic 的出厂默认一致。 */
+function defaultSettings() {
+  return { auto: true, thresholdRatio: 0.8, maxTokens: 8192 };
+}
+
+/**
+ * 校验并规范化用户设置（容忍脏输入，非法值回退默认）。
+ * @param {unknown} input
+ */
+function normalizeSettings(input) {
+  const src = input && typeof input === 'object' ? input : {};
+  const auto = src.auto !== false;
+  let thresholdRatio = Number(src.thresholdRatio);
+  if (!Number.isFinite(thresholdRatio) || thresholdRatio <= 0 || thresholdRatio > 1) {
+    thresholdRatio = 0.8;
+  }
+  let maxTokens = Number(src.maxTokens);
+  if (!Number.isInteger(maxTokens) || maxTokens < 1024 || maxTokens > 1048576) {
+    maxTokens = 8192;
+  }
+  return { auto, thresholdRatio, maxTokens };
+}
+
+/**
+ * 改写单个预设文件的 compaction-basic 条目：
+ *   - 无 compaction-basic → 原样返回（调用方跳过）；
+ *   - 已有 config（含旧版本生成的）→ 整块替换为规范块；
+ *   - 无 config → 插入规范块。
+ * 换行风格跟随文件本身（CRLF/LF）。
+ * @param {string} content 预设 YAML 全文
+ * @param {{auto: boolean, thresholdRatio: number, maxTokens: number}} settings
+ * @returns {string} 改写后的内容（未变则原样返回）
+ */
+function patchPresetFile(content, settings) {
+  const nl = content.includes('\r\n') ? '\r\n' : '\n';
+  const entryRe = new RegExp(
+    '^[ \\t]*- id: compaction-basic\\r?\\n' +
+      "[ \\t]*name: '@deepseek-ai/dsh-compaction-basic'\\r?\\n" +
+      '(?:[ \\t]*config:\\r?\\n(?:[ \\t]+(?!- id:)[^\\r\\n]*\\r?\\n)*)?',
+    'm'
+  );
+  if (!entryRe.test(content)) return content;
+  const block =
+    `    - id: compaction-basic${nl}` +
+    `      name: '@deepseek-ai/dsh-compaction-basic'${nl}` +
+    `      config:${nl}` +
+    `        ${COMPACTION_MARKER}${nl}` +
+    `        auto: ${settings.auto}${nl}` +
+    `        thresholdRatio: ${settings.thresholdRatio}${nl}` +
+    `        maxTokens: ${settings.maxTokens}${nl}`;
+  return content.replace(entryRe, block);
+}
+
+module.exports = { COMPACTION_MARKER, defaultSettings, normalizeSettings, patchPresetFile };

--- a/dsh-desktop/scripts/test/apply-compaction-settings.test.js
+++ b/dsh-desktop/scripts/test/apply-compaction-settings.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// 单测：scripts/apply-compaction-settings.js 的校验与预设改写逻辑。
+// 运行：node --test scripts/test/apply-compaction-settings.test.js
+// 真实预设验证（可选）：设置 DSH_PRESETS_DIR 指向 dsh 包的 config/agent-presets。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { patchPresetFile, normalizeSettings, defaultSettings, COMPACTION_MARKER } = require('../apply-compaction-settings');
+
+const PLAIN_ENTRY_LF = [
+  '- id: compaction',
+  "  name: 'cordis:group'",
+  '  group: true',
+  '  config:',
+  "    - id: compaction-basic",
+  "      name: '@deepseek-ai/dsh-compaction-basic'",
+  '',
+  '    - id: command-compact',
+  "      name: '@deepseek-ai/dsh-command-compact'",
+  '',
+].join('\n');
+
+test('normalizeSettings: defaults and clamping', () => {
+  assert.deepStrictEqual(normalizeSettings(undefined), defaultSettings());
+  assert.deepStrictEqual(normalizeSettings({ auto: false }), { auto: false, thresholdRatio: 0.8, maxTokens: 8192 });
+  assert.deepStrictEqual(normalizeSettings({ thresholdRatio: 0.5, maxTokens: 16384 }), { auto: true, thresholdRatio: 0.5, maxTokens: 16384 });
+  // 非法值回退默认
+  assert.deepStrictEqual(normalizeSettings({ thresholdRatio: 1.5, maxTokens: 10 }), defaultSettings());
+  assert.deepStrictEqual(normalizeSettings({ thresholdRatio: 'abc', maxTokens: 'xyz' }), defaultSettings());
+  assert.deepStrictEqual(normalizeSettings(null), defaultSettings());
+});
+
+test('patchPresetFile: file without compaction-basic is untouched', () => {
+  const src = '- id: x\n  name: y\n';
+  assert.strictEqual(patchPresetFile(src, defaultSettings()), src);
+});
+
+test('patchPresetFile: inserts config into a plain entry (LF)', () => {
+  const out = patchPresetFile(PLAIN_ENTRY_LF, { auto: true, thresholdRatio: 0.6, maxTokens: 16384 });
+  assert.ok(out.includes("    - id: compaction-basic\n      name: '@deepseek-ai/dsh-compaction-basic'\n      config:\n        " + COMPACTION_MARKER));
+  assert.ok(out.includes('        auto: true\n        thresholdRatio: 0.6\n        maxTokens: 16384'));
+  // 后续条目完好
+  assert.ok(out.includes("    - id: command-compact\n      name: '@deepseek-ai/dsh-command-compact'"));
+  // 只出现一个 compaction-basic 条目（id 行 + name 行各一次）
+  assert.strictEqual(out.split('- id: compaction-basic').length - 1, 1);
+});
+
+test('patchPresetFile: replaces an existing config block', () => {
+  const withConfig = PLAIN_ENTRY_LF.replace(
+    "      name: '@deepseek-ai/dsh-compaction-basic'\n",
+    "      name: '@deepseek-ai/dsh-compaction-basic'\n      config:\n        auto: false\n        thresholdRatio: 0.9\n        maxTokens: 4096\n"
+  );
+  const out = patchPresetFile(withConfig, { auto: true, thresholdRatio: 0.3, maxTokens: 32768 });
+  assert.ok(out.includes('        auto: true\n        thresholdRatio: 0.3\n        maxTokens: 32768'));
+  assert.ok(!out.includes('auto: false'));
+  assert.ok(!out.includes('maxTokens: 4096'));
+});
+
+test('patchPresetFile: preserves CRLF and is idempotent', () => {
+  const crlf = PLAIN_ENTRY_LF.replace(/\n/g, '\r\n');
+  const out1 = patchPresetFile(crlf, { auto: true, thresholdRatio: 0.7, maxTokens: 8192 });
+  assert.ok(out1.includes('\r\n'));
+  const out2 = patchPresetFile(out1, { auto: true, thresholdRatio: 0.7, maxTokens: 8192 });
+  assert.strictEqual(out2, out1);
+  // LF 同样幂等
+  const lf1 = patchPresetFile(PLAIN_ENTRY_LF, defaultSettings());
+  assert.strictEqual(patchPresetFile(lf1, defaultSettings()), lf1);
+});
+
+// ---- 真实预设验证（可选，需 DSH_PRESETS_DIR 环境变量） ----------------------
+
+const presetsDir = process.env.DSH_PRESETS_DIR;
+if (presetsDir && fs.existsSync(presetsDir)) {
+  test('real presets: every agent.cordis.yml with compaction-basic gets a valid patch', () => {
+    const files = fs.readdirSync(presetsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(presetsDir, d.name, 'agent.cordis.yml'))
+      .filter((f) => fs.existsSync(f));
+    assert.ok(files.length > 0, 'preset files found');
+    let patched = 0;
+    for (const file of files) {
+      const src = fs.readFileSync(file, 'utf8');
+      if (!src.includes('compaction-basic')) continue;
+      const out = patchPresetFile(src, { auto: false, thresholdRatio: 0.5, maxTokens: 16384 });
+      assert.ok(out.includes(COMPACTION_MARKER), file + ' gets marker');
+      assert.ok(out.includes('thresholdRatio: 0.5'), file + ' gets ratio');
+      assert.strictEqual(out.split('- id: compaction-basic').length - 1, 1, file + ' single entry');
+      // 幂等
+      assert.strictEqual(patchPresetFile(out, { auto: false, thresholdRatio: 0.5, maxTokens: 16384 }), out, file + ' idempotent');
+      patched++;
+    }
+    assert.ok(patched > 0, 'at least one preset patched');
+    console.log(`real presets patched: ${patched}/${files.length}`);
+  });
+}


### PR DESCRIPTION
# 设置页新增「上下文管理」栏：可配置自动上下文压缩（auto / 触发阈值 / 保留量）

## 背景

自动上下文压缩（`@deepseek-ai/dsh-compaction-basic`）一直**默认开启**（上下文占用达 80% 自动压缩，保留约 8192 tokens），但它的配置只存在于各 agent 预设的 `agent.cordis.yml` 里，**设置页没有任何入口**——用户无法调整触发阈值、保留量或关闭自动压缩（插件市场里出现一堆社区压缩插件就是需求证明）。

## 改动

1. **新配套插件 `dsh-compaction-settings`**（设置页「上下文管理」栏，仿 `dsh-wsl-settings` 模式）：
   - 自动压缩开关（`auto`）
   - 触发阈值（`thresholdRatio`，0.1–1.0，默认 0.8）
   - 压缩后保留 token 数（`maxTokens`，默认 8192）
   - 保存 → preload 桥 → IPC → 写入应用 `settings.json` + 立即改写预设
2. **`main.js`**：
   - IPC `dsh:compaction-config` / `dsh:compaction-config-save`（带窗口来源校验，仿 WSL 配置通道）
   - `applyCompactionSettingsPatch()`：把设置幂等写入所有含 `compaction-basic` 的 agent 预设（覆盖内置 app / profile fallback / 用户 overlay 三处副本 + WSL 模式，与 `applyPromptExposeFix` 同策略）；boot 与 dsh 更新后自动重打，设置不丢
3. **`preload.js`**：`window.dshDesktop.compaction` 桥
4. **`scripts/apply-compaction-settings.js`**：纯逻辑模块（校验规范化 + 预设 YAML 幂等改写），脱离 Electron 可单测

## 验证

- `node scripts/check-syntax.js`：全部入口文件通过
- `node --test scripts/test/apply-compaction-settings.test.js`：**6/6 通过**，覆盖：默认值/钳制、无压缩块的预设不动、插入配置块、替换已有配置、CRLF 保持、幂等，以及**对全部真实预设（10 个含 compaction-basic）的只读验证**
- 副本级写盘冒烟：对真实预设副本写入 → 读回内容正确、二次写入幂等、`command-compact`/`tool-result-pruner` 等后续条目完好
- 设置页 UI / IPC 全链路为手动验证项（需重启应用后确认设置页出现「上下文管理」栏）

## 生效说明

保存后**新会话生效**；对已运行会话完全生效需重启应用（设置页有提示）。
