### PR TITLE
fix: 默认启用硬件加速并支持 GPU 崩溃自动降级（issue #26）

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -5,6 +5,12 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 
 
 
+## [Unreleased]
+
+### 修复
+- **桌面版默认启用硬件加速，修复软件渲染掉帧**（issue #26）：移除无条件 `app.disableHardwareAcceleration()`（软件渲染导致 GPU 进程空转 ~40-60% 单核、设置页等整页重绘明显掉帧）。改为：默认硬件加速；仅当 `settings.json` 标记 `hardwareAcceleration:'off'` 时禁用；GPU 进程 60 秒内连续崩溃 3 次（`gpu-process-crashed` / `child-process-gone` 双事件去重）自动持久化降级标记并重启应用，保留崩溃日志与自恢复兜底。降级逻辑抽为 `scripts/gpu-crash-guard.js`（含 `node --test` 单测）
+- **M3 主题管理器设置观察器防抖**（issue #26 附加项）：`assets/themes/m3-theme-manager.js` 的 `MutationObserver` 不再每批 DOM 变更都执行全文档 `querySelector`，改为 300ms 防抖（与 preload.js 中同功能实现对齐）
+
 ## [0.3.8] — 2026-08-15
 
 ### 修复

--- a/dsh-desktop/assets/themes/m3-theme-manager.js
+++ b/dsh-desktop/assets/themes/m3-theme-manager.js
@@ -190,20 +190,25 @@ function injectM3ThemeButton() {
 function startSettingsObserver() {
   if (settingsObserver) return;
   
-  settingsObserver = new MutationObserver((mutations) => {
-    for (const mutation of mutations) {
-      if (mutation.addedNodes.length > 0) {
-        // 检查是否有设置相关的元素被添加
-        const hasSettings = document.querySelector('[class*="setting"], [class*="Setting"], [class*="appearance"], [class*="Appearance"]');
-        if (hasSettings) {
-          const injected = injectM3ThemeButton();
-          if (injected) {
-            // 注入成功后可以暂时断开观察，节省性能
-            // 但设置页面可能重新渲染，所以保持观察
-          }
+  // 防抖（issue #26）：设置页渲染通常伴随大量 DOM 变更，若每批变更都执行
+  // 全文档 querySelector 会拖慢页面。与 preload.js 中同功能实现的 300ms
+  // 防抖对齐——只在变更停歇后检查一次。
+  let observerPending = false;
+  settingsObserver = new MutationObserver(() => {
+    if (observerPending) return;
+    observerPending = true;
+    setTimeout(() => {
+      observerPending = false;
+      // 检查是否有设置相关的元素被添加
+      const hasSettings = document.querySelector('[class*="setting"], [class*="Setting"], [class*="appearance"], [class*="Appearance"]');
+      if (hasSettings) {
+        const injected = injectM3ThemeButton();
+        if (injected) {
+          // 注入成功后可以暂时断开观察，节省性能
+          // 但设置页面可能重新渲染，所以保持观察
         }
       }
-    }
+    }, 300);
   });
   
   settingsObserver.observe(document.body, SETTINGS_OBSERVER_CONFIG);

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -26,6 +26,7 @@ const updater = require('./updater');
 const clientUpdater = require('./client-updater');
 const balance = require('./balance');
 const wslBackend = require('./wsl-backend');
+const { createGpuCrashGuard } = require('./scripts/gpu-crash-guard');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
 const zlib = require('node:zlib');
@@ -3550,14 +3551,34 @@ if (!gotLock) {
 } else {
   app.setAppUserModelId('com.deepseek.dsh.desktop');
   // GPU 进程崩溃是最常见的 Electron 静默退出原因（无日志、无弹窗）。
-  // 禁用硬件加速可规避大多数显卡驱动兼容性问题，对 DSH 这种文本为主
-  // 的应用无明显性能影响。若需排查，注释掉此行并观察崩溃日志。
-  app.disableHardwareAcceleration();
-  // GPU / 渲染进程崩溃日志：即使无法恢复，至少留下痕迹供排查。
-  app.on('gpu-process-crashed', (_e, killed) => {
+  // 默认启用硬件加速（issue #26：软件渲染导致 GPU 进程空转 ~60% 单核、
+  // 设置页等整页重绘明显掉帧）。仅当 settings.json 标记
+  // hardwareAcceleration === 'off'（用户手动关闭，或 GPU 连续崩溃自动降级
+  // 写入）时才禁用硬件加速。
+  if (updater.loadSettings(updCtx()).hardwareAcceleration === 'off') {
+    app.disableHardwareAcceleration();
+  }
+  // GPU / 渲染进程崩溃日志 + 自动降级（issue #26）：GPU 进程短时间内连续
+  // 崩溃达到阈值 → 判定显卡驱动不兼容 → 持久化 hardwareAcceleration:'off'
+  // 并重启应用，而不是旧版那样一刀切全局禁用硬件加速。
+  const gpuCrashGuard = createGpuCrashGuard();
+  const recordGpuCrash = (extra) => {
     const ts = new Date().toISOString();
-    try { const lp = path.join(app.getPath('userData'), 'logs', 'desktop.log'); fs.mkdirSync(path.dirname(lp), { recursive: true }); fs.appendFileSync(lp, `[${ts}] [crash] GPU 进程崩溃 (killed=${killed})\n`); } catch {}
-  });
+    try { const lp = path.join(app.getPath('userData'), 'logs', 'desktop.log'); fs.mkdirSync(path.dirname(lp), { recursive: true }); fs.appendFileSync(lp, `[${ts}] [crash] GPU 进程崩溃 ${extra}\n`); } catch {}
+    if (!gpuCrashGuard.record()) return;
+    try {
+      const s = updater.loadSettings(updCtx());
+      s.hardwareAcceleration = 'off';
+      updater.saveSettings(updCtx(), s);
+      log('boot', 'GPU 进程连续崩溃，已持久化关闭硬件加速，重启应用生效');
+    } catch (err) {
+      log('boot', 'GPU 降级标记写入失败: ' + ((err && err.message) || err));
+    }
+    try { quitting = true; markCleanExit(); killTreeSync(serverProc); } catch {}
+    app.relaunch();
+    app.exit(0);
+  };
+  app.on('gpu-process-crashed', (_e, killed) => recordGpuCrash(`(killed=${killed})`));
   app.on('render-process-gone', (_e, wc, details) => {
     const ts = new Date().toISOString();
     try { const lp = path.join(app.getPath('userData'), 'logs', 'desktop.log'); fs.mkdirSync(path.dirname(lp), { recursive: true }); fs.appendFileSync(lp, `[${ts}] [crash] 渲染进程崩溃: ${details.reason} (exitCode=${details.exitCode})\n`); } catch {}
@@ -3565,6 +3586,7 @@ if (!gotLock) {
   app.on('child-process-gone', (_e, details) => {
     const ts = new Date().toISOString();
     try { const lp = path.join(app.getPath('userData'), 'logs', 'desktop.log'); fs.mkdirSync(path.dirname(lp), { recursive: true }); fs.appendFileSync(lp, `[${ts}] [crash] 子进程崩溃: type=${details.type} reason=${details.reason} (exitCode=${details.exitCode})\n`); } catch {}
+    if (details.type === 'GPU') recordGpuCrash('(via child-process-gone)');
   });
   app.on('second-instance', () => {
     if (mainWindow) {

--- a/dsh-desktop/scripts/gpu-crash-guard.js
+++ b/dsh-desktop/scripts/gpu-crash-guard.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// GPU 崩溃自动降级守卫（纯逻辑，可脱离 Electron 单测，issue #26）。
+//
+// 背景：旧版为了规避显卡驱动兼容性问题无条件 app.disableHardwareAcceleration()，
+// 导致软件渲染下 GPU 进程空转 ~60% 单核、界面掉帧。新版默认启用硬件加速，
+// 仅在 GPU 进程短时间内连续崩溃（判定驱动不兼容）时触发降级：由 main.js
+// 持久化 settings.json 的 hardwareAcceleration:'off' 并重启应用。
+//
+// 双事件去重：Electron 中 GPU 崩溃可能同时触发 app 'gpu-process-crashed' 与
+// 'child-process-gone'（type=GPU），record() 用 dedupeMs 窗口把同一次崩溃
+// 只计一次。
+
+function createGpuCrashGuard(options = {}) {
+  const limit = options.limit ?? 3;
+  const windowMs = options.windowMs ?? 60 * 1000;
+  const dedupeMs = options.dedupeMs ?? 3000;
+  const now = options.now ?? Date.now;
+  let times = [];
+  let last = -Infinity; // 首次记录永不被去重窗口吞掉（真实时钟为 epoch 毫秒，t - (-Infinity) 恒大于窗口）
+
+  return {
+    /**
+     * 记录一次 GPU 崩溃。返回 true 表示已达到连续崩溃阈值（应降级）。
+     * 去重窗口内的重复记录被忽略（双事件触发只计一次）。
+     */
+    record() {
+      const t = now();
+      if (t - last < dedupeMs) return false;
+      last = t;
+      times = times.filter((x) => t - x < windowMs);
+      times.push(t);
+      return times.length >= limit;
+    },
+    /** 当前滑动窗口内的崩溃次数。 */
+    count() {
+      return times.length;
+    },
+    reset() {
+      times = [];
+    },
+  };
+}
+
+module.exports = { createGpuCrashGuard };

--- a/dsh-desktop/scripts/test/gpu-crash-guard.test.js
+++ b/dsh-desktop/scripts/test/gpu-crash-guard.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// 单测：scripts/gpu-crash-guard.js 的连续崩溃阈值与去重逻辑。
+// 运行：node --test scripts/test/gpu-crash-guard.test.js
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { createGpuCrashGuard } = require('../gpu-crash-guard');
+
+function fakeNow(clock) {
+  return () => clock.now;
+}
+
+test('默认阈值：窗口内第 3 次崩溃触发降级', () => {
+  const clock = { now: 1000 };
+  const guard = createGpuCrashGuard({ now: fakeNow(clock) });
+  assert.strictEqual(guard.record(), false);
+  clock.now += 10000;
+  assert.strictEqual(guard.record(), false);
+  clock.now += 10000;
+  assert.strictEqual(guard.record(), true);
+  assert.strictEqual(guard.count(), 3);
+});
+
+test('去重：同一时刻的双事件触发只计一次', () => {
+  const clock = { now: 1000 };
+  const guard = createGpuCrashGuard({ now: fakeNow(clock) });
+  // gpu-process-crashed 与 child-process-gone(type=GPU) 几乎同时到达
+  assert.strictEqual(guard.record(), false);
+  assert.strictEqual(guard.record(), false); // 去重窗口内，忽略
+  assert.strictEqual(guard.count(), 1);
+  clock.now += 5000;
+  assert.strictEqual(guard.record(), false);
+  clock.now += 5000;
+  assert.strictEqual(guard.record(), true); // 第 3 次真实崩溃
+  assert.strictEqual(guard.count(), 3);
+});
+
+test('滑动窗口：超过窗口期的旧崩溃过期不计', () => {
+  const clock = { now: 1000 };
+  const guard = createGpuCrashGuard({ now: fakeNow(clock) });
+  guard.record();                       // t=1s
+  clock.now += 30 * 1000;               // t=31s
+  guard.record();                       // 未过期，count=2
+  clock.now += 40 * 1000;               // t=71s
+  guard.record();                       // 第一次(1s)已超出 60s 窗口被丢弃，count=2
+  assert.strictEqual(guard.count(), 2);
+  clock.now += 10 * 1000;               // t=81s
+  assert.strictEqual(guard.record(), true); // 31s/71s/81s 都在窗口内，第 3 次触发
+  assert.strictEqual(guard.count(), 3);
+});
+
+test('自定义阈值与 reset', () => {
+  const clock = { now: 1000 };
+  const guard = createGpuCrashGuard({ limit: 2, now: fakeNow(clock) });
+  assert.strictEqual(guard.record(), false);
+  clock.now += 5000;
+  assert.strictEqual(guard.record(), true);
+  guard.reset();
+  assert.strictEqual(guard.count(), 0);
+  clock.now += 5000;
+  assert.strictEqual(guard.record(), false);
+});


### PR DESCRIPTION
# 修复：默认启用硬件加速，消除软件渲染掉帧（issue #26）

## 问题

`main.js` 启动时无条件调用 `app.disableHardwareAcceleration()`，导致全应用软件渲染（SwiftShader）：GPU 进程空转 ~40-60% 单核、设置页等整页重绘明显掉帧。实测证据见 issue #26（进程线程级采样）。

## 改动

### 1. `main.js`：默认启用硬件加速 + GPU 崩溃自动降级

- **移除无条件禁用**：默认启用硬件加速；仅当 `settings.json` 标记 `hardwareAcceleration: 'off'`（用户手动关闭，或自动降级写入）时才禁用；
- **自动降级兜底**（替代原"一刀切"方案的合理化版本）：GPU 进程 60 秒内连续崩溃 3 次 → 判定显卡驱动不兼容 → 持久化 `hardwareAcceleration:'off'` 并重启应用；
- **双事件去重**：`gpu-process-crashed` 与 `child-process-gone`（type=GPU）对同一次崩溃可能双触发，3 秒去重窗口只计一次；
- 保留原有崩溃日志与 `renderer-recovery.js` 自恢复兜底。

### 2. `scripts/gpu-crash-guard.js`（新）：降级守卫纯逻辑

连续崩溃阈值 / 滑动窗口 / 去重逻辑独立成模块，脱离 Electron 可单测（与既有 `scripts/apply-compaction-settings.js` 同风格）。

### 3. `assets/themes/m3-theme-manager.js`：设置观察器防抖（issue 附加项）

`MutationObserver` 不再每批 DOM 变更都执行全文档 `querySelector`，改为 300ms 防抖（与 `preload.js` 中同功能实现对齐）。该文件为可选安装的 M3 主题遗留文件，默认不加载，修复零风险。

## 验证

- `node scripts/check-syntax.js`：全部入口文件通过
- `node --test scripts/test/gpu-crash-guard.test.js`：**4/4 通过**（阈值、去重、滑动窗口、自定义参数；测试还抓出 `last=0` 初始值会吞掉首次崩溃的 bug，已修为 `-Infinity`）
- 本机实测（RTX 3060 Laptop + AMD 核显）：热补丁后 GPU 进程加载 **NVIDIA 驱动（nvwgf2umx.dll）+ D3D11，无 swiftshader**，GPU 进程 CPU 从 **43.8% → 21.5%** 单核（空闲）
- 自动降级路径为逻辑单测 + 代码审查（无法在 CI 里模拟 GPU 崩溃）

## 说明

- issue #26 报告者实测：注释掉 `disableHardwareAcceleration()` 后 GPU 进程 CPU 从 ~62% 降至接近 0；
- `settings.json` 的 `hardwareAcceleration:'off'` 为手动回退开关（与自动降级共用）；
- M3 主题的 `* { transition-duration: 150ms }` 全局过渡（issue 附加发现第二条）**未改动**——涉及视觉观感取舍，留给维护者定夺。

Closes #26
