### PR TITLE
fix: WSL 同步补齐内置 Agent 预设配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ npm run dist             # 构建 portable + NSIS 安装包 → dist/
 
 壳支持两种后端：`local`（内置 dsh，默认）、`wsl`（壳在 WSL 里安装并更新自己的 dsh），用 `settings.json` 的 `backend` 或环境变量 `DSH_DESKTOP_BACKEND` 选择。
 
-- **wsl（托管）**：设置页「WSL 后端」栏（或 `settings.json` 的 `backend` / 环境变量 `DSH_DESKTOP_BACKEND`）选 `wsl` 后，壳首次启动在 WSL 内 `npm install` 一套自己的 dsh（默认目录 `~/.dsh-desktop`，可配置；要求 WSL 内有 node/npm），每次启动自动同步配套插件并启动、连接；**agent 自动更新、回退、插件市场重启全部闭环**，体验等同本地模式。转发不通时在 `.wslconfig` 启用 `networkingMode=mirrored`。详见 `dsh-desktop/README.md`。
-- 自己在 WSL 里另装了 dsh（checkout 开发版/npm 版）想用上壳的配套插件？在 WSL 里跑 `node dsh-desktop/scripts/sync-companion-plugins.js ~/.dsh --with-patches`，重启 `dsh web` 生效。
+- **wsl（托管）**：设置页「WSL 后端」栏（或 `settings.json` 的 `backend` / 环境变量 `DSH_DESKTOP_BACKEND`）选 `wsl` 后，壳首次启动在 WSL 内 `npm install` 一套自己的 dsh（默认目录 `~/.dsh-desktop`，可配置；要求 WSL 内有 node/npm），每次启动自动同步配套插件与内置 Agent 预设并启动、连接；**agent 自动更新、回退、插件市场重启全部闭环**，体验等同本地模式。转发不通时在 `.wslconfig` 启用 `networkingMode=mirrored`。详见 `dsh-desktop/README.md`。
+- 自己在 WSL 里另装了 dsh（checkout 开发版/npm 版）想用上壳的配套插件与内置 Agent 预设？在 WSL 里跑 `node dsh-desktop/scripts/sync-companion-plugins.js ~/.dsh --with-patches`（未自动找到 dsh 包时加 `--dsh-package <包目录>`），重启 `dsh web` 生效。
 
 ## 目录结构
 

--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -10,6 +10,7 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 ### 修复
 - **安装后启动即报 `ReferenceError: async is not defined`**：`main.js` 中 `async` 关键字与 `probeOverlayAgent` 函数声明被注释行拆开，导致主进程模块加载失败。已重接 `async function`；新增 `scripts/check-syntax.js` 并接入 `prepack` / `predist`，打包前强制做入口 JS 语法检查与「async/await 关键字与声明被拆开」模式扫描，此类坏包无法再打包。
 - **安装后启动即弹「应用初始化失败：home is not defined」**：`main.js` 的 `applySettingsSectionGuard()` 构造候选补丁路径时引用了未声明的 `home` 变量（相邻的 `applyProfilePatchGuard` / `applyWorkspaceSearchRailFix` 均有声明，唯独此处遗漏），`boot()` 无条件调用该函数导致每次启动必现初始化失败弹窗。已在该函数内补齐 `const home = effectiveDshHome() || path.join(os.homedir(), '.dsh')`，与相邻防护函数保持一致。
+- **WSL 模式「模式列表」比 local 少**：WSL 托管后端经 npm 安装的 dsh 是干净包，不含壳内置的 8 个 Agent 预设（`minimal-win` / `router-standard` / `anchored-standard` 等）。现在 `main.js` 在 WSL bootstrap 与更新后会经 UNC 把 `assets/agent-presets` 写入 WSL agent 包的 `config/agent-presets`；`scripts/sync-companion-plugins.js` 也自动同步预设（可 `--dsh-package <目录>` 显式指定），WSL / Linux 的模式列表与 Windows local 一致。
 
 ## [0.3.6] — 2026-08-15
 

--- a/dsh-desktop/README.md
+++ b/dsh-desktop/README.md
@@ -234,7 +234,7 @@ npm run dist                   # 构建 portable + NSIS 安装包，输出到 di
 node dsh-desktop/scripts/sync-companion-plugins.js ~/.dsh --with-patches
 ```
 
-（`--dry-run` 可先预览；`--with-patches` 额外应用「会话列表闪跳修复 + 设置暴露白名单」两个运行时补丁，否则自定义提示词/第三方思考的设置页可能显示「设置不可用」。）插件在 **dsh web 重启后**才挂载（profile 补丁层在启动时读取）：重启 `dsh web`（checkout 开发模式 `pnpm dsh web`；npm 安装版 `dsh web`），注意会中断正在跑的会话（会话数据在磁盘上，可继续）。终端插件在 POSIX 下自动使用 `sh -i`，其余插件跨平台。卸载：删掉 `cordis.patch.yml` 中对应 `insert` 条目与 `profiles/web/node_modules` 下的对应包目录即可。
+（`--dry-run` 可先预览；`--with-patches` 额外应用「会话列表闪跳修复 + 设置暴露白名单」两个运行时补丁，否则自定义提示词/第三方思考的设置页可能显示「设置不可用」。脚本同时会把壳内置的 8 个 Agent 预设同步进能找到的 dsh 包 `config/agent-presets`——`<DSH_HOME>/agent`（如 WSL 托管布局的 `~/.dsh-desktop/agent`）与 PATH 上的 dsh 命令会自动探测，其它安装位置可用 `--dsh-package <dsh 包目录>` 显式指定。）插件与预设都在 **dsh web 重启后**才挂载（profile 补丁层与包内预设目录在启动时读取）：重启 `dsh web`（checkout 开发模式 `pnpm dsh web`；npm 安装版 `dsh web`），注意会中断正在跑的会话（会话数据在磁盘上，可继续）。终端插件在 POSIX 下自动使用 `sh -i`，其余插件跨平台。卸载：删掉 `cordis.patch.yml` 中对应 `insert` 条目与 `profiles/web/node_modules` 下的对应包目录即可。
 
 ### wsl：壳在 WSL 里托管自己的 dsh（自动更新全闭环）
 
@@ -245,7 +245,7 @@ node dsh-desktop/scripts/sync-companion-plugins.js ~/.dsh --with-patches
   - `wslDistro`（`DSH_DESKTOP_WSL_DISTRO`）：发行版名，默认 `wsl -l -q` 第一个；
   - `wslInstallDir`（`DSH_DESKTOP_WSL_DIR`）：WSL 内安装目录（Linux 绝对路径，**不含空白**），默认 `~/.dsh-desktop`——刻意不默认 `~/.dsh`，避免与你自己的 dsh 共用 DSH_HOME 互相改写 profile；想共享会话就显式设成 `~/.dsh`；
   - 前置条件：WSL 内要有 node + npm（`sh -lc 'node --version'` 能出结果即可，fnm/nvm 皆可；缺失时保存配置会提示、启动会弹窗引导）。
-- 首次启动流程：显示加载页 → 探测 WSL/node → 缺 agent 时在 WSL 内 `npm install @deepseek-ai/dsh@<内置版本>`（约 2–3 分钟，之后复用 npm 缓存）→ 配套插件 + 运行时补丁经 UNC（`\\wsl.localhost\<发行版>\...`）同步进 WSL profile → `wsl.exe -e sh -lc` 启动 `dsh web --host 127.0.0.1 --port 0` → 解析就绪 URL（与 local 同规则）→ Windows 经 localhost 转发加载窗口。
+- 首次启动流程：显示加载页 → 探测 WSL/node → 缺 agent 时在 WSL 内 `npm install @deepseek-ai/dsh@<内置版本>`（约 2–3 分钟，之后复用 npm 缓存）→ 配套插件经 UNC 同步进 WSL profile、内置 Agent 预设经 UNC 写入 WSL agent 包 `config/agent-presets`（与 local 模式列表一致）→ 运行时补丁覆盖 WSL profile/agent → `wsl.exe -e sh -lc` 启动 `dsh web --host 127.0.0.1 --port 0` → 解析就绪 URL（与 local 同规则）→ Windows 经 localhost 转发加载窗口。
 - 目录布局（WSL 内）：`<dir>/agent`（当前版本，`DSH_HOME=<dir>`）、`agent-prev`（回退）、`agent-staging`（更新中转）、`dsh.pid`（退出清理）、`profiles`/`sessions`（数据）。
 - **自动更新**：检查仍在 Windows 侧（npm registry 查询），安装走 WSL 内 npm（staging + 原子切换，失败自动保留旧版），重启应用生效；启动失败弹窗可「回退到上一版本」。
 - 退出/重启服务：按 `dsh.pid` 发 SIGTERM 优雅收尾（绝不 `wsl --terminate`）；插件市场的「重启服务」在托管模式下可用（重启 WSL 内的 dsh web）。
@@ -289,7 +289,7 @@ dsh-desktop/
 ├── wsl-backend.js        # WSL 托管后端（发行版探测 / bootstrap 安装 / 启动停止 / 更新回退）
 ├── assets/               # 加载页、更新进度页、恢复页、图标、托盘图标、配套 dsh 插件
 │   ├── sponsor/          # 赞助收款码（支付宝 / 微信，「请作者喝咖啡」面板与本文档共用）
-│   ├── agent-presets/    # 8 个内置预设（minimal-win / router-standard / anchored-standard / zero-anchored-standard / whoami-standard / v4-flash-godmode-opencode-go / warmupbetter / warmupbetter-replay）
+│   ├── agent-presets/    # 8 个内置预设（minimal-win / router-standard / anchored-standard / zero-anchored-standard / whoami-standard / v4-flash-godmode-opencode-go / warmupbetter / warmupbetter-replay），local 打包写入 / WSL 启动与更新时经 UNC 同步
 │   └── plugins/          # dsh-balance / dsh-file-changes / dsh-vision / zat-dsh-engine / dsh-better-sidebar / harness-pet / dsh-super-injector / dsh-wsl-settings（设置页「WSL 后端」栏）等，启动时自动同步进 web profile
 ├── scripts/
 │   ├── fetch-node.js     # 内置 node.exe 复制脚本
@@ -298,9 +298,9 @@ dsh-desktop/
 │   ├── check-latest.js   # agent 更新链路测试工具
 │   ├── check-client-latest.js # 客户端更新链路测试工具
 │   ├── patch-event-vocabulary.js # dsh-session 事件词汇表补丁（afterPack 自动调用）
-│   ├── install-minimal-win-preset.js # 内置 minimal-win 预设安装（npm start / afterPack 调用）
+│   ├── install-minimal-win-preset.js # 内置 8 个 Agent 预设安装（npm start / afterPack / WSL 同步调用）
 │   ├── test-watcher.js   # 通知检测单测
-│   ├── sync-companion-plugins.js # 把配套插件同步进任意 dsh 的 web profile（独立于壳）
+│   ├── sync-companion-plugins.js # 把配套插件与内置 Agent 预设同步进任意 dsh（独立于壳）
 │   └── inspect-session.js# 会话日志解析工具
 ├── build/icon.png        # electron-builder 图标源
 ├── vendor/               # 内置 node.exe / npm CLI（fetch-runtime 生成，不入库）

--- a/dsh-desktop/docs/agent-presets.md
+++ b/dsh-desktop/docs/agent-presets.md
@@ -2,8 +2,11 @@
 
 所有预设存放在 `assets/agent-presets/<id>/`，由 `scripts/install-minimal-win-preset.js`
 在 `npm start`（开发）与 `afterPack`（打包）时复制进内置 dsh 的
-`config/agent-presets/`。目录名即 preset id（`[a-z0-9-]+`），显示名与描述在
-各目录的 `preset.yml` 中。
+`config/agent-presets/`。WSL 托管模式启动/更新时会经 UNC 调用同一安装逻辑写入
+WSL 内的 dsh 包；`scripts/sync-companion-plugins.js` 也会为 WSL / Linux 里另装的
+dsh 同步这批预设（自动探测 `DSH_HOME/agent` 与 PATH 上的 dsh 命令，或 `--dsh-package`
+指定包目录）。
+目录名即 preset id（`[a-z0-9-]+`），显示名与描述在各目录的 `preset.yml` 中。
 
 ## 预设与上游来源
 

--- a/dsh-desktop/docs/wsl-verification.md
+++ b/dsh-desktop/docs/wsl-verification.md
@@ -58,6 +58,7 @@
 - [ ] WSL 内 `cat ~/.dsh-desktop/profiles/web/cordis.patch.yml` → 11 条 `- insert:`（余额/文件/终端/浮窗/插件市场/提示词/思考/识图/WSL 设置等）；
 - [ ] UI 中：对话底部余额小部件、详情面板「文件」标签页（diff 查看）、「终端」标签页（WSL 内走 `sh -i`，执行 `pwd` 应显示 WSL 路径）、会话浮窗、插件市场、设置页「自定义提示词」可用；
 - [ ] WSL 内目录布局正确：`agent/` `agent-prev/`（更新后）`agent-staging/`（仅安装期间）`profiles/` `sessions/` `dsh.pid`；
+- [ ] WSL 内 `ls ~/.dsh-desktop/agent/node_modules/@deepseek-ai/dsh/config/agent-presets` → 除 npm 包自带的 code/cordis/minimal/standard 外，还有 `minimal-win` / `router-standard` / `anchored-standard` 等 8 个壳内置预设与 `_preset` 共享模块；UI 的模式列表与 local 一致；
 - [ ] 会话完成 → Windows Toast 通知弹出（经 UNC 读 WSL 会话日志）；
 - [ ] 「文件」视图的**还原/打开**应被安全栅栏拒绝（WSL 会话不适用，预期行为；diff 查看不受影响）。
 
@@ -81,10 +82,11 @@
 cd /home/ezio/workspace/dsh_desktop   # 在 WSL 里
 node dsh-desktop/scripts/sync-companion-plugins.js ~/.dsh --dry-run   # 先预览
 node dsh-desktop/scripts/sync-companion-plugins.js ~/.dsh --with-patches
+# 未自动找到你的 dsh 包时（预设同步日志会提示），追加: --dsh-package <dsh 包目录>
 # 重启你自己的 dsh web（checkout: pnpm dsh web；npm 版: dsh web）
 ```
 
-- [ ] 重启后你的 dsh 设置页出现「WSL 后端」等全部配套栏目；补丁日志提示「已应用/无需变更」幂等。
+- [ ] 重启后你的 dsh 设置页出现「WSL 后端」等全部配套栏目；补丁日志提示「已应用/无需变更」幂等；预设日志提示已同步 8 个内置 Agent 预设（未自动找到 dsh 包时用 `--dsh-package <包目录>` 指定）。
 
 ## 3. 已在 WSL 内自动化验证过的项（无需重复）
 

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -26,6 +26,7 @@ const updater = require('./updater');
 const clientUpdater = require('./client-updater');
 const balance = require('./balance');
 const wslBackend = require('./wsl-backend');
+const { installBuiltinPresets } = require('./scripts/install-minimal-win-preset');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
 const zlib = require('node:zlib');
@@ -1639,6 +1640,18 @@ async function runUpdateFlow(manual) {
       // WSL 托管：检查复用 Windows 侧 npm（纯 registry 查询），安装走 WSL 内
       // npm（staging + 原子切换，语义与本地模式一致）。
       await wslBackend.applyUpdate(latest, (line) => log('update', 'wsl: ' + line));
+      // 新 WSL agent 已就位：与 local 一致，立即补同步配套插件/内置预设并重打
+      // 运行时补丁（全部幂等），否则「稍后重启」后再重启服务会以未修复、且
+      // 缺少壳内置模式的新版本启动。
+      syncCompanionPlugins();
+      syncBuiltinAgentPresets();
+      applyRuntimeFlashFix();
+      applyPromptExposeFix();
+      applyImageSendFix();
+      applyVisionKeyFix();
+      applyProfilePatchGuard();
+      applySettingsSectionGuard();
+      applyWorkspaceSearchRailFix();
     } else {
       await updater.applyUpdate(ctx, latest);
       // 新 overlay 已就位：立即重打运行时补丁（全部幂等），否则「稍后重启」后再
@@ -2479,7 +2492,33 @@ function syncCompanionPlugins() {
   } catch (err) {
     log('boot', '同步配套插件失败: ' + err.message);
   }
-}// ---------------------------------------------------------------------------
+}
+
+// ---------------------------------------------------------------------------
+// 内置 Agent 预设同步：local 模式的预设由 npm start / after-pack 直接写入
+// Windows 侧内置 dsh 包的 config/agent-presets；WSL 托管模式的 dsh 是 WSL 内
+// npm 安装的干净包，不包含壳自带的 8 个预设，因此模式列表比 local 少。
+// 这里经 UNC 把 assets/agent-presets 幂等复制进 WSL agent 包，让两种后端
+// 看到的模式一致（_preset 是共享模块目录，installBuiltinPresets 一并处理）。
+// ---------------------------------------------------------------------------
+function syncBuiltinAgentPresets() {
+  if (!IS_WIN || !isWslMode()) return;
+  try {
+    const home = effectiveDshHome();
+    if (!home) { log('boot', 'DSH_HOME 未解析，跳过内置 Agent 预设同步'); return; }
+    const dshPkgDir = path.join(home, 'agent', 'node_modules', '@deepseek-ai', 'dsh');
+    if (!fs.existsSync(path.join(dshPkgDir, 'package.json'))) {
+      log('boot', 'WSL 内 dsh 包未就绪，跳过内置 Agent 预设同步');
+      return;
+    }
+    const dests = installBuiltinPresets(dshPkgDir);
+    log('boot', '已同步 ' + dests.length + ' 个内置 Agent 预设到 WSL dsh: ' + dests.map((d) => path.basename(d)).join(', '));
+  } catch (err) {
+    log('boot', '同步内置 Agent 预设到 WSL 失败: ' + err.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // dsh web 运行时闪跳修复：官方 dsh-client-runtime 在会话列表刷新
 // （mergeOrderedBaseline）时会丢弃「本地已创建、宿主全量列表尚未回显」的
 // 新会话，使 current 瞬时变 undefined，UI 闪回「选择工作区/无会话」状态。
@@ -3481,6 +3520,7 @@ async function boot() {
     setupTestChannel();
     await wslBackend.ensureInstalled();
     syncCompanionPlugins();
+    syncBuiltinAgentPresets();
     applyRuntimeFlashFix();
     applyPromptExposeFix();
     applyImageSendFix();

--- a/dsh-desktop/scripts/sync-companion-plugins.js
+++ b/dsh-desktop/scripts/sync-companion-plugins.js
@@ -1,21 +1,25 @@
 'use strict';
 
 // 把 DSH Desktop 的配套插件同步进任意 dsh 的 web profile（独立于 Electron 壳，
-// 逻辑与 main.js 的 syncCompanionPlugins 完全一致）。典型用途：把自己 WSL / Linux
-// 里另装的 dsh（checkout 开发版或 npm 版）也配上壳自带的插件（余额、文件改动视图、
-// 终端、浮窗、插件市场、自定义提示词、第三方思考、识图等）。
+// 逻辑与 main.js 的 syncCompanionPlugins 完全一致），并顺带把壳内置的 Agent
+// 预设（assets/agent-presets）同步进能找到的 dsh 包 config/agent-presets，
+// 避免 WSL / Linux 里的 dsh 模式列表比 Windows 内置 dsh 少。典型用途：把自己
+// WSL / Linux 里另装的 dsh（checkout 开发版或 npm 版）也配上壳自带的插件
+// （余额、文件改动视图、终端、浮窗、插件市场、自定义提示词、第三方思考、识图等）。
 //
 // 用法（WSL / Linux / Windows 均可执行）：
-//   node scripts/sync-companion-plugins.js [DSH_HOME] [--with-patches] [--dry-run]
+//   node scripts/sync-companion-plugins.js [DSH_HOME] [--with-patches] [--dry-run] [--dsh-package <目录>]
 //     DSH_HOME       目标 dsh 数据目录，默认 ~/.dsh
 //     --with-patches 额外应用两个运行时补丁（会话列表闪跳修复、
 //                    dsh-prompt / 第三方思考设置暴露白名单）
 //     --dry-run      只打印将要做的事，不落盘
+//     --dsh-package  内置 Agent 预设的目标 dsh 包目录（缺省自动探测
+//                    <DSH_HOME>/agent 与 PATH 上的 dsh 命令）
 //
-// 生效方式：同步只落盘；dsh web 在启动时读取 profile 补丁层，因此需要重启
-// WSL 里的 dsh web 后插件才会挂载（checkout 开发模式 `pnpm dsh web`，
-// npm 安装版 `dsh web`）。注意：重启 dsh web 会中断当前正在跑的会话
-// （会话数据在磁盘上，重启后可继续）。
+// 生效方式：同步只落盘；dsh web 在启动时读取 profile 补丁层与包内预设目录，
+// 因此需要重启 WSL 里的 dsh web 后插件才会挂载（checkout 开发模式
+// `pnpm dsh web`，npm 安装版 `dsh web`）。注意：重启 dsh web 会中断当前正在
+// 跑的会话（会话数据在磁盘上，重启后可继续）。
 //
 // 卸载：从 <DSH_HOME>/profiles/web/cordis.patch.yml 删掉对应 insert 条目，
 // 并删掉 <DSH_HOME>/profiles/web/node_modules/@deepseek-ai/dsh-* 目录即可。
@@ -23,6 +27,9 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { installBuiltinPresets } = require('./install-minimal-win-preset');
 
 // 与 main.js COMPANION_PLUGINS 保持一致（保持同步时请两处一起改）。
 const COMPANION_PLUGINS = [
@@ -57,6 +64,91 @@ function log(msg) {
 
 function warn(msg) {
   console.warn('[sync] ⚠ ' + msg);
+}
+
+// ---------------------------------------------------------------------------
+// 内置 Agent 预设同步：Windows 打包产物由 npm start / after-pack 直接写入
+// 内置 dsh 包；WSL / Linux 里另装的 dsh 是干净的 npm 包，缺少壳自带的 8 个
+// 模式预设。这里把 assets/agent-presets 幂等复制进 dsh 包的
+// config/agent-presets，让两端模式列表一致。
+// ---------------------------------------------------------------------------
+
+function isDshPackageDir(dir) {
+  if (!dir) return false;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+    return pkg && pkg.name === '@deepseek-ai/dsh';
+  } catch { return false; }
+}
+
+function packageDirFromBin(binPath) {
+  if (!binPath) return '';
+  let p = path.resolve(binPath);
+  try { p = fs.realpathSync.native(p); } catch {}
+  let dir = path.dirname(p);
+  for (let i = 0; i < 8 && dir; i += 1) {
+    if (isDshPackageDir(dir)) return dir;
+    // npm global 的 shim 在 <prefix> 目录，真正的包在 <prefix>/node_modules 下。
+    const nested = path.join(dir, 'node_modules', '@deepseek-ai', 'dsh');
+    if (isDshPackageDir(nested)) return nested;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return '';
+}
+
+function commandLocations(cmd) {
+  try {
+    const win = process.platform === 'win32';
+    const res = spawnSync(win ? 'where.exe' : 'sh', win ? [cmd] : ['-lc', `command -v ${cmd} 2>/dev/null || true`], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 15000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (res.status !== 0) return [];
+    return (res.stdout || '').split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+  } catch { return []; }
+}
+
+function findDshPackageDir(home, explicit) {
+  if (explicit) {
+    const dir = path.resolve(explicit);
+    return isDshPackageDir(dir) ? dir : '';
+  }
+  const candidates = [
+    path.join(home, 'agent', 'node_modules', '@deepseek-ai', 'dsh'),
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh'),
+    path.join(home, 'node_modules', '@deepseek-ai', 'dsh'),
+  ];
+  for (const dir of candidates) {
+    if (isDshPackageDir(dir)) return dir;
+  }
+  for (const location of commandLocations('dsh')) {
+    const dir = packageDirFromBin(location);
+    if (dir) return dir;
+  }
+  return '';
+}
+
+function syncBuiltinPresets(home, dshPackageArg, dryRun) {
+  const dshPkgDir = findDshPackageDir(home, dshPackageArg);
+  if (!dshPkgDir) {
+    if (dshPackageArg) warn(`--dsh-package 未找到有效的 @deepseek-ai/dsh 包: ${dshPackageArg}`);
+    else log('未找到 dsh 包（@deepseek-ai/dsh），跳过内置 Agent 预设同步；可用 --dsh-package <目录> 显式指定');
+    return;
+  }
+  if (dryRun) {
+    log(`dry-run: 将同步内置 Agent 预设（assets/agent-presets）→ ${path.join(dshPkgDir, 'config', 'agent-presets')}`);
+    return;
+  }
+  try {
+    const dests = installBuiltinPresets(dshPkgDir);
+    log(`已同步 ${dests.length} 个内置 Agent 预设 → ${dshPkgDir}: ${dests.map((d) => path.basename(d)).join(', ')}`);
+  } catch (err) {
+    warn('内置 Agent 预设同步失败: ' + (err && err.message ? err.message : err));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -263,7 +355,16 @@ function applyRuntimePatches(home, dryRun) {
 
 function main() {
   const args = process.argv.slice(2);
-  const homeArg = args.find((a) => !a.startsWith('--'));
+  const dshPkgIdx = args.indexOf('--dsh-package');
+  let dshPackageArg = '';
+  if (dshPkgIdx >= 0) {
+    dshPackageArg = args[dshPkgIdx + 1] || '';
+    if (!dshPackageArg || dshPackageArg.startsWith('--')) {
+      warn('--dsh-package 需要一个目录参数，本次忽略');
+      dshPackageArg = '';
+    }
+  }
+  const homeArg = args.find((a) => !a.startsWith('--') && a !== dshPackageArg);
   const home = path.resolve(homeArg || process.env.DSH_HOME || path.join(os.homedir(), '.dsh'));
   const withPatches = args.includes('--with-patches');
   const dryRun = args.includes('--dry-run');
@@ -279,9 +380,10 @@ function main() {
     }
   }
   syncPlugins(home, dryRun);
+  syncBuiltinPresets(home, dshPackageArg, dryRun);
   if (withPatches) applyRuntimePatches(home, dryRun);
   console.log('[sync] 完成。');
-  console.log('[sync] 提示：插件在 dsh web 启动时才会挂载 —— 请重启 WSL 里的 dsh web：');
+  console.log('[sync] 提示：插件与内置 Agent 预设在 dsh web 启动时才会挂载 —— 请重启 WSL 里的 dsh web：');
   console.log('[sync]   checkout 开发模式:  cd <harness 目录> && pnpm dsh web');
   console.log('[sync]   npm 安装版:        dsh web');
   console.log('[sync]   重启会中断当前正在跑的会话；会话数据在磁盘上，重启后可继续。');

--- a/dsh-desktop/wsl-backend.js
+++ b/dsh-desktop/wsl-backend.js
@@ -8,8 +8,9 @@
 //   <dir>/agent-staging/...                     npm 安装 staging（完成后原子 mv）
 //   <dir>/dsh.pid                               dsh web 进程 pid（退出清理用）
 //   <dir>/profiles、sessions、settings.yaml      dsh 自身数据（与本地模式同构）
-// 配套插件同步不在这里：main.js 的 syncCompanionPlugins 经 UNC（effectiveDshHome
-// = <dir> 的 UNC 等价路径）直接写入 WSL profile，与本模块解耦。
+// 配套插件与内置 Agent 预设同步不在这里：main.js 的 syncCompanionPlugins /
+// syncBuiltinAgentPresets 经 UNC（effectiveDshHome = <dir> 的 UNC 等价路径）
+// 直接写入 WSL profile 与 agent 包，与本模块解耦。
 //
 // 跨 WSL 调用约定（已在真实 wsl.exe 上实测）：
 //   · wsl.exe 只接受 `--` 之后「按空格拆开的独立 argv 单词」；把整条命令拼成


### PR DESCRIPTION
WSL 托管/独立同步脚本此前只搬运配套插件，未把 assets/agent-presets 写入 WSL dsh 包的 config/agent-presets，导致 WSL 模式列表比 Windows local 少。现由 main.js 在 bootstrap 与更新后经 UNC 同步，sync-companion-plugins.js 自动探测并同步，支持 --dsh-package 显式指定。