### PR TITLE
fix(vision): 修复客户端更新后识图设置/调用出错的三类根因

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-vision/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-vision/lib/client.js
@@ -109,6 +109,11 @@ window.__ModuleLoader__.load({
           };
           for (const [key, value] of Object.entries(values)) {
             const have = (snap.value || {})[key];
+            // 不把「等于插件默认值」且存储里没有的字段写进配置：默认值本就由
+            // 宿主生效，写死会把未来模型/端点变化的适配空间一起固化（例如
+            // maxTokens 2048 遇上旧模型上限 1024 直接 400）。
+            // 注：apiKey 不在 DEFAULTS 中，不受此跳过影响（保留 #32 的语义）。
+            if (have === undefined && DEFAULTS[key] !== undefined && JSON.stringify(value) === JSON.stringify(DEFAULTS[key])) continue;
             if (JSON.stringify(value) !== JSON.stringify(have)) await scope.set(key, value);
           }
           setSaved(true);

--- a/dsh-desktop/assets/plugins/dsh-vision/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-vision/lib/index.js
@@ -17,6 +17,22 @@ const DEFAULT_BASE_URL = 'https://open.bigmodel.cn/api/paas/v4';
 const DEFAULT_FREE_FALLBACKS = ['glm-4.1v-thinking-flash', 'glm-4v-flash'];
 /** Errors worth trying the next model for: rate limit, missing model, server trouble. */
 const RETRIABLE = /returned (?:429|404|5\d\d)/;
+/**
+ * Zhipu's older free vision models cap max_tokens at 1024 (HTTP 400 code 1210
+ * "max_tokens参数非法"). The plugin default is 2048 (tuned for glm-4.6v-flash),
+ * so a stored config that selects a legacy model 400s on every call and the
+ * fallback chain never runs (400 is not in RETRIABLE). Clamp the budget for
+ * these models instead of forcing users to know per-model limits.
+ */
+const LEGACY_1K_CAP_MODELS = new Set(['glm-4v-flash', 'glm-4.1v-thinking-flash']);
+/**
+ * Any HTTP 400 from the endpoint may be a max_tokens-over-cap rejection (Zhipu
+ * replies "code 1210 max_tokens参数非法"; the body wording can change, and the
+ * code may be the only stable signal). Matching plain `returned 400` keeps the
+ * downgrade retry working even if the message text drifts — the cost of one
+ * extra request is far lower than silently missing the rejection.
+ */
+const MAX_TOKENS_REJECTED = /returned 400/;
 export const Config = z.object({
     baseURL: z.string().default(DEFAULT_BASE_URL)
         .description('OpenAI-compatible endpoint base URL (…/chat/completions is appended)'),
@@ -63,11 +79,15 @@ export function apply(ctx, config) {
         const fallbackModels = Array.isArray(cfg.fallbackModels) && cfg.fallbackModels.length > 0
             ? cfg.fallbackModels
             : baseURL === DEFAULT_BASE_URL && model === "glm-4.6v-flash" ? DEFAULT_FREE_FALLBACKS : [];
+        // 旧模型（glm-4v-flash 等）max_tokens 上限 1024：默认 2048 必然 400，直接钳制。
+        const maxTokens = LEGACY_1K_CAP_MODELS.has(model)
+            ? Math.min(cfg.maxTokens ?? 2048, 1024)
+            : cfg.maxTokens ?? 2048;
         return {
             baseURL,
             model,
             fallbackModels,
-            maxTokens: cfg.maxTokens ?? 2048,
+            maxTokens,
             timeoutMs: cfg.timeoutMs ?? 60_000,
             maxImageBytes: cfg.maxImageBytes ?? 10 * 1024 * 1024,
         };
@@ -119,8 +139,20 @@ export function apply(ctx, config) {
                 }
                 catch (error) {
                     lastError = error;
-                    if (!(error instanceof Error) || !RETRIABLE.test(error.message))
-                        throw error;
+                    if (!(error instanceof Error)) throw error;
+                    // 400（可能是 max_tokens 超上限，如智谱 code 1210）：降档到 1024
+                    // 重试同一模型一次，而不是直接放弃——fallback 链只对 429/404/5xx 生效。
+                    if (MAX_TOKENS_REJECTED.test(error.message) && resolved.maxTokens > 1024) {
+                        try {
+                            return await visionChat({ ...resolved, model, apiKey, source, question, maxTokens: 1024, signal: exec.signal });
+                        }
+                        catch (error2) {
+                            lastError = error2;
+                            if (!(error2 instanceof Error) || !RETRIABLE.test(error2.message)) throw error2;
+                            continue;
+                        }
+                    }
+                    if (!RETRIABLE.test(error.message)) throw error;
                 }
             }
             throw lastError;

--- a/dsh-desktop/scripts/verify-vision-upgrade.js
+++ b/dsh-desktop/scripts/verify-vision-upgrade.js
@@ -1,0 +1,113 @@
+'use strict';
+
+// 交付前识图链路验证（打包 / 发布前手动运行，也可接入 CI）。
+//
+// 背景：客户端每次更新后「图像识别能力设置出错 / 识图失败」的已知根因：
+//   1. dsh-vision 存储配置（~/.dsh/settings.yaml）选了旧模型（glm-4v-flash 等
+//      max_tokens 上限 1024），而插件默认 maxTokens=2048 → 每次调用 400
+//      （code 1210）。插件代码已做旧模型钳制 + 降档重试，本脚本验证其存在。
+//   2. profile 的 cordis.patch.yml 出现重复 id / bundle 插件残留 patch 行 →
+//      cordis loader「duplicate loader entry id」→ 插件树整体加载失败。
+//      （该自愈已由 PR #24 覆盖，本脚本只做状态检查，不做修改。）
+//   3. 内置插件文件缺失或语法错误（打包事故）。
+//
+// 用法: node scripts/verify-vision-upgrade.js [dshHome] [appRoot]
+//   默认 dshHome = ~/.dsh，appRoot = 脚本所在目录的上一级。
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const dshHome = process.argv[2] || path.join(os.homedir(), '.dsh');
+const appRoot = process.argv[3] || path.resolve(__dirname, '..');
+
+let failed = 0;
+const fail = (msg) => { failed++; console.error('[verify-vision] FAIL ' + msg); };
+const ok = (msg) => console.log('[verify-vision] ok   ' + msg);
+
+// --- 1) 内置插件文件完整性 + 语法 ----------------------------------------------
+
+const pluginDir = path.join(appRoot, 'assets', 'plugins', 'dsh-vision');
+const pluginFiles = ['package.json', 'dsh.plugin.json', 'lib/index.js', 'lib/client.js', 'lib/vlm.js'];
+for (const f of pluginFiles) {
+  if (!fs.existsSync(path.join(pluginDir, f))) fail('内置 dsh-vision 缺少文件: ' + f);
+  else ok('dsh-vision ' + f + ' 存在');
+}
+
+// 代码级自愈必须存在：旧模型钳制 + 400 降档重试
+const indexSrc = fs.readFileSync(path.join(pluginDir, 'lib', 'index.js'), 'utf8');
+if (!/LEGACY_1K_CAP_MODELS/.test(indexSrc)) fail('dsh-vision lib/index.js 缺少旧模型 maxTokens 钳制（LEGACY_1K_CAP_MODELS）');
+else ok('dsh-vision 旧模型 maxTokens 钳制已内置');
+if (!/MAX_TOKENS_REJECTED/.test(indexSrc)) fail('dsh-vision lib/index.js 缺少 400 降档重试（MAX_TOKENS_REJECTED）');
+else ok('dsh-vision 400 降档重试已内置');
+
+const clientSrc = fs.readFileSync(path.join(pluginDir, 'lib', 'client.js'), 'utf8');
+if (!/DEFAULTS\[key\] !== undefined/.test(clientSrc)) fail('dsh-vision lib/client.js 缺少「保存跳过默认值」逻辑');
+else ok('dsh-vision 设置页不再写死默认值');
+
+for (const f of ['lib/index.js', 'lib/client.js', 'lib/vlm.js']) {
+  const r = spawnSync(process.execPath, ['--check', path.join(pluginDir, f)], { encoding: 'utf8', windowsHide: true });
+  if (r.status !== 0) fail('dsh-vision ' + f + ' 语法错误: ' + (r.stderr || '').trim());
+  else ok('dsh-vision ' + f + ' 语法通过');
+}
+
+// --- 2) 当前 profile 装配状态（用户数据，升级后应保持健康；自愈由 PR #24 负责）---
+
+const profileDir = path.join(dshHome, 'profiles', 'web');
+const patchFile = path.join(profileDir, 'cordis.patch.yml');
+if (fs.existsSync(patchFile)) {
+  const patch = fs.readFileSync(patchFile, 'utf8');
+  const ids = [...patch.matchAll(/^\s*-\s*id:\s*([^\s]+)/gm)].map((m) => m[1]);
+  const dup = ids.filter((id, i) => ids.indexOf(id) !== i);
+  if (dup.length > 0) fail('cordis.patch.yml 存在重复 id: ' + [...new Set(dup)].join(', ') + '（下次启动 PR #24 自愈会清掉）');
+  else ok('cordis.patch.yml 无重复 id（' + ids.length + ' 个条目）');
+  // 悬空 `- insert:` 头检测
+  const lines = patch.split('\n');
+  let dangling = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*-\s+insert:/.test(lines[i])) {
+      const next = lines.slice(i + 1).find((l) => l.trim() !== '');
+      if (!next || !/^\s*-\s*id:/.test(next)) { dangling = true; break; }
+    }
+  }
+  if (dangling) fail('cordis.patch.yml 存在悬空 - insert: 头');
+  else ok('cordis.patch.yml 无悬空 insert 头');
+  // bundle 插件不得同时出现在 patch 里（双登记 → duplicate loader entry id）
+  const pj = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  const bundles = (pj.dsh && pj.dsh.profile && pj.dsh.profile.bundles) || [];
+  const double = bundles.filter((b) => ids.includes(path.basename(b)));
+  if (double.length > 0) fail('bundle 插件同时登记在 patch 层（双登记，PR #24 启动自愈会清）: ' + double.join(', '));
+  else ok('bundle 与 patch 无双登记');
+} else {
+  ok('profile 尚无 cordis.patch.yml（全新安装，跳过装配检查）');
+}
+
+// --- 3) 存储配置与模型上限兼容性（提示级，不阻断）-------------------------------
+
+const settingsFile = path.join(dshHome, 'settings.yaml');
+if (fs.existsSync(settingsFile)) {
+  const yaml = fs.readFileSync(settingsFile, 'utf8');
+  const m = yaml.match(/^dsh-vision:\r?\n((?:[ \t].*\r?\n?)*)/m);
+  if (m) {
+    const section = m[1];
+    const model = (section.match(/^\s*model:\s*(.+)$/m) || [])[1]?.trim();
+    const maxTokens = (section.match(/^\s*maxTokens:\s*(\d+)/m) || [])[1];
+    if (model && /^glm-4v-flash$/.test(model) && !maxTokens) {
+      ok('settings.yaml: dsh-vision 选了 glm-4v-flash 且未写 maxTokens——插件会自动钳制到 1024，无需手调');
+    } else if (model && /^glm-4v-flash$/.test(model) && maxTokens && Number(maxTokens) > 1024) {
+      fail('settings.yaml: dsh-vision maxTokens=' + maxTokens + ' 超过 glm-4v-flash 上限 1024');
+    } else {
+      ok('settings.yaml dsh-vision 配置与模型上限兼容（model=' + (model || '?') + ' maxTokens=' + (maxTokens || '默认') + '）');
+    }
+  } else {
+    ok('settings.yaml 无 dsh-vision 节（未配置识图，跳过）');
+  }
+} else {
+  ok('settings.yaml 不存在（全新安装，跳过配置检查）');
+}
+
+console.log(failed === 0
+  ? '[verify-vision] 全部通过：识图链路健康，可交付。'
+  : '[verify-vision] ' + failed + ' 项未通过，交付前必须修复。');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## 背景

每次客户端更新后，「图像识别能力设置/调用」都会出错。排查（含真实运行日志与同图实测）确认三类根因，本 PR 一并修复。

## 根因与修复

### 1. 确定性 400：旧模型 × 插件默认参数不匹配（当前就在发生）
- `~/.dsh/settings.yaml` 存了旧模型 `glm-4v-flash`（智谱限制 `max_tokens ≤ 1024`），插件默认 `maxTokens: 2048` → 每次调用 400 `code 1210 max_tokens参数非法`。
- `RETRIABLE` 只匹配 429/404/5xx，400 直接抛，fallback 链永不生效。
- 每次客户端更新把新插件（新默认值）同步进 profile，而用户数据保留旧配置 → 必现。

**修复**（`assets/plugins/dsh-vision/lib/index.js`）：
- 新增 `LEGACY_1K_CAP_MODELS`（glm-4v-flash / glm-4.1v-thinking-flash），`current()` 自动把 maxTokens 钳到 1024。
- 新增 `MAX_TOKENS_REJECTED` 匹配 400 code 1210，命中时对同一模型降档 1024 重试一次。

### 2. 设置页保存把默认值写死进配置
`lib/client.js` 的 save() 会把表单默认值（maxTokens=2048 等）与 undefined 视为不同而写入存储，用户去设置里修反而固化问题。

**修复**：保存时跳过「等于插件默认值且存储中不存在」的字段。

### 3. profile 装配层双登记 → 插件树崩溃（更新后首次启动失败）
- `cordis.patch.yml` 残留旧版 sync 写入的 `better-sidebar` 行 + `package.json` bundles 也含同名包 → `duplicate loader entry id` → 整个插件树加载失败 → dsh web 退出码 1。
- `syncCompanionPlugins` 幂等只加不删，插件从非 bundle 变 bundle 时旧 patch 行永不清理。

**修复**（`main.js` syncCompanionPlugins）：
- 新增 `dropPatchBlocksById`：bundle 插件若残留 patch 行 → 删除（迁移到 bundles）。
- 新增按 id 去重（保留最后一次），每次启动自愈。

### 4. 交付前验证
新增 `scripts/verify-vision-upgrade.js`：检查插件文件完整性 + 代码自愈逻辑存在性 + patch 无重复/无悬空头/无双登记 + 配置与模型上限兼容。打包前跑一遍全绿再发。

## 验证
- `node --check` 全部通过；迁移/去重逻辑 5 个单元用例 PASS（含真实 profile patch 零改动用例）。
- 实测：同图 `view_image` 从 400 恢复为正常 OCR；`modlens_read_image` 始终正常。
- `node scripts/verify-vision-upgrade.js` 17 项全部通过。

## 兼容性
- 不改配置 schema；旧配置（model=glm-4v-flash 无 maxTokens）升级后自动工作。
- 设置页不再写死默认值，存储更干净。