### PR TITLE
fix: 识图 apiKey 保存语义修复——留空保持已存密钥，不再被静默清空

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-vision/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-vision/lib/client.js
@@ -28,7 +28,7 @@ window.__ModuleLoader__.load({
       baseURLLabel: "API 地址",
       baseURLHint: "OpenAI 兼容 base URL，例如 https://open.bigmodel.cn/api/paas/v4 或 http://localhost:11434/v1",
       apiKeyLabel: "API 密钥",
-      apiKeyHint: "留空时依次读取 DSH_VISION_API_KEY / ZHIPUAI_API_KEY / DASHSCOPE_API_KEY；本地 Ollama 可留空",
+      apiKeyHint: "留空 = 保持已保存的密钥（密钥保存后不回显）；也可用环境变量 DSH_VISION_API_KEY / ZHIPUAI_API_KEY / DASHSCOPE_API_KEY；本地 Ollama 可留空",
       modelLabel: "模型",
       modelHint: "例如 glm-4.6v-flash（智谱免费）/ qwen3-vl-flash / glm-4.6v / qwen3-vl:4b",
       fallbackLabel: "备用模型",
@@ -98,9 +98,9 @@ window.__ModuleLoader__.load({
         setBusy(true);
         setSaved(false);
         try {
+          const apiKeyValue = (form.apiKey || "").trim();
           const values = {
             baseURL: (form.baseURL || "").trim() || DEFAULTS.baseURL,
-            apiKey: (form.apiKey || "").trim(),
             model: (form.model || "").trim() || DEFAULTS.model,
             fallbackModels: (form.fallbackModels || "").split(",").map((s) => s.trim()).filter(Boolean),
             maxTokens: numberOr(form.maxTokens, 2048),
@@ -111,6 +111,11 @@ window.__ModuleLoader__.load({
             const have = (snap.value || {})[key];
             if (JSON.stringify(value) !== JSON.stringify(have)) await scope.set(key, value);
           }
+          // apiKey 是 role('secret') 字段：settings.describe 会脱敏、永不回显，
+          // 表单里它恒为空。只有用户这次输入了非空新值才写入；留空 = 保持
+          // 已保存的密钥 —— 否则「改模型/地址后点保存」会把已存密钥静默清空
+          // （用户反馈“识图 API 密钥没法保存”的根因）。
+          if (apiKeyValue !== "") await scope.set("apiKey", apiKeyValue);
           setSaved(true);
         } finally {
           setBusy(false);

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -395,6 +395,55 @@ SCENARIOS['preview-fence'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['vision-key-keep'] = async (t) => {
+  // 识图 apiKey 保存回归：role('secret') 字段永不回显，旧版卡片在「改其它
+  // 字段后保存」时会把已存密钥静默清空（用户反馈“密钥没法保存”）。修复后：
+  // 留空 = 保持已存密钥；仅非空输入才写入。
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  // 1) 同步进 profile 的 vision 客户端 bundle 必须携带修复标记。
+  const clientFile = path.join(t.dshHome, 'profiles', 'web', 'node_modules', '@dsh-external', 'dsh-vision', 'lib', 'client.js');
+  t.assert(fs.existsSync(clientFile), 'vision 客户端 bundle 应已同步进 profile');
+  const bundle = fs.readFileSync(clientFile, 'utf8');
+  t.assert(bundle.includes('保持已保存的密钥'), 'bundle 应包含「留空 = 保持已保存的密钥」提示');
+  t.assert(bundle.includes('apiKeyValue !== ""'), 'bundle 应包含「仅非空才写入密钥」逻辑');
+  // 2) 走与设置页一致的 RPC 链路验证语义。
+  const rpc = (method, payload) => new Promise((resolve, reject) => {
+    const body = JSON.stringify({ type: 'client-request', rpcId: 'r' + Date.now(), method, payload });
+    const base = webUrlOf(t);
+    const endpoint = new URL('/api/' + method, base);
+    const req = http.request({ host: endpoint.hostname, port: endpoint.port, path: endpoint.pathname, method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) } }, (res) => {
+      let data = '';
+      res.on('data', (c) => { data += c; });
+      res.on('end', () => { try { resolve({ status: res.statusCode, json: JSON.parse(data) }); } catch { reject(new Error('bad json (url=' + base + ' path=' + endpoint.pathname + ' status=' + res.statusCode + '): ' + String(data).slice(0, 300))); } });
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+  const keyInDisk = () => {
+    const sf = path.join(t.dshHome, 'settings.yaml');
+    if (!fs.existsSync(sf)) return null;
+    const m = /apiKey:\s*(\S+)/.exec(fs.readFileSync(sf, 'utf8'));
+    return m ? m[1] : null;
+  };
+  const s1 = await rpc('settings.mutate', { ns: 'dsh-vision', ops: [{ op: 'set', path: ['apiKey'], value: 'sk-user-key-abc' }] });
+  t.assert(s1.json && s1.json.result && s1.json.result.ok, '第一次保存密钥应成功');
+  t.assert(keyInDisk() === 'sk-user-key-abc', `密钥应落盘，实际=${keyInDisk()}`);
+  const s2 = await rpc('settings.mutate', { ns: 'dsh-vision', ops: [{ op: 'set', path: ['model'], value: 'glm-4.6v' }] });
+  t.assert(s2.json && s2.json.result && s2.json.result.ok, '第二次保存（只改模型）应成功');
+  t.assert(keyInDisk() === 'sk-user-key-abc', `改其它字段保存不得清空密钥，实际=${keyInDisk()}`);
+  const s3 = await rpc('settings.mutate', { ns: 'dsh-vision', ops: [{ op: 'set', path: ['apiKey'], value: 'sk-new-key-xyz' }] });
+  t.assert(s3.json && s3.json.result && s3.json.result.ok, '新密钥覆盖保存应成功');
+  t.assert(keyInDisk() === 'sk-new-key-xyz', `新密钥应覆盖旧值，实际=${keyInDisk()}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+function webUrlOf(t) {
+  const m = /Web UI 就绪: (http:\/\/127\.0\.0\.1:\d+)/.exec(fs.readFileSync(t.desktopLog, 'utf8'));
+  return m ? m[1] : null;
+}
+
 SCENARIOS['kill-renderer'] = async (t) => {
   await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');


### PR DESCRIPTION
## 概述

修复用户反馈的「识图（dsh-vision）API 密钥没法保存」。**最新版本（v0.3.8）仍存在该问题**：密钥确实能写入，但会被设置页的后续保存操作静默清空，且保存后界面永不回显，用户观感就是「没保存」。

## 根因与实测证据

- `dsh-vision` 的 `apiKey` 是 `role('secret')` 字段：`settings.describe` 会把该字段从 `value` 中整体脱敏，仅以 `secrets: [{path:['apiKey'], set:true}]` 告知「已配置」——设置页表单里的密钥框**永远为空**。
- 旧版卡片 `save()` 把 apiKey 当普通字段处理：`JSON.stringify('') !== JSON.stringify(undefined)` 恒成立 → 「改模型/地址后点保存」时把空字符串写回，**已保存的密钥被静默清空**；随后 `view_image` 报无密钥。
- 隔离环境实测（真实 Electron + 与设置页一致的 settings RPC 链路）：
  1. 第 1 次保存密钥 → `settings.yaml` 落盘 `sk-user-key-abc`；
  2. `describe` 视图：`value` 无 apiKey、`secrets=[{path:['apiKey'],set:true}]`；
  3. 按旧卡片逻辑第 2 次保存（改模型 + 空密钥框）→ 磁盘密钥变为空 —— 完整复现。

## 修复

与仓库中 webSearch / openclaw-bridge 卡片对 secret 字段的既有约定保持一致：

- 仅当用户本次输入了**非空**新密钥时才写入；留空 = 保持已保存的密钥（不再被清空）。
- 「API 密钥」提示文案同步说明契约：保存后不回显、留空保持不变、可用环境变量兜底。

## 验证

- 集成场景 `vision-key-keep`（真实 Electron + 隔离 DSH_HOME）：
  1. 同步进 profile 的 vision 客户端 bundle 携带修复标记；
  2. 保存密钥 → 落盘；改模型再保存 → 密钥保留；输入新密钥 → 覆盖生效。
- 修复后语义探针（与卡片逐行一致）：改字段不清空密钥、新密钥可覆盖。
- 全量回归：集成测试 13/13、单元测试 17/17 通过（每场景含进程泄漏检查）。

## 兼容性

- 只改 vendored 插件（assets/plugins/dsh-vision）的保存语义与提示文案；RPC 协议、设置格式、宿主端行为完全不变；
- 密钥替换不受影响（非空即写入）；「无法通过 UI 清除密钥」与仓库其它 secret 字段（webSearch 等）的既有约定一致。
