### PR TITLE
fix: profile patch 自愈只删注册行——修复 main 已合入版误删用户 config/disabled 条目（issue #17 修正）

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -2330,9 +2330,10 @@ function removeLegacyMarketplace(profileWebModules, profileDir) {
 // profile patch 自愈：cordis.patch.yml 损坏会让 dsh web 装配 profile 时抛错并
 // 以 exit 1 退出，桌面端「启动失败」。每次启动 dsh web 前调用本函数：
 //   1. 顶层孤立 `[]` 与列表条目混存 → 移除 `[]` 行（修复为单一顶层列表）；
-//   2. issue #17 存量：同一 loader id 重复注册（旧版本插件安装写入的重复
-//      insert 条目 → cordis loader "duplicate loader entry id: X"）→ 块级
-//      去重，保留首个条目、备份原文件；
+//   2. issue #17 存量：同一 loader id 被注册多次（旧版本插件安装写入的重复
+//      insert 条目 → cordis loader "duplicate loader entry id: X"）→ 注册行级
+//      去重，保留首次注册、备份原文件；config 覆盖/disabled 禁用条目是用户
+//      配置，绝不改动；
 //   3. 仍无法解析（其它损坏形态）→ 备份为 cordis.patch.yml.broken-<ts> 并
 //      重置为最小合法文件，日志告警，备份保留用户内容供恢复。
 //   健康文件零写入（幂等）。
@@ -2389,9 +2390,10 @@ function healProfilePatch() {
     let error = null;
     try { parsed = yaml.load(text); } catch (err) { error = err; }
     if (!error && Array.isArray(parsed)) {
-      // issue #17 存量自愈：按 id 去重顶层条目。重复注册（旧版本插件安装
-      // 写入的第二个同 id insert 块）会让 cordis loader 抛
-      // "duplicate loader entry id: X"，且该状态永远无法自愈。
+      // issue #17 存量自愈：注册行级去重。重复注册（旧版本插件安装
+      // 写入的第二个同 id insert 条目）会让 cordis loader 抛
+      // "duplicate loader entry id: X"，且该状态永远无法自愈；只删重复
+      // 注册行，用户手写的 config/disabled 覆盖条目原样保留。
       const dedupe = dedupePatchEntries(text);
       if (dedupe.removed.length > 0) {
         const backup = file + '.dup-' + Date.now();
@@ -2543,9 +2545,9 @@ function syncCompanionPlugins() {
     let changed = false;
     // bundle 迁移自愈（issue #17 同族）：旧版本把后来升级为 bundle 的配套插件
     // 当非 bundle 写进了 patch（insert 行）；插件现经 dsh.profile.bundles 装配，
-    // 残留行会造成同 id 双登记 → cordis loader "duplicate loader entry id" →
-    // 整树加载失败（更新后首次启动崩溃）。幂等移除命中的 patch 行/块，其余
-    // 条目（含用户手写内容）原样保留。
+    // 残留注册行会造成同 id 双登记 → cordis loader "duplicate loader entry id" →
+    // 整树加载失败（更新后首次启动崩溃）。幂等移除命中的注册行/块；用户手写
+    // 的 config 覆盖/disabled 禁用条目原样保留。
     const bundleIds = new Set();
     for (const p of COMPANION_PLUGINS) {
       if (bundleNames.has(p.name)) bundleIds.add(p.id);

--- a/dsh-desktop/profile-patch-heal.js
+++ b/dsh-desktop/profile-patch-heal.js
@@ -4,71 +4,153 @@
 // electron 依赖，便于 node:test 单测）。
 //
 // 背景（issue #17）：旧版本（如 v0.3.4）的插件安装路径会向 cordis.patch.yml
-// 写入与桌面端配套插件相同的 `- insert: - id: balance` 条目，同一 id 出现
-// 两次。cordis loader 装配时抛
+// 写入与桌面端配套插件相同的 `- insert: - id: balance` 条目，同一 id 被
+// 注册两次。cordis loader 装配时抛
 //   duplicate loader entry id: balance
 //   或 failed to apply loader entry <hash> (@scope/pkg): list slot ... already
 //   has an entry with id ... at priority 0
-// 且该存量状态无法自愈，用户「进不来主界面」。这里提供：
-//   · dedupePatchEntries —— 块级按 id 去重（只整块删除「后出现且全部 id 均
-//     已出现过」的顶层条目，绝不改动块内部行，防止行级手术破坏 YAML）；
+// 且该存量状态无法自愈，用户「进不来主界面」。
+//
+// 语义边界（依据 dsh-app-boot 的 applyEntryPatches 与 cordis.patch.yml 文件头
+// 注释）：patch 顶层数组包含三类条目——insert 注册列表、id 定向 config 覆盖、
+// disabled 禁用。只有 insert 列表内的行是「注册」；config/disabled 覆盖条目
+// 不注册任何东西，`duplicate loader entry id` 只可能来自注册行。因此自愈
+// 只允许删「注册行」，绝不触碰 config/disabled 覆盖条目（用户配置数据）。
+//
+// 这里提供：
+//   · dedupePatchEntries —— 注册行级去重：同一 id 的第二次及以后注册行
+//     （连同其同缩进兄弟行，如 name/config）被移除，保留首次注册；insert
+//     块内部分重复时只删重复行、保留新注册；config/disabled/定向 insert
+//     块永不改动；无重复时零写入；
+//   · dropBlocksByIds —— bundle 迁移自愈：移除命中移除集的注册行（insert
+//     块内行级删除、整块命中时整块删除）；顶层的 name-only 直注册行（旧版
+//     遗留、无 config/disabled）整块移除；config/disabled 覆盖条目原样保留；
 //   · parseFailedLoaderIds —— 识别 loader 失败日志中的三种 id 形态
 //     （旧 hash 形态 / duplicate loader entry id: X 形态 / 括号包名形态）；
 //   · mapPackagesToPatchIds —— 把括号中的包名映射回 patch 条目 id
 //     （供安全启动 overlay 兜底禁用）。
 
+const idRowRe = /^(\s*)-\s*id:\s*([A-Za-z0-9_-]+)/;
+
 /**
- * 移除顶层条目中「按 id 重复」的后出现条目（issue #17 存量自愈）。
- * 只做块级判断与整块删除；块内（同一 insert 内）的重复 id 属更罕见形态，
- * 不在本函数内行级手术，交由安全启动 overlay 兜底。
+ * 把文本切分为顶层条目块。顶层条目 = 行首（列 0）以 `- ` 开头的行，
+ * 其后到下一个顶层条目之前的所有行属于该块。块的 insert 属性表示
+ * 块首行为 `- insert:`（注册列表块）；其余（`- id: X` 直条目等）为
+ * 非注册块。
+ * @param {string[]} lines 文件按行切分（已去行尾符）
+ * @returns {{begin:number,end:number,lines:string[],insert:boolean}[]}
+ */
+function topLevelBlocks(lines) {
+  const starts = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^-(\s|$)/.test(lines[i])) starts.push(i);
+  }
+  const blocks = [];
+  for (let s = 0; s < starts.length; s += 1) {
+    const begin = starts[s];
+    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
+    blocks.push({
+      begin,
+      end,
+      lines: lines.slice(begin, end),
+      insert: /^-\s*insert\s*:/.test(lines[begin]),
+    });
+  }
+  return blocks;
+}
+
+/**
+ * 输出兜底：若修复后的文本只剩注释/空行（没有任何顶层条目），补一个空
+ * 数组 `[]`，保证文件仍是合法的顶层数组（YAML 可解析为 []），避免被
+ * 下次启动误判为「解析失败」而重置。
+ * @param {string[]} lines 修复后的行集合
+ * @returns {string[]} 补兜底后的行集合
+ */
+function ensurePatchArray(lines) {
+  if (!lines.some((l) => /^-(\s|$)/.test(l))) lines.push('[]');
+  return lines;
+}
+
+/**
+ * 移除「重复注册」的 loader 条目（issue #17 存量自愈）。
+ * 只针对 insert 注册块做行级去重：同一 id 的第二次及以后注册行（连同其
+ * 同缩进兄弟行）被移除，保留首次注册；insert 块内部分重复时只删重复行、
+ * 保留新注册。config 覆盖、disabled 禁用、定向 insert（`- id: X` +
+ * `insert:`）等非注册条目永不改动。
  * @param {string} text cordis.patch.yml 原文
  * @returns {{ text: string, removed: string[] }} 修复后的文本与被移除的重复 id；
  *   无重复时返回原文本与空数组（零写入）。
  */
 function dedupePatchEntries(text) {
   const lines = text.split(/\r?\n/);
-  const starts = [];
-  for (let i = 0; i < lines.length; i += 1) {
-    if (/^-(\s|$)/.test(lines[i])) starts.push(i);
-  }
-  if (starts.length < 2) return { text, removed: [] };
-  const seen = new Set();
+  const blocks = topLevelBlocks(lines);
+  const registered = new Set();
   const removed = [];
-  const keep = [];
-  if (starts[0] > 0) keep.push([0, starts[0]]); // 文件头注释等前置内容
-  for (let s = 0; s < starts.length; s += 1) {
-    const begin = starts[s];
-    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
-    const block = lines.slice(begin, end).join('\n');
-    const ids = [...block.matchAll(/(?:^|\n)\s*-\s*id:\s*([A-Za-z0-9_-]+)/g)].map((m) => m[1]);
-    if (ids.length === 0) { keep.push([begin, end]); continue; } // 无 id 的条目原样保留
-    const dups = ids.filter((id) => seen.has(id));
-    if (dups.length === ids.length) {
-      // 该块声明的 id 全部已出现过：整块移除（后出现的注册是冲突源）。
-      removed.push(...dups);
+  const out = [];
+  if (blocks.length > 0 && blocks[0].begin > 0) out.push(...lines.slice(0, blocks[0].begin));
+  for (const block of blocks) {
+    if (!block.insert) {
+      // 非注册块（config 覆盖 / disabled / 定向 insert / 无 id 条目）：
+      // 绝不删除。
+      out.push(...block.lines);
       continue;
     }
-    // 块内仍有新 id：保留整块；块内的部分重复不在此手术（极端形态由
-    // 安全启动 overlay 兜底），但已见过的 id 仍计入，避免后续块再撞。
-    for (const id of ids) seen.add(id);
-    keep.push([begin, end]);
+    // insert 注册块：行级去重，只删「重复注册」行及其同缩进兄弟行。
+    const kept = [block.lines[0]];
+    let blockDupCount = 0;
+    let i = 1;
+    while (i < block.lines.length) {
+      const m = idRowRe.exec(block.lines[i]);
+      if (!m) {
+        // 非 id 行（name 等兄弟行、嵌套列表值、空行）：跟随其前一行保留。
+        kept.push(block.lines[i]);
+        i += 1;
+        continue;
+      }
+      const id = m[2];
+      if (registered.has(id)) {
+        removed.push(id);
+        blockDupCount += 1;
+        i += 1;
+        const indent = m[1].length;
+        while (i < block.lines.length) {
+          const l = block.lines[i];
+          const li = /^\s*/.exec(l)[0].length;
+          if (l.trim() === '' || (li > indent && !/^\s*-\s+/.test(l))) {
+            i += 1;
+            continue;
+          }
+          break;
+        }
+        continue;
+      }
+      registered.add(id);
+      kept.push(block.lines[i]);
+      i += 1;
+    }
+    // 本块确有重复注册行被删且只剩块头（`- insert:`）→ 丢弃空块；
+    // 无重复的块（含 `- insert: []`）原样保留（保证零写入）。
+    if (blockDupCount > 0 && kept.length === 1) continue;
+    out.push(...kept);
   }
-  if (removed.length === 0) return { text, removed };
-  const out = [];
-  for (const [b, e] of keep) out.push(...lines.slice(b, e));
-  return { text: out.join('\n'), removed };
+  if (removed.length === 0) return { text, removed: [] };
+  return { text: ensurePatchArray(out).join('\n'), removed };
 }
 
 /**
  * 移除「已迁移为 bundle 的插件」在 patch 层残留的旧注册条目（双登记自愈）。
  * 旧版本客户端把某些配套插件当非 bundle 写入 cordis.patch.yml（insert 块）；
- * 插件升级为 bundle（经 dsh.profile.bundles 装配）后，残留行会让 cordis loader
- * 抛 `duplicate loader entry id: X` 且整树加载失败（更新后首次启动崩溃的根因）。
+ * 插件升级为 bundle（经 dsh.profile.bundles 装配）后，残留注册行会让
+ * cordis loader 抛 `duplicate loader entry id: X` 且整树加载失败（更新后
+ * 首次启动崩溃的根因）。
  *
- * 处理规则（块级优先、行级兜底）：
- *   · 顶层条块声明的 id 全部命中移除集 → 整块删除（含块头注释之外的块内行）；
- *   · insert 块内仅部分 id 命中 → 只删除命中的「- id: X」行及其同缩进兄弟行
- *     （name 等），其余条目原样保留 —— 绝不整块误删；
+ * 处理规则：
+ *   · insert 注册块声明的 id 全部命中移除集 → 整块删除；
+ *   · insert 注册块内仅部分 id 命中 → 只删除命中的「- id: X」行及其同缩进
+ *     兄弟行（name 等），其余注册原样保留 —— 绝不整块误删；
+ *   · 顶层的纯注册直条目（除 id 行外只有 name 行，旧版遗留）→ 整块移除；
+ *   · config 覆盖 / disabled 禁用 / 携带任意自定义键的覆盖条目是用户配置，
+ *     绝不删除；
  *   · 其余内容（注释/空行/非命中条目）原样保留。
  * 无命中时返回原文本（零写入）。
  * @param {string} text cordis.patch.yml 原文
@@ -79,50 +161,64 @@ function dropBlocksByIds(text, ids) {
   const removal = new Set((ids || []).filter((i) => typeof i === 'string' && i));
   if (removal.size === 0) return { text, removed: [] };
   const lines = text.split(/\r?\n/);
-  const starts = [];
-  for (let i = 0; i < lines.length; i += 1) {
-    if (/^-(\s|$)/.test(lines[i])) starts.push(i);
-  }
-  if (starts.length === 0) return { text, removed: [] };
-  const idRe = /^\s*-\s*id:\s*([A-Za-z0-9_-]+)/;
+  const blocks = topLevelBlocks(lines);
+  if (blocks.length === 0) return { text, removed: [] };
   const removed = [];
   const out = [];
-  if (starts[0] > 0) out.push(...lines.slice(0, starts[0])); // 文件头注释等
-  for (let s = 0; s < starts.length; s += 1) {
-    const begin = starts[s];
-    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
-    const block = lines.slice(begin, end);
-    const idRows = block
-      .map((line, idx) => ({ line, idx, m: idRe.exec(line) }))
+  if (blocks[0].begin > 0) out.push(...lines.slice(0, blocks[0].begin));
+  for (const block of blocks) {
+    const idRows = block.lines
+      .map((line, idx) => ({ line, idx, m: idRowRe.exec(line) }))
       .filter((r) => r.m !== null)
-      .map((r) => ({ ...r, id: r.m[1] }));
+      .map((r) => ({ ...r, id: r.m[2] }));
     const hitIds = idRows.filter((r) => removal.has(r.id)).map((r) => r.id);
-    if (hitIds.length === 0) { out.push(...block); continue; }
+    if (hitIds.length === 0) {
+      out.push(...block.lines);
+      continue;
+    }
+    if (!block.insert) {
+      // 非 insert 块：仅当是「旧版遗留的纯注册直条目」——除 id 行外只有
+      // name 行（无 config/disabled/insert 等任何其它键）——才允许整块
+      // 移除；其余形态（config 覆盖、disabled 禁用、定向 insert、携带任意
+      // 自定义键的覆盖条目）都是用户配置，绝不删除。
+      const bodyLines = block.lines.slice(1).filter((l) => l.trim() !== '');
+      const nameOnly = bodyLines.length > 0 && bodyLines.every((l) => /^\s*name\s*:/.test(l));
+      if (nameOnly) {
+        removed.push(...hitIds);
+        continue;
+      }
+      out.push(...block.lines);
+      continue;
+    }
     if (hitIds.length === idRows.length) {
       // 全部命中：整块删除。
       removed.push(...hitIds);
       continue;
     }
-    // 部分命中：行级删除命中的「- id: X」行及其同缩进兄弟行（name 等），
-    // 保留块内其余条目。兄弟行判定：缩进大于 id 行、且不以「- 」开头。
-    const keep = block.map((line) => ({ line, drop: false }));
+    // 部分命中：行级删除命中的「- id: X」注册行及其同缩进兄弟行（name 等），
+    // 保留块内其余注册。兄弟行判定：缩进大于 id 行、且不以「- 」开头。
+    const keep = block.lines.map((line) => ({ line, drop: false }));
     for (const r of idRows) {
       if (!removal.has(r.id)) continue;
       removed.push(r.id);
       const indent = /^\s*/.exec(r.line)[0].length;
       keep[r.idx].drop = true;
       let j = r.idx + 1;
-      while (j < block.length) {
-        const l = block[j];
+      while (j < block.lines.length) {
+        const l = block.lines[j];
         const li = /^\s*/.exec(l)[0].length;
-        if (l.trim() === '' || (li > indent && !/^\s*-\s+/.test(l))) { keep[j].drop = true; j += 1; continue; }
+        if (l.trim() === '' || (li > indent && !/^\s*-\s+/.test(l))) {
+          keep[j].drop = true;
+          j += 1;
+          continue;
+        }
         break;
       }
     }
     for (const k of keep) if (!k.drop) out.push(k.line);
   }
-  if (removed.length === 0) return { text, removed };
-  return { text: out.join('\n'), removed };
+  if (removed.length === 0) return { text, removed: [] };
+  return { text: ensurePatchArray(out).join('\n'), removed };
 }
 
 /**

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -477,6 +477,46 @@ SCENARIOS['heal-bundle-patch'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['heal-dup-patch-keeps-config'] = async (t) => {
+  // 回归防线：自愈只允许删「重复注册行」，绝不删除用户手写的
+  // config 覆盖 / disabled 禁用条目（cordis.patch.yml 官方文件头声明的
+  // 顶层条目形态）。同 id 的重复 insert 注册 + disabled/config 覆盖共存时，
+  // 应去重注册行并原样保留用户配置条目后正常启动。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const patch = [
+    '# 重复注册 balance + 用户手写的 disabled/config 覆盖条目',
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: balance',
+    '  disabled: true',
+    '- insert:',
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+    '- id: terminal',
+    '  config: {}',
+    '',
+  ].join('\n');
+  const patchFile = path.join(profileDir, 'cordis.patch.yml');
+  fs.writeFileSync(patchFile, patch);
+  await t.waitFor('boot-ready', 240000, '重复注册应被自愈，且用户配置条目保留');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('移除了重复注册的 loader 条目'), '应记录重复条目自愈日志');
+  const healed = fs.readFileSync(patchFile, 'utf8');
+  t.assert((healed.match(/^\s*- id: balance$/gm) || []).length === 2, `balance 应只剩 1 条注册 + 1 条 disabled 覆盖，实际=${healed}`);
+  t.assert((healed.match(/^\s*- id: terminal$/gm) || []).length === 2, `terminal 应只剩 1 条注册 + 1 条 config 覆盖，实际=${healed}`);
+  t.assert(/disabled: true/.test(healed), '用户 disabled 条目应保留');
+  t.assert(/config: \{\}/.test(healed), '用户 config 覆盖条目应保留');
+  const backups = fs.readdirSync(profileDir).filter((f) => f.startsWith('cordis.patch.yml.dup-'));
+  t.assert(backups.length >= 1, '原文件应被备份为 cordis.patch.yml.dup-<ts>');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
 SCENARIOS['web-search-patch'] = async (t) => {
   // issue #20：启动时必须把 web-search baseURL 契约补丁落到生效的 profile
   // fallback 副本（junction 写穿内置包），并记录日志。

--- a/dsh-desktop/scripts/test/unit-patch-heal-fuzz.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-heal-fuzz.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+// profile-patch-heal.js 的确定性模糊/性质测试（node --test）。
+// 对 dedupePatchEntries / dropBlocksByIds 做 3000 组确定性随机输入验证。
+// 性质：
+//   1. 输出 YAML 必须可解析为顶层数组（同 dsh 方言，JSON_SCHEMA + !!js 标量）；
+//   2. 幂等：二次调用 removed 为空且文本逐字节不变；
+//   3. 每个 id 在 insert 注册块中的出现次数 → 恰好 1（输入 ≥1 时）；
+//   4. 非 insert 块（config/disabled/注释）逐字节保留（dedupe 全部保留；
+//      dropBlocks 仅允许删除 name-only 直注册块）；
+//   5. 无重复时零修改（逐字节相等）。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { dedupePatchEntries, dropBlocksByIds } = require('../../profile-patch-heal.js');
+const yaml = require('../../node_modules/js-yaml');
+
+const jsType = new yaml.Type('tag:yaml.org,2002:js', {
+  kind: 'scalar',
+  resolve: () => true,
+  construct: (d) => ({ __jsExpr: d }),
+});
+const load = (c) => yaml.load(c, { schema: yaml.JSON_SCHEMA.extend(jsType) });
+
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+const IDS = ['a', 'b', 'c', 'd'];
+
+function topBlocks(lines) {
+  const starts = [];
+  for (let i = 0; i < lines.length; i += 1) if (/^-(\s|$)/.test(lines[i])) starts.push(i);
+  const blocks = [];
+  for (let s = 0; s < starts.length; s += 1) {
+    const begin = starts[s];
+    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
+    blocks.push({
+      lines: lines.slice(begin, end),
+      insert: /^-\s*insert\s*:/.test(lines[begin]),
+    });
+  }
+  return blocks;
+}
+
+function registrationCount(text) {
+  const counts = new Map();
+  for (const b of topBlocks(text.split(/\r?\n/))) {
+    if (!b.insert) continue;
+    for (const line of b.lines) {
+      const m = /^\s*-\s*id:\s*([A-Za-z0-9_-]+)/.exec(line);
+      if (m) counts.set(m[1], (counts.get(m[1]) || 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function nonInsertBlocks(text) {
+  return topBlocks(text.split(/\r?\n/)).filter((b) => !b.insert).map((b) => b.lines.join('\n'));
+}
+
+function genPatch(rand) {
+  const blocks = [];
+  const n = 2 + Math.floor(rand() * 5);
+  for (let i = 0; i < n; i += 1) {
+    const kind = i === 0 ? 0.1 : rand(); // 首块固定为 insert：保证输入是合法顶层数组
+    if (kind < 0.5) {
+      const rows = 1 + Math.floor(rand() * 3);
+      const lines = ['- insert:'];
+      for (let j = 0; j < rows; j += 1) {
+        const id = IDS[Math.floor(rand() * IDS.length)];
+        lines.push('    - id: ' + id);
+        lines.push("      name: 'pkg-" + id + "'");
+      }
+      blocks.push(lines.join('\n'));
+    } else if (kind < 0.7) {
+      blocks.push('- id: ' + IDS[Math.floor(rand() * IDS.length)] + '\n  disabled: true');
+    } else if (kind < 0.9) {
+      blocks.push('- id: ' + IDS[Math.floor(rand() * IDS.length)] + '\n  config:\n    k: v');
+    } else {
+      blocks.push('# comment block');
+    }
+  }
+  return '# head\n' + blocks.join('\n') + '\n';
+}
+
+test('fuzz 性质验证：3000 组确定性随机输入（dedupe/drop 幂等、可解析、注册唯一、非注册块保留、零写入）', () => {
+  let crlfChecked = false;
+  for (let seed = 1; seed <= 3000; seed += 1) {
+    const rand = rng(seed * 7919);
+    const p = genPatch(rand);
+    const tag = `seed=${seed}`;
+    assert.ok(Array.isArray(load(p)), `${tag} 输入可解析为数组`);
+    if (!crlfChecked) {
+      const crlf = p.replace(/\n/g, '\r\n');
+      assert.ok(Array.isArray(load(dedupePatchEntries(crlf).text)), 'CRLF 输入输出可解析');
+      crlfChecked = true;
+    }
+
+    // ---- dedupe 性质 ----
+    const before = registrationCount(p);
+    const nonBefore = nonInsertBlocks(p);
+    const r1 = dedupePatchEntries(p);
+    assert.ok(Array.isArray(load(r1.text)), `${tag} dedupe 输出可解析`);
+    const r2 = dedupePatchEntries(r1.text);
+    assert.ok(r2.removed.length === 0 && r2.text === r1.text, `${tag} dedupe 幂等`);
+    if (r1.removed.length === 0) assert.strictEqual(r1.text, p, `${tag} 无重复零修改`);
+    const after = registrationCount(r1.text);
+    for (const [id, n] of before) {
+      assert.strictEqual(after.get(id) || 0, n > 0 ? 1 : 0, `${tag} id=${id} 注册行唯一`);
+    }
+    assert.deepStrictEqual(nonInsertBlocks(r1.text), nonBefore, `${tag} dedupe 非 insert 块逐字节保留`);
+
+    // ---- dropBlocks 性质 ----
+    const dropIds = IDS.filter(() => rand() < 0.5);
+    const d1 = dropBlocksByIds(p, dropIds);
+    assert.ok(Array.isArray(load(d1.text)), `${tag} drop 输出可解析`);
+    const d2 = dropBlocksByIds(d1.text, dropIds);
+    assert.ok(d2.removed.length === 0 && d2.text === d1.text, `${tag} drop 幂等`);
+    if (dropIds.length === 0) assert.strictEqual(d1.text, p, `${tag} 空移除集零修改`);
+    const dAfter = registrationCount(d1.text);
+    for (const id of IDS) {
+      if (dropIds.includes(id)) {
+        assert.strictEqual(dAfter.get(id) || 0, 0, `${tag} drop 移除注册行 id=${id}`);
+      } else {
+        assert.strictEqual(dAfter.get(id) || 0, before.get(id) || 0, `${tag} drop 保留未命中注册行 id=${id}`);
+      }
+    }
+    const removable = (b) => {
+      const hit = /^\s*-\s*id:\s*([A-Za-z0-9_-]+)/m.exec(b);
+      if (!hit || !dropIds.includes(hit[1])) return false;
+      const body = b.split(/\r?\n/).slice(1).filter((l) => l.trim() !== '');
+      return body.length > 0 && body.every((l) => /^\s*name\s*:/.test(l));
+    };
+    const nonDAfter = nonInsertBlocks(d1.text).filter((b) => !removable(b));
+    const nonDBefore = nonBefore.filter((b) => !removable(b));
+    assert.deepStrictEqual(nonDAfter, nonDBefore, `${tag} drop 非注册配置块逐字节保留`);
+  }
+});

--- a/dsh-desktop/scripts/test/unit-patch-heal.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-heal.test.js
@@ -2,10 +2,10 @@
 
 // profile-patch-heal.js 纯函数单元测试（node --test）。
 // 用法：node --test scripts/test/unit-patch-heal.test.js
-// 覆盖：重复条目块级移除与保留顺序、文件头/尾注释保留、无重复零修改、
-//       无 id 条目保留、部分重复形态（保留块，交由 overlay 兜底）、
+// 覆盖：注册行级去重（双缺/三同名/零修改/注释保留/块内重复/部分重复行级手术）、
+//       config 覆盖与 disabled 禁用条目绝不删除、定向 insert 块不动、
 //       loader 日志三种 id 形态解析、包名→patch id 映射、
-//       bundle 迁移双登记移除（整块/部分行级/直接条目/零修改）。
+//       bundle 迁移双登记移除（整块/部分行级/直注册条目/用户配置保留/零修改）。
 
 const test = require('node:test');
 const assert = require('node:assert');
@@ -65,7 +65,7 @@ test('dedupePatchEntries: 三个同名块 → 只保留第一个', () => {
   assert.strictEqual((r.text.match(/- id: balance/g) || []).length, 1);
 });
 
-test('dedupePatchEntries: 部分重复形态（块含新 id）→ 保留块、移除列表为空（overlay 兜底）', () => {
+test('dedupePatchEntries: insert 块部分重复 → 只删重复注册行，保留块内新注册', () => {
   const input = [
     '- insert:',
     '    - id: balance',
@@ -77,8 +77,61 @@ test('dedupePatchEntries: 部分重复形态（块含新 id）→ 保留块、�
     "      name: '@deepseek-ai/dsh-terminal-tab'",
   ].join('\n');
   const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, ['balance']);
+  assert.strictEqual((r.text.match(/- id: balance/g) || []).length, 1, '重复注册的 balance 行只剩首次注册');
+  assert.strictEqual((r.text.match(/- id: terminal/g) || []).length, 1, '新注册 terminal 保留');
+  assert.ok(r.text.includes('- insert:'), '块头保留');
+  assert.ok(r.text.includes("name: '@deepseek-ai/dsh-terminal-tab'"), 'terminal 的 name 保留');
+});
+
+test('dedupePatchEntries: config 覆盖与 disabled 禁用条目绝不删除（用户配置保留）', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: balance',
+    '  disabled: true',
+    '- insert:',
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+    '- id: terminal',
+    '  config:',
+    '    width: 320',
+  ].join('\n');
+  const r = dedupePatchEntries(input);
   assert.deepStrictEqual(r.removed, []);
-  assert.strictEqual(r.text, input, '极端形态不做行级手术');
+  assert.strictEqual(r.text, input, '无重复注册 → 零写入（config/disabled 覆盖条目原样保留）');
+});
+
+test('dedupePatchEntries: 同一 insert 块内重复注册（罕见形态）→ 行级去重', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '    - id: terminal',
+    "      name: '@deepseek-ai/dsh-terminal-tab'",
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, ['balance']);
+  assert.strictEqual((r.text.match(/- id: balance/g) || []).length, 1, '块内重复注册行移除');
+  assert.strictEqual((r.text.match(/- id: terminal/g) || []).length, 1, 'terminal 保留');
+});
+
+test('dedupePatchEntries: 定向 insert 块（- id: X + insert:）不参与去重', () => {
+  const input = [
+    '- insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+    '- id: extra-group',
+    '  insert:',
+    '    - id: balance',
+    "      name: '@deepseek-ai/dsh-balance'",
+  ].join('\n');
+  const r = dedupePatchEntries(input);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '定向 insert 块原样保留');
 });
 
 test('parseFailedLoaderIds: 三种日志形态', () => {
@@ -186,4 +239,56 @@ test('dropBlocksByIds: 多个命中块全部移除', () => {
   assert.deepStrictEqual(r.removed, ['better-sidebar', 'harness-pet']);
   assert.ok(r.text.includes('id: balance'), '未命中条目保留');
   assert.strictEqual((r.text.match(/id: balance/g) || []).length, 1);
+});
+
+test('dropBlocksByIds: config 覆盖与 disabled 禁用条目绝不删除（bundle 迁移保留用户配置）', () => {
+  const input = [
+    '- insert:',
+    '    - id: better-sidebar',
+    "      name: 'dsh-better-sidebar'",
+    '- id: better-sidebar',
+    '  disabled: true',
+    '- id: better-sidebar',
+    '  config:',
+    '    width: 320',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, ['better-sidebar']);
+  assert.strictEqual((r.text.match(/- id: better-sidebar/g) || []).length, 2, 'disabled 与 config 覆盖条目保留');
+  assert.ok(!r.text.includes("name: 'dsh-better-sidebar'"), '注册行（insert 块）已移除');
+  assert.ok(r.text.includes('disabled: true') && r.text.includes('width: 320'), '用户配置原样保留');
+});
+
+test('dropBlocksByIds: 直注册条目带 config 时不删除（用户配置保留）', () => {
+  const input = [
+    '- id: better-sidebar',
+    "  name: 'dsh-better-sidebar'",
+    '  config:',
+    '    width: 320',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '含 config 的直条目保留');
+});
+
+test('dropBlocksByIds: 直注册条目带 disabled 时不删除（用户禁用意图保留）', () => {
+  const input = [
+    '- id: better-sidebar',
+    "  name: 'dsh-better-sidebar'",
+    '  disabled: true',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '含 disabled 的直条目保留');
+});
+
+test('dropBlocksByIds: 直注册条目带任意自定义键时不删除（用户覆盖条目保留）', () => {
+  const input = [
+    '- id: better-sidebar',
+    "  name: 'dsh-better-sidebar'",
+    '  width: 320',
+  ].join('\n');
+  const r = dropBlocksByIds(input, ['better-sidebar']);
+  assert.deepStrictEqual(r.removed, []);
+  assert.strictEqual(r.text, input, '携带自定义键的直条目保留');
 });


### PR DESCRIPTION
## 概述

修正 issue #17 修复的残留缺陷：main 已合入版的自愈会误删用户 config/disabled 条目。

上游在 main（53b0260）手动合入了 issue #17 自愈的初版实现（ed040ad，对应已关闭的 PR #24 早期版本，该 PR 现已由仓库所有者关闭）。对合入版做最严格审核后发现并实测复现一个破坏性缺陷：按「id 已出现过」对顶层条目做块级去重，会把用户手写的 - id: X + config 覆盖 / disabled 禁用条目一并删除（每次启动静默丢失用户配置），与 cordis.patch.yml 文件头声明的顶层条目形态（config overrides / disables / insert lists）矛盾；「部分重叠交 overlay 兜底」亦不可行（EntryGroup.update 的重复检查先于 disabled 处理，overlay 无法救回该形态）。

## 修复

- dedupePatchEntries 改为注册行级去重（依据 dsh-app-boot pplyEntryPatches 语义：只有 insert 列表内的行是注册，config/disabled 覆盖条目不产生重复注册）：
  - 只删 insert 块内第二次及以后的注册行（连同同缩进兄弟行），保留首次注册；
  - 块内部分重复/块内重复时行级手术；
  - config 覆盖 / disabled 禁用 / 定向 insert / 携带自定义键的覆盖条目逐字节保留；
  - 无重复零写入（幂等）。
- dropBlocksByIds 同样只删注册行：insert 块内行级、整块命中整块删除；顶层直条目仅当「除 id 行外只有 name 行」才整块移除，其余形态绝不删除。
- nsurePatchArray 输出兜底：条目全部移除后补 []，保证文件仍是合法顶层数组（避免下次启动被误判「解析失败」而重置）。
- main.js 自愈注释同步为注册行级语义。
- 新增集成场景 heal-dup-patch-keeps-config（回归防线：用户 config/disabled 条目保留）与 3000 组确定性随机性质单测（幂等、输出可解析、注册唯一、非注册块逐字节保留、零写入）。

## 验证（真实 Electron + 隔离 DSH_HOME，不影响运行中的 dsh）

- 缺陷复现（main 53b0260 实测）：含 - id: balance + disabled: true 与 - id: terminal + config: 的合法 patch，dedupePatchEntries 输出 removed=["balance","terminal"]（用户配置被删）；本 PR 修复后 removed=[]、条目逐字节保留。
- 集成：heal-dup-patch / heal-bundle-patch / heal-dup-patch-keeps-config 三个场景 GREEN（约 46-47s 自愈启动；残留注册行移除、备份生成、用户 config/disabled 条目保留）。
- 全量回归：集成测试 18/18（main 既有 17 场景 + 新场景）、单元测试 55/55（patch-heal 19、fuzz 1、recovery 17、manifest 8、web-search 6、gpu 4）、check-syntax 全入口通过（每集成场景含进程泄漏检查）。

## 兼容性

- 健康 patch 零写入（幂等）；只删重复注册行，用户手写内容（config 覆盖、disabled 禁用、注释、非命中条目）原样保留；
- 不改变任何 IPC/插件接口与设置格式；main 中其它合入内容（#21/#22/#32 等）不受影响；
- 与上游将来对 cordis.patch.yml 的官方修复兼容：锚点语义只依赖 applyEntryPatches 的公开行为。