### PR TITLE
feat: 状态栏新增 OpenCode Go 套餐用量显示

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
@@ -61,6 +61,31 @@ window.__ModuleLoader__.load({
 			return data;
 		}
 
+		/** OpenCode Go 套餐用量展示（官方配额接口 /zen/go/v1/usage 三窗口已用百分比）。 */
+		const GO_LABELS = { rolling: "滚", weekly: "周", monthly: "月" };
+		const GO_WINDOW_ORDER = ["monthly", "weekly", "rolling"];
+		function goUsageText(windows) {
+			return "Go " + GO_WINDOW_ORDER
+				.filter((k) => windows[k])
+				.map((k) => GO_LABELS[k] + (windows[k].percent || 0) + "%")
+				.join(" · ");
+		}
+		function goUsageTitle(windows) {
+			const fmt = (iso) => {
+				try {
+					return new Date(iso).toLocaleString("zh-CN", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" });
+				} catch { return ""; }
+			};
+			const lines = ["OpenCode Go 套餐用量（已用百分比）"];
+			for (const k of GO_WINDOW_ORDER) {
+				const w = windows[k];
+				if (!w) continue;
+				lines.push(GO_LABELS[k] + "：" + (w.percent || 0) + "%" + (w.resetsAt ? "，" + fmt(w.resetsAt) + " 重置" : ""));
+			}
+			lines.push("点击打开 opencode.ai 用量页");
+			return lines.join("\n");
+		}
+
 		function BalanceDock({ useProjection }) {
 			const usage = typeof useProjection === "function" ? useProjection("tokenUsage") : void 0;
 			const data = useBalanceData();
@@ -71,14 +96,15 @@ window.__ModuleLoader__.load({
 			const primary = balances.find((b) => b.currency === "CNY") || balances[0];
 			const hasBalance = !!(data && data.ok && primary);
 			const usageKnown = hasUsage(usage);
-			if (!hasBalance && !usageKnown) return null;
+			const go = data && data.opencodeGo && data.opencodeGo.ok && data.opencodeGo.windows ? data.opencodeGo.windows : null;
+			if (!hasBalance && !usageKnown && !go) return null;
 			const parts = [];
 			if (usageKnown) parts.push("本轮 ¥" + money(sessionCost(usage, prices)));
 			if (hasBalance) parts.push("余额 ¥" + money(primary.total));
 			const title = hasBalance
 				? `${primary.currency} 余额 ¥${money(primary.total)}（充值 ¥${money(primary.toppedUp)} · 赠送 ¥${money(primary.granted)}）；本轮费用按 token 用量估算（¥/百万 token：命中 ${prices?.cacheHit ?? FALLBACK_PRICES.cacheHit} / 未命中 ${prices?.cacheMiss ?? FALLBACK_PRICES.cacheMiss} / 输出 ${prices?.output ?? FALLBACK_PRICES.output}${data.model ? " · " + data.model : ""}${typeof data.peak === "boolean" ? (data.peak ? " · 高峰价" : " · 空闲价") : ""}），点击前往充值`
 				: "本轮费用按 token 用量估算；未读取到 DeepSeek API Key，无法显示余额";
-			return react_jsx_runtime.jsx("a", {
+			const dock = react_jsx_runtime.jsx("a", {
 				className: "dsh-balance-dock",
 				href: "https://platform.deepseek.com/top_up",
 				target: "_blank",
@@ -86,9 +112,24 @@ window.__ModuleLoader__.load({
 				title,
 				children: parts.join(" · ")
 			});
+			if (!go) return dock;
+			const goDock = react_jsx_runtime.jsx("a", {
+				className: "dsh-balance-dock dsh-balance-go",
+				href: "https://opencode.ai",
+				target: "_blank",
+				rel: "noreferrer",
+				title: goUsageTitle(go),
+				children: goUsageText(go)
+			});
+			if (!usageKnown && !hasBalance) return goDock;
+			return react_jsx_runtime.jsx("span", {
+				className: "dsh-balance-wrap",
+				children: [dock, goDock]
+			});
 		}
 
 		const CSS = [
+			".dsh-balance-wrap{display:inline-flex;align-items:center;gap:4px}",
 			".dsh-balance-dock{display:inline-flex;align-items:center;box-sizing:border-box;",
 			"color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:16px;text-decoration:none;",
 			"white-space:nowrap;border:1px solid var(--dsw-alias-border-l1);border-radius:999px;",

--- a/dsh-desktop/balance.js
+++ b/dsh-desktop/balance.js
@@ -87,6 +87,49 @@ function readApiKey(dshHome) {
   return '';
 }
 
+// 从 env 或 ~/.dsh/.credentials.yaml 读取任意凭据条目（与 readApiKey 同构）。
+function readCredentialValue(dshHome, name) {
+  const envKey = process.env[name];
+  if (envKey) return envKey.trim();
+  try {
+    const text = fs.readFileSync(path.join(dshHome, '.credentials.yaml'), 'utf8');
+    const re = new RegExp('^\\s*' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*:\\s*["\']?([^"\'\\s#]+)');
+    for (const line of text.split(/\r?\n/)) {
+      const m = line.match(re);
+      if (m) return m[1];
+    }
+  } catch {}
+  return '';
+}
+
+// OpenCode Go 套餐用量查询（官方配额接口：GET https://opencode.ai/zen/go/v1/usage，
+// Authorization: Bearer <OPENCODE_GO_API_KEY>）。响应：
+//   { usage: { rolling, weekly, monthly: { percent, status, resetsAt } } }
+// 三个窗口均为「套餐额度已用百分比」。失败只影响本 provider，不影响 DeepSeek 余额。
+async function queryOpenCodeGoUsage(dshHome) {
+  const key = readCredentialValue(dshHome, 'OPENCODE_GO_API_KEY');
+  if (!key) return { ok: false, error: 'no-key' };
+  try {
+    const data = await fetchJson('https://opencode.ai/zen/go/v1/usage', key);
+    const u = (data && data.usage) || {};
+    const windows = {};
+    for (const k of ['rolling', 'weekly', 'monthly']) {
+      const v = u[k];
+      if (v && typeof v === 'object') {
+        windows[k] = {
+          percent: Number(v.percent) || 0,
+          status: String(v.status || ''),
+          resetsAt: v.resetsAt ? new Date(v.resetsAt).toISOString() : '',
+        };
+      }
+    }
+    if (!Object.keys(windows).length) return { ok: false, error: 'empty usage payload' };
+    return { ok: true, windows };
+  } catch (err) {
+    return { ok: false, error: String((err && err.message) || err) };
+  }
+}
+
 // 当前默认模型（~/.dsh/settings.yaml 的 agent-default-model.model），
 // 决定按哪一档价格估算本轮费用。
 function readActiveModel(dshHome) {
@@ -152,6 +195,8 @@ async function queryBalance(dshHome) {
 
 module.exports = {
   queryBalance,
+  queryOpenCodeGoUsage,
+  readCredentialValue,
   readActiveModel,
   effectivePrice,
   isPeakHour,

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -2517,17 +2517,25 @@ async function refreshBalance() {
     return result;
   }
   const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  let result;
-  try {
-    result = await balance.queryBalance(home);
-  } catch (err) {
-    result = { ok: false, error: String((err && err.message) || err), balances: [] };
-  }
+  // DeepSeek 余额 + OpenCode Go 套餐用量并行查询（失败隔离，各自独立兜底）。
+  const [bal, go] = await Promise.all([
+    (async () => {
+      try { return await balance.queryBalance(home); }
+      catch (err) { return { ok: false, error: String((err && err.message) || err), balances: [] }; }
+    })(),
+    (async () => {
+      try { return await balance.queryOpenCodeGoUsage(home); }
+      catch (err) { return { ok: false, error: String((err && err.message) || err) }; }
+    })(),
+  ]);
+  let result = bal;
   // 按当前默认模型 + 当前时段（峰谷）计算有效单价；settings.json 的
-  // balancePrices.<model> 可整体覆盖该模型的单价。
+  // balancePrices.<model> 可整体覆盖该模型的单价；showOpenCodeGoUsage:false
+  // 可关闭 Go 套餐用量（查询与展示一并关闭）。
   const model = balance.readActiveModel(home) || 'deepseek-v4-pro';
   const s = updater.loadSettings(updCtx());
   const override = s.balancePrices && s.balancePrices[model];
+  if (s.showOpenCodeGoUsage !== false) result.opencodeGo = go;
   result.prices = { ...balance.effectivePrice(model), ...(override || {}) };
   result.model = model;
   result.peak = balance.isPeakHour();


### PR DESCRIPTION
## 改动内容

状态栏（`conversation.composer.dock` 余额胶囊旁）新增 **OpenCode Go 套餐用量**显示：

- **`dsh-desktop/balance.js`**
  - 新增 `readCredentialValue()`：从环境变量或 `~/.dsh/.credentials.yaml` 读取任意凭据条目（与 `readApiKey` 同构）
  - 新增 `queryOpenCodeGoUsage()`：调用官方配额接口 `GET https://opencode.ai/zen/go/v1/usage`（`Authorization: Bearer <OPENCODE_GO_API_KEY>`），解析 `rolling / weekly / monthly` 三个窗口的「已用百分比 + 状态 + 重置时间」；无凭据/接口失败只影响本 provider，不影响 DeepSeek 余额查询
- **`dsh-desktop/main.js`**（`refreshBalance()`）
  - DeepSeek 余额与 Go 用量改为 `Promise.all` **并行查询**，各自 try/catch 失败隔离
  - 结果挂载到 `result.opencodeGo`；`settings` 中 `showOpenCodeGoUsage: false` 可整体关闭（查询与展示一并关闭）
- **`dsh-desktop/assets/plugins/dsh-balance/lib/client.js`**
  - 余额胶囊旁新增「Go 月x% · 周x% · 滚x%」小胶囊，title 悬浮显示各窗口百分比与重置时间，点击跳转 `opencode.ai`
  - 新增 `.dsh-balance-wrap` 样式，无余额时也可独立展示 Go 用量

## 凭据配置

```yaml
# ~/.dsh/.credentials.yaml
OPENCODE_GO_API_KEY: sk-xxxx
```

或环境变量 `OPENCODE_GO_API_KEY`。

## 测试方法

1. 配置 `OPENCODE_GO_API_KEY` 后重启客户端，状态栏应出现「Go 月x% · 周x% · 滚x%」胶囊
2. 不配置凭据：只显示 DeepSeek 余额，无报错
3. `settings.json` 设 `"showOpenCodeGoUsage": false`：Go 胶囊消失
4. 断网/接口异常：仅 Go 胶囊不显示，余额查询不受影响

## 效果预览

状态栏示例：`本轮 ¥0.02 · 余额 ¥123.45 · Go 月34% · 周67% · 滚12%`，悬浮 Go 胶囊显示各窗口重置时间。
