### PR TITLE
feat: 设置页「插件」页融合为单一「管理」标签——全量清单 + 搜索/分类/双视图 + 一键开关

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -5,6 +5,11 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 
 
 
+## [Unreleased]
+
+### 新增
+- **设置页「插件」页融合为单一「管理」标签（`dsh-plugin-manager`）**：启动时幂等隐藏官方只读「全部」清单（`applyPluginInventoryTabMergeFix` 过滤 `settings.plugins.tab` 中 id 为 `all` 的条目），管理标签成为唯一插件入口——**搜索框**（按名称/包名/描述过滤）+ **可点击分类标签**（配套插件可开关 / 其他插件可开关 / 核心组件只读，点击过滤、再点取消，各组显示启用/关闭计数）+ **双视图**（简洁：名称+包名+开关 / 详情：+状态徽章+中文描述）+ 全量 live 清单与本地清单融合（描述取自各插件 package.json）+ **乐观 UI 开关**（点击立即翻转勾选框并标记「重启后生效」，写盘失败自动回滚）。关闭/重新打开写入 web profile `cordis.patch.yml` 的用户层 `disabled` 条目（与 `llm-deepseek` 同款覆盖机制，同一 id 只保留一处，避免 loader 双登记崩溃），完全退出并重启 DSH Desktop 生效。解决「插件看不懂作用、默认启用无法关闭」的社区反馈
+
 ## [0.3.9] — 2026-08-16
 
 ### 新增

--- a/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
@@ -47,6 +47,60 @@ window.__ModuleLoader__.load({
 			children: text
 		});
 
+		// 简洁视图卡片网格的窄屏适配（与官方清单页同款：≤680px 收成单列）。
+		const PM_CSS_ID = "@deepseek-ai/dsh-plugin-manager/compact-grid.css";
+		if (typeof document !== "undefined" && !document.querySelector("style[data-plugin-css=\"" + PM_CSS_ID + "\"]")) {
+			const st = document.createElement("style");
+			st.dataset.plugin = "@deepseek-ai/dsh-plugin-manager";
+			st.dataset.pluginCss = PM_CSS_ID;
+			st.textContent = "@media (width <= 680px){.dshpm-cards{grid-template-columns:minmax(0,1fr) !important}}";
+			document.head.appendChild(st);
+		}
+
+		/** 包名短名（去掉 @scope/ 前缀，如 @deepseek-ai/dsh-balance → dsh-balance）。 */
+		const pkgShort = (name) => {
+			const s = String(name || "");
+			const i = s.indexOf("/");
+			return i >= 0 ? s.slice(i + 1) : s;
+		};
+
+		/** 迷你开关（简洁视图卡片用）。 */
+		const switchControl = (row, on, onToggle, pending) => {
+			const disabled = !row.toggleable || pending;
+			return jsx("button", {
+				type: "button",
+				role: "switch",
+				"aria-checked": on,
+				"aria-label": row.id,
+				disabled,
+				onClick: () => onToggle(row, !on),
+				style: {
+					position: "relative",
+					width: 32,
+					height: 18,
+					borderRadius: 999,
+					border: "1px solid " + (on ? "var(--dsw-alias-state-success-primary, #4caf7d)" : "var(--dsw-alias-border-l2, rgba(128,128,128,0.35))"),
+					background: on ? "color-mix(in srgb, var(--dsw-alias-state-success-primary, #4caf7d) 30%, transparent)" : "transparent",
+					cursor: row.toggleable ? "pointer" : "not-allowed",
+					flex: "none",
+					padding: 0,
+					opacity: disabled ? 0.55 : 1
+				},
+				children: jsx("span", {
+					style: {
+						position: "absolute",
+						top: 2,
+						left: on ? 18 : 2,
+						width: 12,
+						height: 12,
+						borderRadius: 999,
+						background: on ? "var(--dsw-alias-state-success-primary, #4caf7d)" : "var(--dsw-alias-label-tertiary, rgba(128,128,128,0.6))",
+						transition: "left .14s var(--ds-ease-in-out, ease)"
+					}
+				})
+			});
+		};
+
 		/** 归一化 live 注册表返回：可能 {ok,value} / {entries} / 数组。 */
 		function normalizeLive(result) {
 			if (Array.isArray(result)) return result;
@@ -196,29 +250,48 @@ window.__ModuleLoader__.load({
 			const rowName = (row) => (/^[0-9a-f]{8}$/i.test(row.id) ? null : row.id);
 			const rowPkg = (row) => row.title;
 
-			/** 简洁视图行：名称 + 包名 + 开关（悬停显示描述）。 */
-			const renderCompactRow = (row) => jsx("div", {
-				key: row.id,
-				style: { display: "flex", alignItems: "center", gap: 10, padding: "6px 0", borderBottom: "1px solid var(--dsw-alias-divider-weak, rgba(128,128,128,0.14))" },
-				children: [
-					jsxs("span", {
-						style: { flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", opacity: rowValue(row) ? 1 : 0.5 },
-						title: row.description || L.descFallback,
-						children: [
-							jsx("span", { style: { fontWeight: 600 }, children: rowName(row) || rowPkg(row) }),
-							rowName(row) ? jsx("span", { style: { fontSize: 12, opacity: 0.55, marginLeft: 8 }, children: rowPkg(row) }) : null
-						]
-					}),
-					rowDirty(row) ? badge(L.badgePending, "var(--dsw-alias-state-info-primary, #5b9bd5)") : null,
-					jsx("input", {
-						type: "checkbox",
-						checked: rowValue(row),
-						disabled: !row.toggleable || pendingId === row.id,
-						onChange: () => onToggle(row, !rowValue(row)),
-						style: { marginLeft: 8, cursor: row.toggleable ? "pointer" : "not-allowed" }
-					})
-				]
-			});
+			/** 简洁视图卡片（官方清单页同款：标题 + 状态圆点 + 开关）。 */
+			const renderCompactCard = (row) => {
+				const on = rowValue(row);
+				const failed = row.phase === "failed";
+				const dotColor = failed
+					? "var(--dsw-alias-state-error-primary, #ff7a85)"
+					: on
+						? "var(--dsw-alias-state-success-primary, #4caf7d)"
+						: "var(--dsw-alias-label-tertiary, rgba(128,128,128,0.5))";
+				const name = rowName(row) || rowPkg(row);
+				const short = rowName(row) ? pkgShort(rowPkg(row)) : null;
+				return jsxs("div", {
+					key: row.id,
+					title: row.description || L.descFallback,
+					style: {
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "space-between",
+						gap: 10,
+						minWidth: 0,
+						padding: "10px 12px",
+						border: "1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.35))",
+						borderRadius: 10,
+						background: "var(--dsw-alias-bg-layer-3, transparent)",
+						opacity: on ? 1 : 0.62
+					},
+					children: [
+						jsxs("span", {
+							style: { display: "flex", alignItems: "baseline", minWidth: 0, overflow: "hidden" },
+							children: [
+								jsx("span", { style: { fontWeight: 600, fontSize: 13, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: name }),
+								short ? jsx("span", { style: { fontSize: 11, opacity: 0.5, marginLeft: 6, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: short }) : null
+							]
+						}),
+						jsxs("div", { style: { display: "flex", alignItems: "center", gap: 8, flex: "none" }, children: [
+							rowDirty(row) ? badge(L.badgePending, "var(--dsw-alias-state-info-primary, #5b9bd5)") : null,
+							jsx("span", { style: { width: 7, height: 7, borderRadius: 999, background: dotColor, flex: "none" } }),
+							switchControl(row, on, onToggle, pendingId === row.id)
+						] })
+					]
+				});
+			};
 
 			/** 详情视图行：名称 + 包名 + 状态徽章 + 描述 + 开关。 */
 			const renderDetailRow = (row) => jsx("div", {
@@ -260,7 +333,7 @@ window.__ModuleLoader__.load({
 				};
 				const shown = cat === "all" ? base : groups[cat];
 				if (shown.length === 0) return jsx("div", { style: { fontSize: 12, opacity: 0.7, marginTop: 8 }, children: L.noMatch });
-				const renderRow = view === "compact" ? renderCompactRow : renderDetailRow;
+				const compact = view === "compact";
 				const group = (title, note, items) => items.length === 0 ? null : jsxs("div", {
 					children: [
 						jsxs("div", { style: { fontWeight: 600, fontSize: 13, margin: "14px 0 2px" }, children: [
@@ -268,7 +341,9 @@ window.__ModuleLoader__.load({
 							jsx("span", { style: { fontSize: 12, opacity: 0.55, marginLeft: 8 }, children: note + " · " + items.length }),
 							jsx("span", { style: { fontSize: 12, opacity: 0.4, marginLeft: 8 }, children: items.filter((r) => rowValue(r)).length + " 启用 / " + items.filter((r) => !rowValue(r)).length + " 关闭" })
 						] }),
-						items.map(renderRow)
+						compact
+							? jsx("div", { className: "dshpm-cards", style: { display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 10, marginTop: 6 }, children: items.map(renderCompactCard) })
+							: items.map(renderDetailRow)
 					]
 				});
 				if (cat !== "all") {

--- a/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
@@ -1,0 +1,377 @@
+window.__ModuleLoader__.load({
+	id: "@deepseek-ai/dsh-plugin-manager",
+	factory: (require) => {
+		var module = { exports: {} };
+		var exports = module.exports;
+		Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+
+		const react = require("react");
+		const { jsx, jsxs } = require("react/jsx-runtime");
+
+		const L = {
+			tab: "管理",
+			tabHint: "搜索插件、点击分类标签过滤；配套/其他插件可一键关闭，完全退出并重启 DSH Desktop 后生效。",
+			searchPlaceholder: "搜索插件（名称 / id / 描述）…",
+			viewCompact: "简洁",
+			viewDetail: "详情",
+			catAll: "全部",
+			groupCompanion: "配套插件",
+			groupOther: "其他插件",
+			groupCore: "核心组件",
+			groupToggleableNote: "可开关",
+			groupReadonlyNote: "不可关闭",
+			descFallback: "（无描述）",
+			badgeEnabled: "已启用",
+			badgeDisabled: "已关闭",
+			badgePending: "重启后生效",
+			badgeFailed: "挂载失败",
+			badgePendingLoad: "加载中",
+			loading: "加载中…",
+			errorPrefix: "插件清单加载失败：",
+			noBridge: "插件管理桥接不可用（请确认已更新到最新版 DSH Desktop）",
+			toastFailed: "操作失败：",
+			refresh: "刷新",
+			noMatch: "没有匹配的插件",
+			localOnlyHint: "（清单来自本地文件，实时注册表暂不可用）",
+			countSuffix: "个插件"
+		};
+
+		function bridge() {
+			const b = window.dshDesktop;
+			if (!b || !b.pluginManager || typeof b.pluginManager.list !== "function") return null;
+			return b.pluginManager;
+		}
+
+		const badge = (text, color) => jsx("span", {
+			style: { fontSize: 11, padding: "1px 8px", borderRadius: 8, border: "1px solid currentColor", color, marginLeft: 6, whiteSpace: "nowrap" },
+			children: text
+		});
+
+		/** 归一化 live 注册表返回：可能 {ok,value} / {entries} / 数组。 */
+		function normalizeLive(result) {
+			if (Array.isArray(result)) return result;
+			if (result && Array.isArray(result.entries)) return result.entries;
+			if (result && result.ok && Array.isArray(result.value)) return result.value;
+			if (result && result.ok && result.value && Array.isArray(result.value.entries)) return result.value.entries;
+			return null;
+		}
+
+		function PluginManagerTab({ list }) {
+			const [rows, setRows] = react.useState(null);
+			const [error, setError] = react.useState(null);
+			const [localOnly, setLocalOnly] = react.useState(false);
+			const [pendingId, setPendingId] = react.useState(null);
+			// 乐观 UI：点击立即反映到勾选框与「重启后生效」标记（id → 期望值）
+			const [pendingMap, setPendingMap] = react.useState({});
+			const [query, setQuery] = react.useState("");
+			const [view, setView] = react.useState("detail"); // compact | detail
+			const [cat, setCat] = react.useState("all"); // all | companion | other | core
+			const [refreshTick, setRefreshTick] = react.useState(0);
+
+			react.useEffect(() => {
+				let cancelled = false;
+				(async () => {
+					setError(null);
+					// 1) 本地桥：完整（配套/用户/核心 bundle）+ 描述 + 可开关集合 —— 主数据源
+					const b = bridge();
+					let mine = [];
+					if (b && typeof b.list === "function") {
+						try {
+							const data = await b.list();
+							if (Array.isArray(data)) mine = data;
+						} catch (err) {
+							console.error("[dsh-plugin-manager] 本地桥 list 失败:", err);
+						}
+					}
+					// 2) live 注册表：尽力补充（核心组件全集），失败不阻塞
+					let live = [];
+					let liveOk = false;
+					try {
+						const raw = await list();
+						const entries = normalizeLive(raw);
+						if (entries) { live = entries; liveOk = true; }
+						else console.warn("[dsh-plugin-manager] live list 返回异常形状:", raw);
+					} catch (err) {
+						console.warn("[dsh-plugin-manager] live list 失败（降级本地清单）:", err);
+					}
+					if (cancelled) return;
+
+					const toggleableById = new Map(mine.filter((r) => r && r.toggleable).map((r) => [r.id, r]));
+					const descById = new Map(mine.map((r) => [r.id, r.description]));
+					const liveIds = new Set(live.filter((e) => e && e.entryId !== void 0).map((e) => e.entryId));
+					const byId = new Map();
+					for (const r of mine) {
+						// live 可用时：本地推导的占位核心行（manifest 包名 ≠ 真实 loader 条目 id，
+						// 如 dsh-web-app → web-runtime）不展示，避免与「全部」标签对不上；
+						// 可开关行即使当前未加载（如已禁用的 balance）也必须展示，否则无法重新打开。
+						if (liveOk && !r.toggleable && !liveIds.has(r.id)) continue;
+						if (!byId.has(r.id)) byId.set(r.id, {
+							id: r.id,
+							title: r.name || r.id,
+							enabled: !!r.enabled,
+							phase: "",
+							description: r.description || "",
+							toggleable: !!r.toggleable,
+							from: "local"
+						});
+					}
+					for (const e of live) {
+						if (!e || typeof e !== "object" || e.entryId === void 0) continue;
+						const row = byId.get(e.entryId);
+						if (row) {
+							row.enabled = !!e.enabled;
+							row.phase = e.fiberPhase || row.phase;
+						} else {
+							byId.set(e.entryId, {
+								id: e.entryId,
+								title: e.moduleName || e.entryId,
+								enabled: !!e.enabled,
+								phase: e.fiberPhase || "",
+								description: descById.get(e.entryId) || "",
+								toggleable: toggleableById.has(e.entryId),
+								from: "live"
+							});
+						}
+					}
+					const mapped = [...byId.values()].sort((a, b) => {
+						const ga = a.toggleable ? 0 : 1, gb = b.toggleable ? 0 : 1;
+						return ga - gb || a.title.localeCompare(b.title);
+					});
+					if (!cancelled) {
+						setRows(mapped);
+						setLocalOnly(!liveOk && mapped.length > 0);
+					}
+				})();
+				return () => { cancelled = true; };
+			}, [list, refreshTick]);
+
+			const onToggle = (row, enabled) => {
+				const b = bridge();
+				if (!b || !row || !row.toggleable) return;
+				// 1) 立即反映到 UI（打勾/取消 + 「重启后生效」标记）
+				setPendingMap((prev) => ({ ...prev, [row.id]: enabled }));
+				setPendingId(row.id);
+				// 2) 写盘（失败则回滚 UI 并提示）
+				b.setEnabled(row.id, enabled).then((res) => {
+					setPendingId(null);
+					if (res && res.ok) {
+						// pendingMap 保留：重启前一直显示新状态 + 标记
+					} else {
+						setPendingMap((prev) => {
+							const next = { ...prev };
+							delete next[row.id];
+							return next;
+						});
+						setError(L.toastFailed + String((res && res.error) || "未知错误"));
+					}
+				}).catch((err) => {
+					setPendingId(null);
+					setPendingMap((prev) => {
+						const next = { ...prev };
+						delete next[row.id];
+						return next;
+					});
+					setError(L.toastFailed + String((err && err.message) || err));
+				});
+			};
+
+			/** 行当前显示值：有未生效的点击 → 新值；否则实际状态。 */
+			const rowValue = (row) => (row.id in pendingMap ? pendingMap[row.id] : row.enabled);
+			const rowDirty = (row) => row.id in pendingMap;
+			const rowCat = (row) => (row.toggleable ? (row.id === "llm-deepseek" ? "other" : "companion") : "core");
+
+			const matches = (row) => {
+				if (!query) return true;
+				const q = query.toLowerCase();
+				return (row.title + " " + row.id + " " + row.description).toLowerCase().includes(q);
+			};
+
+			const phaseBadge = (row) => {
+				if (row.phase === "failed") return badge(L.badgeFailed, "var(--dsw-alias-state-error-primary, #ff7a85)");
+				if (row.phase === "loading" || row.phase === "pending") return badge(L.badgePendingLoad, "var(--dsw-alias-state-info-primary, #5b9bd5)");
+				return null;
+			};
+
+			/** 行显示名：名称（可读 id）+ 包名（moduleName/package）；匿名 id 退化为只显包名。 */
+			const rowName = (row) => (/^[0-9a-f]{8}$/i.test(row.id) ? null : row.id);
+			const rowPkg = (row) => row.title;
+
+			/** 简洁视图行：名称 + 包名 + 开关（悬停显示描述）。 */
+			const renderCompactRow = (row) => jsx("div", {
+				key: row.id,
+				style: { display: "flex", alignItems: "center", gap: 10, padding: "6px 0", borderBottom: "1px solid var(--dsw-alias-divider-weak, rgba(128,128,128,0.14))" },
+				children: [
+					jsxs("span", {
+						style: { flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", opacity: rowValue(row) ? 1 : 0.5 },
+						title: row.description || L.descFallback,
+						children: [
+							jsx("span", { style: { fontWeight: 600 }, children: rowName(row) || rowPkg(row) }),
+							rowName(row) ? jsx("span", { style: { fontSize: 12, opacity: 0.55, marginLeft: 8 }, children: rowPkg(row) }) : null
+						]
+					}),
+					rowDirty(row) ? badge(L.badgePending, "var(--dsw-alias-state-info-primary, #5b9bd5)") : null,
+					jsx("input", {
+						type: "checkbox",
+						checked: rowValue(row),
+						disabled: !row.toggleable || pendingId === row.id,
+						onChange: () => onToggle(row, !rowValue(row)),
+						style: { marginLeft: 8, cursor: row.toggleable ? "pointer" : "not-allowed" }
+					})
+				]
+			});
+
+			/** 详情视图行：名称 + 包名 + 状态徽章 + 描述 + 开关。 */
+			const renderDetailRow = (row) => jsx("div", {
+				key: row.id,
+				style: { display: "flex", alignItems: "flex-start", gap: 10, padding: "9px 0", borderBottom: "1px solid var(--dsw-alias-divider-weak, rgba(128,128,128,0.16))" },
+				children: [
+					jsx("div", {
+						style: { flex: 1, display: "flex", flexDirection: "column", gap: 3, minWidth: 0 },
+						children: [
+							jsxs("div", { children: [
+								jsx("span", { style: { fontWeight: 600 }, children: rowName(row) || rowPkg(row) }),
+								jsx("span", { style: { fontSize: 12, opacity: 0.55, marginLeft: 8 }, children: rowPkg(row) }),
+								rowValue(row) ? badge(L.badgeEnabled, "var(--dsw-alias-state-success-primary, #4caf7d)") : badge(L.badgeDisabled, "var(--dsw-alias-state-warning-primary, #d99a3d)"),
+								phaseBadge(row),
+								rowDirty(row) ? badge(L.badgePending, "var(--dsw-alias-state-info-primary, #5b9bd5)") : null
+							] }),
+							jsx("span", { style: { fontSize: 12, opacity: 0.65, lineHeight: 1.5 }, children: row.description || L.descFallback })
+						]
+					}),
+					jsx("input", {
+						type: "checkbox",
+						checked: rowValue(row),
+						disabled: !row.toggleable || pendingId === row.id,
+						onChange: () => onToggle(row, !rowValue(row)),
+						style: { marginTop: 2, cursor: row.toggleable ? "pointer" : "not-allowed" }
+					})
+				]
+			});
+
+			const renderBody = () => {
+				if (error) return jsx("div", { style: { fontSize: 12, color: "var(--dsw-alias-state-error-primary, #ff7a85)", marginTop: 8 }, children: error });
+				if (!rows) return jsx("div", { style: { fontSize: 12, opacity: 0.7, marginTop: 8 }, children: L.loading });
+				const base = rows.filter(matches);
+				if (base.length === 0) return jsx("div", { style: { fontSize: 12, opacity: 0.7, marginTop: 8 }, children: L.noMatch });
+				const groups = {
+					companion: base.filter((r) => rowCat(r) === "companion"),
+					other: base.filter((r) => rowCat(r) === "other"),
+					core: base.filter((r) => rowCat(r) === "core")
+				};
+				const shown = cat === "all" ? base : groups[cat];
+				if (shown.length === 0) return jsx("div", { style: { fontSize: 12, opacity: 0.7, marginTop: 8 }, children: L.noMatch });
+				const renderRow = view === "compact" ? renderCompactRow : renderDetailRow;
+				const group = (title, note, items) => items.length === 0 ? null : jsxs("div", {
+					children: [
+						jsxs("div", { style: { fontWeight: 600, fontSize: 13, margin: "14px 0 2px" }, children: [
+							jsx("span", { children: title }),
+							jsx("span", { style: { fontSize: 12, opacity: 0.55, marginLeft: 8 }, children: note + " · " + items.length }),
+							jsx("span", { style: { fontSize: 12, opacity: 0.4, marginLeft: 8 }, children: items.filter((r) => rowValue(r)).length + " 启用 / " + items.filter((r) => !rowValue(r)).length + " 关闭" })
+						] }),
+						items.map(renderRow)
+					]
+				});
+				if (cat !== "all") {
+					const meta = { companion: [L.groupCompanion, L.groupToggleableNote], other: [L.groupOther, L.groupToggleableNote], core: [L.groupCore, L.groupReadonlyNote] };
+					const [title, note] = meta[cat];
+					return group(title, note, shown);
+				}
+				return jsxs("div", {
+					children: [
+						group(L.groupCompanion, L.groupToggleableNote, groups.companion),
+						group(L.groupOther, L.groupToggleableNote, groups.other),
+						group(L.groupCore, L.groupReadonlyNote, groups.core)
+					]
+				});
+			};
+
+			/** 分类标签（可点击过滤）。 */
+			const chipStyle = (active) => ({
+				fontSize: 12,
+				padding: "3px 12px",
+				borderRadius: 12,
+				border: "1px solid " + (active ? "var(--dsw-alias-state-info-primary, #5b9bd5)" : "var(--dsw-alias-border-l2, rgba(128,128,128,0.35))"),
+				background: active ? "color-mix(in srgb, var(--dsw-alias-state-info-primary, #5b9bd5) 12%, transparent)" : "transparent",
+				color: active ? "var(--dsw-alias-state-info-primary, #5b9bd5)" : "inherit",
+				cursor: "pointer"
+			});
+			const chip = (key, label, count) => jsx("button", {
+				type: "button",
+				key: key,
+				onClick: () => setCat((c) => (c === key ? "all" : key)),
+				style: chipStyle(cat === key),
+				children: label + " · " + count
+			});
+
+			const renderChips = () => {
+				if (!rows) return null;
+				const base = rows.filter(matches);
+				const n = (k) => base.filter((r) => rowCat(r) === k).length;
+				return jsxs("div", { style: { display: "flex", gap: 8, marginTop: 10, flexWrap: "wrap" }, children: [
+					chip("all", L.catAll, base.length),
+					chip("companion", L.groupCompanion, n("companion")),
+					chip("other", L.groupOther, n("other")),
+					chip("core", L.groupCore, n("core"))
+				] });
+			};
+
+			return jsxs("div", { children: [
+				jsx("span", { style: { fontSize: 12, opacity: 0.65 }, children: L.tabHint }),
+				rows ? jsxs("div", { style: { display: "flex", alignItems: "center", gap: 10, marginTop: 10 }, children: [
+					jsx("input", {
+						type: "search",
+						placeholder: L.searchPlaceholder,
+						value: query,
+						onChange: (e) => setQuery(e.target.value),
+						style: { flex: 1, maxWidth: 360, fontSize: 13, padding: "5px 10px", borderRadius: 8, border: "1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.35))", background: "transparent", color: "inherit" }
+					}),
+					jsx("span", { style: { fontSize: 12, opacity: 0.6 }, children: rows.length + " " + L.countSuffix }),
+					jsxs("div", { style: { display: "flex", gap: 4 }, children: [
+						jsx("button", {
+							type: "button",
+							onClick: () => setView("compact"),
+							style: { fontSize: 12, padding: "3px 10px", borderRadius: 8, cursor: "pointer", border: "1px solid " + (view === "compact" ? "var(--dsw-alias-state-info-primary, #5b9bd5)" : "var(--dsw-alias-border-l2, rgba(128,128,128,0.35))"), color: view === "compact" ? "var(--dsw-alias-state-info-primary, #5b9bd5)" : "inherit" },
+							children: L.viewCompact
+						}),
+						jsx("button", {
+							type: "button",
+							onClick: () => setView("detail"),
+							style: { fontSize: 12, padding: "3px 10px", borderRadius: 8, cursor: "pointer", border: "1px solid " + (view === "detail" ? "var(--dsw-alias-state-info-primary, #5b9bd5)" : "var(--dsw-alias-border-l2, rgba(128,128,128,0.35))"), color: view === "detail" ? "var(--dsw-alias-state-info-primary, #5b9bd5)" : "inherit" },
+							children: L.viewDetail
+						})
+					] }),
+					jsx("button", {
+						type: "button",
+						onClick: () => setRefreshTick((v) => v + 1),
+						style: { fontSize: 12, cursor: "pointer" },
+						children: L.refresh
+					})
+				] }) : null,
+				renderChips(),
+				localOnly ? jsx("div", { style: { fontSize: 12, opacity: 0.6, marginTop: 6 }, children: L.localOnlyHint }) : null,
+				renderBody()
+			] });
+		}
+
+		function apply(ctx) {
+			const list = async () => {
+				const result = await ctx.remote.pluginInventory.list();
+				if (!result.ok) throw new Error(`pluginInventory.list failed: ${result.error.code}: ${result.error.message}`);
+				return result.value;
+			};
+			const injected = () => ({ list });
+			ctx.slots.inject("settings.plugins.tab", () => ctx.slots.register({
+				name: "settings.plugins.tab",
+				id: "manage",
+				order: 20,
+				label: () => L.tab,
+				inject: injected
+			}, PluginManagerTab), "dsh-plugin-manager: plugins management tab");
+		}
+
+		const inject = ["slots", "remote", "remote.pluginInventory"];
+		exports.apply = apply;
+		exports.inject = inject;
+		return module.exports;
+	}
+});

--- a/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/index.js
@@ -1,0 +1,13 @@
+// Host-side entry: this companion package has no server half — the plugin
+// list and enable/disable toggles are served by the DSH Desktop shell's main
+// process through the preload bridge (window.dshDesktop.pluginManager):
+//   list()       → every bundled/user/core plugin with description & enabled state
+//   setEnabled() → write/remove the user-layer disabled entry in the web
+//                  profile's cordis.patch.yml (takes effect on next app start)
+// The loader rejects an empty default export, so the host half is a valid
+// no-op Cordis plugin (same pattern as dsh-compaction-settings /
+// dsh-wsl-settings / dsh-balance).
+const name = 'dsh-plugin-manager';
+const inject = [];
+function apply() {}
+export { apply, inject, name };

--- a/dsh-desktop/assets/plugins/dsh-plugin-manager/package.json
+++ b/dsh-desktop/assets/plugins/dsh-plugin-manager/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@deepseek-ai/dsh-plugin-manager",
+  "version": "0.1.0",
+  "private": true,
+  "description": "DSH Desktop 配套插件：设置页「插件」栏——列出全部内置插件及其作用（含核心组件），配套插件可一键关闭（写入 web profile 的 cordis.patch.yml disabled 条目，重启生效）",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": { "default": "./lib/index.js" },
+    "./client": { "default": "./lib/client.js" },
+    "./package.json": "./package.json"
+  },
+  "license": "MIT",
+  "dsh": {
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-runtime",
+        "@deepseek-ai/dsh-client-ui-settings"
+      ],
+      "platform": "web"
+    }
+  },
+  "peerDependencies": {
+    "@deepseek-ai/dsh-client-ui-settings": "*",
+    "@deepseek-ai/dsh-client-ui-primitives": "*",
+    "react": ">=18"
+  }
+}

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -27,6 +27,7 @@ const clientUpdater = require('./client-updater');
 const balance = require('./balance');
 const wslBackend = require('./wsl-backend');
 const { createGpuCrashGuard } = require('./scripts/gpu-crash-guard');
+const { togglePluginInPatch } = require('./scripts/plugin-manager-patch');
 const { installBuiltinPresets } = require('./scripts/install-minimal-win-preset');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
@@ -2129,6 +2130,7 @@ async function runUpdateFlow(manual) {
       applyProfilePatchGuard();
       applySettingsSectionGuard();
       applyWorkspaceSearchRailFix();
+      applyPluginInventoryTabMergeFix();
     } else {
       await updater.applyUpdate(ctx, latest);
       // 新 overlay 已就位：立即重打运行时补丁（全部幂等），否则「稍后重启」后再
@@ -2142,6 +2144,7 @@ async function runUpdateFlow(manual) {
       applyProfilePatchGuard();
       applySettingsSectionGuard();
       applyWorkspaceSearchRailFix();
+      applyPluginInventoryTabMergeFix();
       applyWebSearchBaseUrlFix();
       applyMenuViewportFix();
       applySessionManageFix();
@@ -2645,6 +2648,33 @@ function registerChromeIpc() {
       status: wslStatusSnapshot({ force: true }),
     };
   });
+
+  // -------------------------------------------------------------------------
+  // 插件管理（设置页「插件」页「管理」标签，dsh-plugin-manager 插件消费）：
+  //   list —— 收集配套/用户/核心插件：id、包名、package.json 描述、启用状态
+  //   set  —— 写入/移除 web profile cordis.patch.yml 的用户层 disabled 条目
+  //           （与 llm-deepseek 同款覆盖机制；完全退出并重启应用后生效）
+  // -------------------------------------------------------------------------
+  ipcMain.handle('dsh:plugin-list', async (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return [];
+    return pluginManagerCollect();
+  });
+
+  ipcMain.handle('dsh:plugin-set-enabled', async (event, { id, enabled } = {}) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
+    const row = pluginManagerCollect().find((r) => r.id === id);
+    if (!row) return { ok: false, error: '未知插件: ' + String(id) };
+    if (!row.toggleable) return { ok: false, error: '该插件不可关闭: ' + String(id) };
+    try {
+      const res = pluginManagerSetEnabled(id, !!enabled);
+      if (!res.ok) return res;
+      log('plugin-manager', '已' + (enabled ? '启用' : '关闭') + '插件 ' + id);
+      return { ok: true, restartRequired: true };
+    } catch (err) {
+      log('plugin-manager', '设置插件 ' + id + ' 失败: ' + ((err && err.message) || err));
+      return { ok: false, error: String((err && err.message) || err) };
+    }
+  });
 }
 
 let trayHintShown = false;
@@ -2821,13 +2851,14 @@ const COMPANION_PLUGINS = [
   // 面板（恢复/删除）。依赖 patch-session-manage.js 的官方包运行时补丁。
   { id: 'dsh-session-manager', name: 'dsh-session-manager' },
   { id: 'conversation-tweaks', name: '@deepseek-ai/dsh-conversation-tweaks' },
-  { id: 'super-injector', name: '@dsh-external/dsh-super-injector' },
+  { id: 'dsh-super-injector', name: '@dsh-external/dsh-super-injector' },
   { id: 'prompt-custom', name: '@deepseek-ai/dsh-prompt-custom' },
   { id: 'third-party-thinking', name: '@deepseek-ai/dsh-third-party-thinking' },
   { id: 'wsl-settings', name: '@deepseek-ai/dsh-wsl-settings' },
   { id: 'dsh-vision', name: '@dsh-external/dsh-vision' },
   { id: 'side-session', name: '@dsh-external/dsh-side-session' },
   { id: 'compaction-acp', name: 'billion-context-dsh' },
+  { id: 'plugin-manager', name: '@deepseek-ai/dsh-plugin-manager' },
 ];
 
 function companionDirName(p) {
@@ -3319,6 +3350,158 @@ function syncCompanionPlugins() {
 }
 
 // ---------------------------------------------------------------------------
+// 插件管理数据与写盘（设置页「插件」页「管理」标签；IPC 见 dsh:plugin-list /
+// dsh:plugin-set-enabled）
+// ---------------------------------------------------------------------------
+
+/** web profile 目录（与 profilePatchFile 同源，WSL 模式下走 UNC 写穿）。 */
+function pluginManagerProfileDir() {
+  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+  return path.join(home, 'profiles', 'web');
+}
+
+/** 读取并解析 cordis.patch.yml（js-yaml 方言；解析失败返回空列表）。 */
+function pluginManagerReadPatch() {
+  const file = path.join(pluginManagerProfileDir(), 'cordis.patch.yml');
+  let text = '';
+  try { text = fs.readFileSync(file, 'utf8'); } catch {}
+  const yaml = loadDshYamlDialect();
+  if (!yaml) return { file, text, entries: [] };
+  try {
+    const parsed = yaml.load(text);
+    return { file, text, entries: Array.isArray(parsed) ? parsed : [] };
+  } catch {
+    return { file, text, entries: [] };
+  }
+}
+
+/** 读插件包 package.json 的 description（profile node_modules → app assets 兜底）。 */
+function pluginManagerPackageDescription(name) {
+  if (!name) return '';
+  const candidates = [
+    path.join(pluginManagerProfileDir(), 'node_modules', ...name.split('/')),
+    path.join(__dirname, 'assets', 'plugins', name.includes('/') ? name.slice(name.indexOf('/') + 1) : name),
+  ];
+  for (const dir of candidates) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+      if (pkg && typeof pkg.description === 'string' && pkg.description) return pkg.description;
+    } catch {}
+  }
+  return '';
+}
+
+/**
+ * 收集插件清单（供「管理」标签展示）：
+ *   - companion：COMPANION_PLUGINS 定义的配套插件（可开关）
+ *   - other    ：patch 的 insert 块里出现但不在配套表（用户安装/热装）+
+ *                用户层条目（llm-deepseek / web 等），可开关（带 config 且未禁用的除外）
+ *   - core     ：manifest bundles 中的核心组件（不可开关）
+ * enabled = 用户层没有 disabled: true。
+ */
+function pluginManagerCollect() {
+  const { entries } = pluginManagerReadPatch();
+  const companionById = new Map(COMPANION_PLUGINS.map((p) => [p.id, p.name]));
+  const insertById = new Map();
+  const userById = new Map();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (Array.isArray(entry.insert)) {
+      for (const it of entry.insert) {
+        if (it && typeof it.id === 'string') insertById.set(it.id, it.name || '');
+      }
+    } else if (typeof entry.id === 'string') {
+      userById.set(entry.id, {
+        name: entry.name || '',
+        disabled: entry.disabled === true,
+        hasConfig: entry.config !== undefined && entry.config !== null,
+      });
+    }
+  }
+  let bundles = [];
+  try {
+    const m = JSON.parse(fs.readFileSync(path.join(pluginManagerProfileDir(), 'package.json'), 'utf8'));
+    bundles = (m && m.dsh && m.dsh.profile && Array.isArray(m.dsh.profile.bundles)) ? m.dsh.profile.bundles : [];
+  } catch {}
+  const companionNames = new Set(COMPANION_PLUGINS.map((p) => p.name));
+
+  const seen = new Set();
+  const rows = [];
+  const addRow = (id, name, group) => {
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    const user = userById.get(id);
+    const userDisabled = !!(user && user.disabled);
+    const hasConfig = !!(user && user.hasConfig);
+    const toggleable = group !== 'core' && !(hasConfig && !userDisabled);
+    rows.push({
+      id,
+      name: name || id,
+      description: pluginManagerPackageDescription(name || id),
+      enabled: !userDisabled,
+      toggleable,
+      group,
+    });
+  };
+  // 配套插件（COMPANION_PLUGINS 为准；patch insert 里的同名 id 统一归属）
+  for (const p of COMPANION_PLUGINS) addRow(p.id, p.name, 'companion');
+  // 其他：insert 块出现但不在配套表
+  for (const [id, name] of insertById) if (!companionById.has(id)) addRow(id, name, 'other');
+  // 其他：用户层条目（llm-deepseek / web / 手动条目）
+  for (const [id, u] of userById) if (!companionById.has(id)) addRow(id, u.name, 'other');
+  // 核心：manifest bundles 中非配套包（dsh-base / dsh-web-app 等）
+  for (const name of bundles) {
+    if (companionNames.has(name)) continue;
+    const id = name.includes('/') ? name.slice(name.indexOf('/') + 1) : name;
+    if (!seen.has(id)) addRow(id, name, 'core');
+  }
+  const order = { companion: 0, other: 1, core: 2 };
+  return rows.sort((a, b) => order[a.group] - order[b.group] || a.id.localeCompare(b.id));
+}
+
+/** 解析插件包名（配套表 → insert 块）。 */
+function pluginManagerResolveName(id) {
+  const c = COMPANION_PLUGINS.find((p) => p.id === id);
+  if (c) return c.name;
+  const { entries } = pluginManagerReadPatch();
+  for (const entry of entries) {
+    if (entry && Array.isArray(entry.insert)) {
+      const it = entry.insert.find((x) => x && x.id === id);
+      if (it && it.name) return it.name;
+    }
+  }
+  return '';
+}
+
+/**
+ * 写入/移除用户层 disabled 条目（纯文本手术见 scripts/plugin-manager-patch.js）：
+ *   关闭 —— 若 id 在 insert 块里，先从块内移除，再追加/更新顶层条目
+ *           {id, name, disabled: true}（同一 id 只保留一处，避免 loader 双登记崩溃）
+ *   启用 —— 移除顶层条目的 disabled 行；条目无 config 时整个移除
+ *           （配套插件下次启动由 syncCompanionPlugins 重新 insert）
+ */
+function pluginManagerSetEnabled(id, enabled) {
+  const file = path.join(pluginManagerProfileDir(), 'cordis.patch.yml');
+  let text = '';
+  try { text = fs.readFileSync(file, 'utf8'); } catch {}
+  if (!text.trim()) text = '# dsh web profile patch（由 DSH Desktop 维护）\n';
+
+  const name = pluginManagerResolveName(id);
+  if (!enabled && !name) return { ok: false, error: '无法解析插件包名: ' + id };
+
+  let patched;
+  try {
+    patched = togglePluginInPatch(text, id, !!enabled, name);
+  } catch (err) {
+    return { ok: false, error: String((err && err.message) || err) };
+  }
+  if (patched !== text) {
+    try { writePatchAtomic(file, patched); } catch (err) { return { ok: false, error: String((err && err.message) || err) }; }
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
 // 内置 Agent 预设同步：local 模式的预设由 npm start / after-pack 直接写入
 // Windows 侧内置 dsh 包的 config/agent-presets；WSL 托管模式的 dsh 是 WSL 内
 // npm 安装的干净包，不包含壳自带的 8 个预设，因此模式列表比 local 少。
@@ -3790,6 +3973,37 @@ function applyWorkspaceSearchRailFix() {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// 插件页标签合并补丁：官方「全部」只读清单与 dsh-plugin-manager 的「管理」标签
+// 功能重叠（管理已含全量列表 + 搜索 + 分类 + 开关）。幂等地从插件页标签列表
+// 中过滤掉 id 为 "all" 的只读清单，让「管理」成为唯一的插件列表入口。
+// 目标：内置副本 + profile fallback；锚点不匹配（上游将来修复后）自动跳过。
+// ---------------------------------------------------------------------------
+function applyPluginInventoryTabMergeFix() {
+  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+  const marker = 'dsh-desktop fix: hide inventory tab';
+  const oldPat = 'tabs = ctx.slots.entries("settings.plugins.tab").map((entry) => ({';
+  const newPat = 'tabs = ctx.slots.entries("settings.plugins.tab").filter((entry) => (entry.options.id ?? "") !== "all").map((entry) => ({ // ' + marker;
+  const candidates = [
+    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
+  ];
+  for (const file of candidates) {
+    if (!file || !fs.existsSync(file)) continue;
+    try {
+      let src = fs.readFileSync(file, 'utf8');
+      if (src.includes(marker)) { log('boot', '插件页标签合并: 已应用，跳过 ' + file); continue; }
+      if (!src.includes(oldPat)) { log('boot', '插件页标签合并: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file); continue; }
+      src = src.replace(oldPat, newPat);
+      fs.writeFileSync(file, src, { encoding: 'utf8' });
+      log('boot', '插件页标签合并: 已隐藏「全部」只读清单 ' + file);
+    } catch (err) {
+      log('boot', '插件页标签合并失败(' + file + '): ' + err.message);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // issue #20 运行时补丁：dsh-web-search-deepseek 的「接口地址」契约与拼接修复。
 // 补丁本体在 scripts/patch-web-search-baseurl.js（与打包补丁共用同一实现，
@@ -4491,6 +4705,7 @@ async function boot() {
     applyProfilePatchGuard();
     applySettingsSectionGuard();
     applyWorkspaceSearchRailFix();
+    applyPluginInventoryTabMergeFix();
     applyWebSearchBaseUrlFix();
     applyMenuViewportFix();
     applySessionManageFix();
@@ -4506,6 +4721,7 @@ async function boot() {
     applyProfilePatchGuard();
     applySettingsSectionGuard();
     applyWorkspaceSearchRailFix();
+    applyPluginInventoryTabMergeFix();
     applyWebSearchBaseUrlFix();
     applyMenuViewportFix();
     applySessionManageFix();

--- a/dsh-desktop/preload.js
+++ b/dsh-desktop/preload.js
@@ -66,6 +66,13 @@ const dshDesktop = {
     open: (sessionId) => ipcRenderer.invoke('chrome:float-window', { action: 'open', sessionId }),
     close: () => ipcRenderer.send('float:close'),
   },
+  // 插件管理（设置页「插件」页「管理」标签，dsh-plugin-manager 插件消费）：
+  // 列出插件 / 开关写入 web profile cordis.patch.yml 的用户层 disabled 条目
+  // （完全退出并重启应用生效）。
+  pluginManager: {
+    list: () => ipcRenderer.invoke('dsh:plugin-list'),
+    setEnabled: (id, enabled) => ipcRenderer.invoke('dsh:plugin-set-enabled', { id, enabled }),
+  },
   // 桌面宠物原生小窗（harness-pet）：主窗控制开关/状态查询/最小化自动弹出
   // 上报；小窗内关闭自身/搬窗（绝对目标位置）。
   petWindow: {

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -35,6 +35,7 @@ const entryFiles = [
   'scripts/sync-companion-plugins.js',
   'scripts/after-pack.js',
   'scripts/patch-portable-template.js',
+  'scripts/plugin-manager-patch.js',
 ];
 
 // 匹配「async/await 关键字与紧随其后的 function 声明之间被空行/注释行拆开」：

--- a/dsh-desktop/scripts/plugin-manager-patch.js
+++ b/dsh-desktop/scripts/plugin-manager-patch.js
@@ -1,0 +1,96 @@
+'use strict';
+// ---------------------------------------------------------------------------
+// 纯文本手术：web profile 的 cordis.patch.yml 中某个插件的用户层 disabled 条目
+// 开关。不改写文件其它内容/注释（保留格式与用户手写条目）。
+//
+//   关闭 —— 先从任何 `- insert:` 块内移除该 id 的内层条目（避免 loader 双登记
+//           崩溃），再保证存在一个顶层 `- id: <id>` 条目且带 `disabled: true`；
+//           顶层条目已存在（如 llm-deepseek）则就地补 disabled 行。
+//   启用 —— 移除顶层条目的 disabled 行；条目没有 config 时整个条目移除
+//           （配套插件下次启动由壳的 syncCompanionPlugins 重新 insert）。
+// ---------------------------------------------------------------------------
+
+function escRegExp(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// loader 条目 id 的白名单：普通标识符（连字符/下划线/点）。防注入：
+// id 会被拼进正则与 YAML 文本，禁止空白、引号、冒号等特殊字符。
+const ID_RE = /^[A-Za-z0-9_.-]+$/;
+
+/** YAML 单引号串转义：单引号加倍（''）。 */
+function yamlQuote(s) {
+  return "'" + String(s).replace(/'/g, "''") + "'";
+}
+
+// 顶层用户层条目（缩进 0-2 空格）+ 全部续行（含行尾换行）。
+function topLevelEntryRe(id) {
+  return new RegExp('(?:^|\\n)([ \\t]{0,2})- id:\\s*' + escRegExp(id) + '\\b[^\\n]*\\n(?:[ \\t]+[^\\n]*\\n)*', 'g');
+}
+
+// insert 块内的内层条目（缩进 >= 4）+ 续行（含行尾换行）。
+function insertInnerEntryRe(id) {
+  return new RegExp('(?:^|\\n)[ \\t]+- id:\\s*' + escRegExp(id) + '\\b[^\\n]*\\n(?:[ \\t]+[^\\n]*\\n)*', 'g');
+}
+
+// 本模块写入的标记注释行（整行，含行尾换行）。
+// 用零宽 lookbehind 锚定行首：连续多行同类注释能逐条匹配，
+// 不会被「消费型行首锚点」隔行跳过（那是注释堆积自愈失效的根因）。
+function markerCommentRe(id) {
+  return new RegExp('(?:^|(?<=\\n))# [^\\n]*关闭 ' + escRegExp(id) + '[^\\n]*(?:\\n|$)', 'g');
+}
+
+/**
+ * @param {string} text     cordis.patch.yml 原文
+ * @param {string} id       插件 id（如 terminal / llm-deepseek）
+ * @param {boolean} enabled true=启用（移除 disabled 覆盖），false=关闭
+ * @param {string} [name]   插件包名（追加新条目时写入 name 行；缺省用 id 占位）
+ * @returns {string} 修改后的文本（幂等；无变化时返回原文本）
+ */
+function togglePluginInPatch(text, id, enabled, name) {
+  if (typeof text !== 'string') throw new TypeError('text must be a string');
+  if (typeof id !== 'string' || !id) throw new TypeError('id must be a non-empty string');
+  if (!ID_RE.test(id)) throw new TypeError('id 含非法字符（仅允许字母/数字/下划线/点/连字符）: ' + id);
+  let out = text;
+  const pkgName = typeof name === 'string' && name ? name : id;
+
+  if (!enabled) {
+    // 1) 从 insert 块内移除内层条目（同一 id 只保留一个登记点）
+    out = out.replace(insertInnerEntryRe(id), (m) => (m[0] === '\n' ? '\n' : ''));
+    // 1.5) 清理被掏空的孤立 `- insert:` 空块（后续不再是缩进条目）
+    out = out.replace(/(?:^|\n)- insert:\s*\n(?![ \t]+-)/g, (m) => (m[0] === '\n' ? '\n' : ''));
+    // 2) 顶层条目：存在则确保 disabled: true；不存在则追加
+    const topRe = topLevelEntryRe(id);
+    if (topRe.test(out)) {
+      topRe.lastIndex = 0;
+      out = out.replace(topRe, (block) => {
+        // 只认 0-2 空格缩进的 disabled/name 行（本模块写入的格式），
+        // 不碰 config 块内更深缩进的同名键。
+        if (/(?:^|\n)[ \t]{0,2}disabled\s*:/.test(block)) return block;
+        if (/(?:^|\n)[ \t]{0,2}name\s*:/.test(block)) {
+          return block.replace(/(?:\n[ \t]{0,2}name\s*:[^\n]*)/, (m) => m + '\n  disabled: true');
+        }
+        return block.replace(/\n$/, '') + '\n  disabled: true\n';
+      });
+    } else {
+      // 追加前先清掉历史遗留的标记注释（上一次启用只删条目、注释残留时
+      // 会重复堆积），再追加一份「注释 + 条目」，保证多次开关不叠加。
+      out = out.replace(markerCommentRe(id), '');
+      const block = '\n# 插件管理（设置页「插件」栏）：关闭 ' + id + '\n- id: ' + id + '\n  name: ' + yamlQuote(pkgName) + '\n  disabled: true\n';
+      out = out.replace(/\s*$/, '') + block;
+    }
+    return out;
+  }
+
+  // 启用：顶层条目移除 disabled 行（0-2 空格缩进）；无 config 则整个条目移除；
+  // 连带移除本模块的标记注释（避免反复开关时注释堆积）。
+  out = out.replace(topLevelEntryRe(id), (m) => {
+    const withoutDisabled = m.replace(/\n[ \t]{0,2}disabled\s*:\s*(?:true|false)[^\n]*/g, '');
+    if (/(?:^|\n)[ \t]{0,2}config\s*:/.test(withoutDisabled)) return withoutDisabled;
+    return m[0] === '\n' ? '\n' : '';
+  });
+  out = out.replace(markerCommentRe(id), '');
+  return out;
+}
+
+module.exports = { togglePluginInPatch };

--- a/dsh-desktop/scripts/sync-companion-plugins.js
+++ b/dsh-desktop/scripts/sync-companion-plugins.js
@@ -44,13 +44,14 @@ const COMPANION_PLUGINS = [
   { id: 'dsh-navbar', name: '@vlln/dsh-navbar' },
   { id: 'dsh-session-manager', name: 'dsh-session-manager' },
   { id: 'conversation-tweaks', name: '@deepseek-ai/dsh-conversation-tweaks' },
-  { id: 'super-injector', name: '@dsh-external/dsh-super-injector' },
+  { id: 'dsh-super-injector', name: '@dsh-external/dsh-super-injector' },
   { id: 'prompt-custom', name: '@deepseek-ai/dsh-prompt-custom' },
   { id: 'third-party-thinking', name: '@deepseek-ai/dsh-third-party-thinking' },
   { id: 'wsl-settings', name: '@deepseek-ai/dsh-wsl-settings' },
   { id: 'dsh-vision', name: '@dsh-external/dsh-vision' },
   { id: 'side-session', name: '@dsh-external/dsh-side-session' },
   { id: 'compaction-acp', name: 'billion-context-dsh' },
+{ id: 'plugin-manager', name: '@deepseek-ai/dsh-plugin-manager' },
 ];
 
 const PLUGIN_FILES = [

--- a/dsh-desktop/scripts/test/plugin-manager-patch.test.js
+++ b/dsh-desktop/scripts/test/plugin-manager-patch.test.js
@@ -1,0 +1,155 @@
+'use strict';
+// 单元测试：scripts/plugin-manager-patch.js（cordis.patch.yml 用户层 disabled 开关）
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { togglePluginInPatch } = require('../plugin-manager-patch');
+
+const FIXTURE = [
+  '# dsh web profile patch（由 DSH Desktop 维护）',
+  '- insert:',
+  '    - id: balance',
+  "      name: '@deepseek-ai/dsh-balance'",
+  '- insert:',
+  '    - id: terminal',
+  "      name: '@deepseek-ai/dsh-terminal-tab'",
+  '- id: llm-deepseek',
+  "  name: '@deepseek-ai/dsh-llm-deepseek'",
+  '  disabled: true',
+  '- id: web',
+  "  name: '@deepseek-ai/dsh-web'",
+  '  config:',
+  '    searchProvider: opencode-mcp',
+  '',
+].join('\n');
+
+function countId(text, id) {
+  return (text.match(new RegExp('- id: ' + id + '\\b', 'g')) || []).length;
+}
+
+test('禁用：文件中不存在该 id 时追加顶层 disabled 条目', () => {
+  const out = togglePluginInPatch(FIXTURE, 'vision', false, '@dsh-external/dsh-vision');
+  assert.equal(countId(out, 'vision'), 1);
+  assert.match(out, /- id: vision\s*\n\s*name: '@dsh-external\/dsh-vision'\s*\n\s*disabled: true/);
+  // 既有内容与注释不受影响
+  assert.ok(out.includes('# dsh web profile patch（由 DSH Desktop 维护）'));
+  assert.ok(out.includes('- id: web'));
+});
+
+test('禁用：id 在 insert 块内时移出并保证只登记一处', () => {
+  const out = togglePluginInPatch(FIXTURE, 'terminal', false, '@deepseek-ai/dsh-terminal-tab');
+  assert.ok(!out.includes('    - id: terminal'), '应已从 insert 块移除');
+  assert.equal(countId(out, 'terminal'), 1, '全文件只保留一个登记点');
+  assert.match(out, /- id: terminal\s*\n\s*name: '@deepseek-ai\/dsh-terminal-tab'\s*\n\s*disabled: true/);
+  // 同块其它条目与孤立空块清理
+  assert.ok(out.includes('    - id: balance'));
+  assert.ok(!out.includes('- insert:\n\n'), '被掏空的 insert 块应被清理');
+});
+
+test('禁用：顶层条目已存在（无 disabled 行）时就地补行', () => {
+  const noDisabled = FIXTURE.replace('  disabled: true\n', '');
+  const out = togglePluginInPatch(noDisabled, 'llm-deepseek', false);
+  assert.ok(out.includes('  disabled: true'));
+  assert.equal((out.match(/disabled\s*:/g) || []).length, 1);
+});
+
+test('禁用：已禁用条目幂等（重复调用结果一致）', () => {
+  const once = togglePluginInPatch(FIXTURE, 'terminal', false, '@deepseek-ai/dsh-terminal-tab');
+  const twice = togglePluginInPatch(once, 'terminal', false, '@deepseek-ai/dsh-terminal-tab');
+  assert.equal(once, twice);
+});
+
+test('启用：无 config 的顶层条目整个移除', () => {
+  const disabled = togglePluginInPatch(FIXTURE, 'vision', false, '@dsh-external/dsh-vision');
+  const out = togglePluginInPatch(disabled, 'vision', true, '@dsh-external/dsh-vision');
+  assert.equal(countId(out, 'vision'), 0);
+  assert.ok(!out.includes("name: '@dsh-external/dsh-vision'"), 'vision 条目已不存在');
+});
+
+test('启用：带 config 的条目只移除 disabled 行，config 保留', () => {
+  const withDisabledConfig = FIXTURE.replace('  config:\n', '  disabled: true\n  config:\n');
+  const out = togglePluginInPatch(withDisabledConfig, 'web', true);
+  assert.ok(out.includes('- id: web'));
+  assert.ok(out.includes('  config:'));
+  assert.ok(out.includes('    searchProvider: opencode-mcp'));
+  // web 条目自己的 disabled 行被移除；llm-deepseek 的 disabled 保留
+  assert.ok(!out.includes("name: '@deepseek-ai/dsh-web'\n  disabled: true"));
+  assert.ok(out.includes("name: '@deepseek-ai/dsh-llm-deepseek'\n  disabled: true"));
+});
+
+test('往返：禁用→启用后文件回到无该条目状态（等待启动同步重新 insert）', () => {
+  const disabled = togglePluginInPatch(FIXTURE, 'terminal', false, '@deepseek-ai/dsh-terminal-tab');
+  const enabled = togglePluginInPatch(disabled, 'terminal', true, '@deepseek-ai/dsh-terminal-tab');
+  assert.equal(countId(enabled, 'terminal'), 0);
+});
+
+test('开关其它插件不影响 web 的 config 块', () => {
+  const out = togglePluginInPatch(FIXTURE, 'balance', false, '@deepseek-ai/dsh-balance');
+  assert.ok(out.includes('searchProvider: opencode-mcp'));
+  assert.ok(out.includes('- id: web'));
+  assert.ok(out.includes('config:'));
+});
+
+test('顶层条目只有 id 行（无 name）时也能补 disabled', () => {
+  const bare = '# dsh web profile patch\n- id: mystery\n';
+  const out = togglePluginInPatch(bare, 'mystery', false);
+  assert.ok(out.includes('disabled: true'));
+  assert.equal(countId(out, 'mystery'), 1);
+});
+
+test('防注入：包名含单引号时按 YAML 转义（加倍），不破坏文件', () => {
+  const out = togglePluginInPatch(FIXTURE, 'quoted', false, "weird'name");
+  assert.ok(out.includes("name: 'weird''name'"), '单引号应加倍转义');
+  assert.ok(!out.includes("name: 'weird'name'"), '不得出现未转义的单引号串');
+  assert.equal(countId(out, 'quoted'), 1);
+});
+
+test('防注入：非法 id（含空白/冒号）直接拒绝', () => {
+  assert.throws(() => togglePluginInPatch(FIXTURE, 'bad id', false), TypeError);
+  assert.throws(() => togglePluginInPatch(FIXTURE, 'a:b', false), TypeError);
+  assert.throws(() => togglePluginInPatch(FIXTURE, 'a\nb', false), TypeError);
+});
+
+test('启用：config 块内更深缩进的 disabled 键不受影响', () => {
+  const nested = [
+    '# dsh web profile patch',
+    '- id: gizmo',
+    "  name: '@scope/gizmo'",
+    '  disabled: true',
+    '  config:',
+    '    disabled: false',
+    '    searchProvider: opencode-mcp',
+    '',
+  ].join('\n');
+  const out = togglePluginInPatch(nested, 'gizmo', true);
+  assert.ok(!out.includes("name: '@scope/gizmo'\n  disabled: true"), '条目自己的 disabled 行已移除');
+  assert.ok(out.includes('    disabled: false'), 'config 内嵌 disabled 键必须保留');
+  assert.ok(out.includes('searchProvider: opencode-mcp'));
+});
+
+function commentCount(text, id) {
+  return (text.match(new RegExp('# [^\\n]*关闭 ' + id + '\\b', 'g')) || []).length;
+}
+
+test('注释不堆积：禁用→启用→禁用→启用，标记注释始终至多一条', () => {
+  let t = FIXTURE;
+  t = togglePluginInPatch(t, 'balance', false, '@deepseek-ai/dsh-balance');
+  t = togglePluginInPatch(t, 'balance', true, '@deepseek-ai/dsh-balance');
+  t = togglePluginInPatch(t, 'balance', false, '@deepseek-ai/dsh-balance');
+  assert.equal(commentCount(t, 'balance'), 1, '禁用后恰一条注释');
+  t = togglePluginInPatch(t, 'balance', true, '@deepseek-ai/dsh-balance');
+  assert.equal(commentCount(t, 'balance'), 0, '启用后注释清空');
+  assert.equal(countId(t, 'balance'), 0, '启用后条目移除（等待启动同步重新 insert）');
+});
+
+test('自愈：历史遗留的多条重复注释在下次禁用时收敛为一条', () => {
+  const messy = FIXTURE + [
+    '# 插件管理（设置页「插件」栏）：关闭 balance',
+    '# 插件管理（设置页「插件」栏）：关闭 balance',
+    '# 插件管理（设置页「插件」栏）：关闭 balance',
+    '# 插件管理（设置页「插件」栏）：关闭 balance',
+    '',
+  ].join('\n');
+  const out = togglePluginInPatch(messy, 'balance', false, '@deepseek-ai/dsh-balance');
+  assert.equal(commentCount(out, 'balance'), 1, '四条历史注释收敛为一条');
+  assert.equal(countId(out, 'balance'), 1, '且只有一份条目');
+});


### PR DESCRIPTION
## 背景

社区反馈两个痛点：
1. **「插件看不懂什么作用」**——官方「全部」清单只显示包名和状态，没有描述；
2. **「插件全部默认启用，无法关闭」**——配套插件没有关闭入口。

## 改动

### 设置页「插件」页融合为单一「管理」标签（`dsh-plugin-manager` 配套插件）

- **启动时幂等隐藏官方只读「全部」清单**（`applyPluginInventoryTabMergeFix` 过滤 `settings.plugins.tab` 中 id 为 `all` 的条目），「管理」成为唯一插件列表入口；锚点不匹配时自动跳过并记日志，不破坏任何文件；
- **搜索框**：按 名称 / 包名 / 描述 实时过滤；
- **可点击分类标签**：配套插件（可开关）/ 其他插件（可开关）/ 核心组件（只读），点击过滤、再点取消，各组显示启用/关闭计数；
- **双视图**：
  - 简洁：2 列卡片网格（官方清单页同款样式）——标题 + 包名短名 + 状态圆点（绿=启用/灰=关闭/红=挂载失败）+ 迷你开关，窄屏（≤680px）自动单列；
  - 详情：名称 + 包名 + 状态徽章 + 中文描述 + 勾选框；
- **乐观 UI 开关**：点击立即翻转勾选框/滑块并标记「重启后生效」，写盘失败自动回滚并红字提示；
- **数据双源**：主数据源为本地桥（完整清单 + 描述取自各插件 package.json），官方 live 注册表（`pluginInventory.list()`）尽力补充核心组件全集与实时状态——live 失败自动降级本地清单，不再整页报错；
- 核心组件由 live 清单驱动展示，与官方「全部」一一对应（本地 manifest 占位行在 live 可用时隐藏）。

### 主进程（main.js / preload.js）

- 新增 IPC `dsh:plugin-list` / `dsh:plugin-set-enabled`（校验主窗来源）；
- `pluginManagerCollect()`：配套（`COMPANION_PLUGINS`）/ 其他（patch insert + 用户层条目）/ 核心（manifest bundles）三类，含包名、描述、启用状态、可开关判定（带 config 且未禁用的条目不可关，如 `web`）；
- `pluginManagerSetEnabled()`：写入/移除 web profile `cordis.patch.yml` 的用户层 `disabled` 条目（与 `llm-deepseek` 同款覆盖机制），**完全退出并重启 DSH Desktop 生效**；
- `scripts/plugin-manager-patch.js` 纯文本手术模块：
  - 关闭：先从 `- insert:` 块内移除该 id（避免 loader 双登记崩溃），再保证顶层 `disabled: true` 条目唯一；
  - 启用：移除 disabled 行（无 config 则整条移除，配套插件由启动同步重新 insert）；
  - **防注入**：id 白名单 `[A-Za-z0-9_.-]`、包名 YAML 单引号转义（`''`）、disabled 行只认 0-2 空格缩进（不误伤 config 内嵌键）；
  - **注释自愈**：反复开关不再堆积标记注释（历史遗留的多条重复注释自动收敛为一条）；
- **配套插件清单修正**：`super-injector` 的 loader 条目 id 应为 `dsh-super-injector`（此前写 `super-injector` 会被 loader 静默跳过，禁用无效）；`main.js` 与 `scripts/sync-companion-plugins.js` 两处清单同步；
- 新增插件 `@deepseek-ai/dsh-plugin-manager`（浏览器端 + 空宿主端）进入 `COMPANION_PLUGINS`，随启动同步进 web profile。

## 测试与验证

- `scripts/test/plugin-manager-patch.test.js`：**14 个单测全过**（含注入防护、注释收敛、往返幂等、config 保护）；
- 仓库语法门 `scripts/check-syntax.js` 已纳入新模块，全部通过；
- 冒烟：真实 `cordis.patch.yml` 副本上 禁用→启用→禁用 往返干净（YAML 始终可解析、其它条目完好）；
- 其余可运行单测 70/70 通过（`unit-web-search` / `unit-patch-heal-fuzz` 因仓库未安装 node_modules 依赖无法运行，与本次改动无关）。

## 注意事项

- 开关在**完全退出并重启 DSH Desktop** 后生效（页面刷新不生效——dsh web 服务不热重载 patch）；
- 已禁用的插件仍会显示在列表中（标记「已关闭」），便于重新打开；
- 首次启动时 `applyPluginInventoryTabMergeFix` 会改写 `dsh-client-ui-settings-plugins/lib/client.js`（幂等，带标记注释，锚点不匹配自动跳过）。
