### PR TITLE
fix: profile bundle 装配自愈根治与运行时补丁/配套同步机制统一（消除重复与漂移，补齐 WSL·overlay 覆盖）

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -15,11 +15,12 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 - **侧边临时会话升级 v0.2.5（合入上游更新）**：左侧栏图标对齐、浮窗展开/收起动画档位（0/300/500/800/1200ms，默认 500）、输入框与发送按钮样式与主会话同款、移除「停止回答」按钮；服务端**热重载自愈**（`settings.registrations.delete(NS)` + 路由重注册，开发热重载后不再残留重复注册）。保留本地增量解析与 4s 拉取节流。版本号定为 0.2.5 与上游 0.2.4 区分
 - **桌面宠物默认关闭（插件级）**：harness-pet 常驻 canvas 逐帧绘制在软渲染/流式输出下持续占用主进程，且旧版保存的开关值会覆盖客户端默认关闭。现启动同步时幂等写入 profile patch `- id: harness-pet\n  disabled: true`（一票否决任何已保存状态），需要时在 设置 → 插件 → 管理 一键开启
 - **更新后桌面快捷方式消失**：安装版（NSIS）此前依赖安装器创建桌面快捷方式，壳层只在便携版下补建——安装版更新（向导取消勾选创建 / 旧版卸载清理 / 手动覆盖安装目录）后桌面快捷方式缺失且永远不会自愈。现壳层对**安装版与便携版一致**地「缺失即补建」规范名 `DSH Desktop.lnk`（去重逻辑先行，桌面上至多保留一个，不会复现旧版「每次启动生成多个快捷方式」），并修复快捷方式指向被移动/更新后的 exe。另给 `maintainShortcuts` 加 `DSH_DESKTOP_TEST=1` 显式守卫：集成测试（dev electron 以文件路径启动时 `app.isPackaged` 也为 true）不再把用户真实快捷方式改指向测试用 electron.exe
-- **profile bundle 缺失 / 损坏导致 dsh web 启动失败（退出码 1）根治**：dsh 官方装配对 `dsh.profile.bundles` fail-loud——登记了未安装的插件抛 `cannot resolve profile bundle`、普通库或仅客户端 bundle 被登记抛 `declares no dsh.bundle`、bundle 的 `cordis.patch.yml` 损坏抛 `failed to parse overlay`、profile `package.json` 损坏直接抛 JSON 错误、家级 `cordis.patch.yml` 损坏抛 `failed to parse patches`——任一命中桌面端永久无法启动。三层修复：
+- **profile bundle 缺失 / 损坏导致 dsh web 启动失败（退出码 1）根治 + 重启丢插件数据恢复（issue #48）**：dsh 官方装配对 `dsh.profile.bundles` fail-loud——登记了未安装的插件抛 `cannot resolve profile bundle`、普通库或仅客户端 bundle 被登记抛 `declares no dsh.bundle`、bundle 的 `cordis.patch.yml` 损坏抛 `failed to parse overlay`、profile `package.json` 损坏直接抛 JSON 错误、家级 `cordis.patch.yml` 损坏抛 `failed to parse patches`——任一命中桌面端永久无法启动。四层修复：
   - **启动防护**（`applyProfileBundleGuard`，幂等运行时补丁，dsh 更新后自动重打）：改写 `@deepseek-ai/dsh-app-boot` 的 `loadProfile`——bundle 层逐个跳过并写带修复指引的 stderr 诊断；profile manifest 损坏则备份 `.broken-<ts>` 后按出厂模板重建；改写 dsh `profile-boot` 装配——家级补丁层与 profile 补丁层损坏时备份 + 重置为空列表（同时覆盖启动与 HMR 热重载路径）。用户数据只备份不删除，重装插件即恢复。
-  - **写盘侧防呆**：配套插件同步在 bundle 落盘后校验「补丁层 + 入口文件」存在才登记进 manifest（`billion-context-dsh` 上游缺 `dist` 构建产物时不再登记，杜绝整棵插件树加载失败）；profile manifest 损坏时先备份原文再重建；本次改动的 manifest 与补丁层写入全部原子化。
+  - **写盘侧防呆**：配套插件同步在 bundle 落盘后校验「补丁层 + 入口文件」存在才登记进 manifest（`billion-context-dsh` 上游缺 `dist` 构建产物时不再登记，杜绝整棵插件树加载失败）；profile manifest 损坏时先备份原文再重建；manifest 写入全部原子化（消除写盘撕裂这一损坏来源）。
+  - **用户插件数据恢复**（issue #48）：manifest 损坏被重置后，用户手动安装的第三方 bundle 仍实际落在 profile node_modules 里——启动自愈会扫描、校验并把它们合并回 manifest（`bundles` + `dependencies`），用户插件照常装配；普通依赖与损坏包不恢复登记。同时弹「配置自愈」系统通知（集成测试态抑制），不再静默。
   - **启动前健康检查**：`dsh web` 启动前把每个 bundles 条目的装配状态落到 `desktop.log`（缺失 / 未声明 / 补丁层缺失一目了然），`dsh-web.log` 保留完整 stderr 诊断。
-  变换逻辑收口为纯模块 `profile-bundle-heal.js`（`node --test` 单测 11 项 + 6 个新集成场景：heal-missing-bundle / heal-manifestless-bundle / heal-broken-manifest / heal-broken-home-patch / heal-broken-bundle-patch / companion-bundle-invariant）。
+  变换与恢复逻辑收口为纯模块 `profile-bundle-heal.js`（`node --test` 单测 13 项 + 7 个新集成场景：heal-missing-bundle / heal-manifestless-bundle / heal-broken-manifest / heal-broken-manifest-recovers / heal-broken-home-patch / heal-broken-bundle-patch / companion-bundle-invariant）。
 
 ## [0.3.9] — 2026-08-16
 

--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -15,6 +15,11 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 - **侧边临时会话升级 v0.2.5（合入上游更新）**：左侧栏图标对齐、浮窗展开/收起动画档位（0/300/500/800/1200ms，默认 500）、输入框与发送按钮样式与主会话同款、移除「停止回答」按钮；服务端**热重载自愈**（`settings.registrations.delete(NS)` + 路由重注册，开发热重载后不再残留重复注册）。保留本地增量解析与 4s 拉取节流。版本号定为 0.2.5 与上游 0.2.4 区分
 - **桌面宠物默认关闭（插件级）**：harness-pet 常驻 canvas 逐帧绘制在软渲染/流式输出下持续占用主进程，且旧版保存的开关值会覆盖客户端默认关闭。现启动同步时幂等写入 profile patch `- id: harness-pet\n  disabled: true`（一票否决任何已保存状态），需要时在 设置 → 插件 → 管理 一键开启
 - **更新后桌面快捷方式消失**：安装版（NSIS）此前依赖安装器创建桌面快捷方式，壳层只在便携版下补建——安装版更新（向导取消勾选创建 / 旧版卸载清理 / 手动覆盖安装目录）后桌面快捷方式缺失且永远不会自愈。现壳层对**安装版与便携版一致**地「缺失即补建」规范名 `DSH Desktop.lnk`（去重逻辑先行，桌面上至多保留一个，不会复现旧版「每次启动生成多个快捷方式」），并修复快捷方式指向被移动/更新后的 exe。另给 `maintainShortcuts` 加 `DSH_DESKTOP_TEST=1` 显式守卫：集成测试（dev electron 以文件路径启动时 `app.isPackaged` 也为 true）不再把用户真实快捷方式改指向测试用 electron.exe
+- **profile bundle 缺失 / 损坏导致 dsh web 启动失败（退出码 1）根治**：dsh 官方装配对 `dsh.profile.bundles` fail-loud——登记了未安装的插件抛 `cannot resolve profile bundle`、普通库或仅客户端 bundle 被登记抛 `declares no dsh.bundle`、bundle 的 `cordis.patch.yml` 损坏抛 `failed to parse overlay`、profile `package.json` 损坏直接抛 JSON 错误、家级 `cordis.patch.yml` 损坏抛 `failed to parse patches`——任一命中桌面端永久无法启动。三层修复：
+  - **启动防护**（`applyProfileBundleGuard`，幂等运行时补丁，dsh 更新后自动重打）：改写 `@deepseek-ai/dsh-app-boot` 的 `loadProfile`——bundle 层逐个跳过并写带修复指引的 stderr 诊断；profile manifest 损坏则备份 `.broken-<ts>` 后按出厂模板重建；改写 dsh `profile-boot` 装配——家级补丁层与 profile 补丁层损坏时备份 + 重置为空列表（同时覆盖启动与 HMR 热重载路径）。用户数据只备份不删除，重装插件即恢复。
+  - **写盘侧防呆**：配套插件同步在 bundle 落盘后校验「补丁层 + 入口文件」存在才登记进 manifest（`billion-context-dsh` 上游缺 `dist` 构建产物时不再登记，杜绝整棵插件树加载失败）；profile manifest 损坏时先备份原文再重建；本次改动的 manifest 与补丁层写入全部原子化。
+  - **启动前健康检查**：`dsh web` 启动前把每个 bundles 条目的装配状态落到 `desktop.log`（缺失 / 未声明 / 补丁层缺失一目了然），`dsh-web.log` 保留完整 stderr 诊断。
+  变换逻辑收口为纯模块 `profile-bundle-heal.js`（`node --test` 单测 11 项 + 6 个新集成场景：heal-missing-bundle / heal-manifestless-bundle / heal-broken-manifest / heal-broken-home-patch / heal-broken-bundle-patch / companion-bundle-invariant）。
 
 ## [0.3.9] — 2026-08-16
 

--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -30,6 +30,7 @@ files:
   - renderer-recovery.js
   - profile-manifest.js
   - profile-patch-heal.js
+  - profile-bundle-heal.js
   - wsl-backend.js
   - watchdog.js
   - assets/**/*

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -33,6 +33,7 @@ const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
 const { ensureCoreBundles, CORE_BUNDLE_NAMES } = require('./profile-manifest');
 const { dedupePatchEntries, dropBlocksByIds, parseFailedLoaderIds, mapPackagesToPatchIds } = require('./profile-patch-heal');
+const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, bundlePatchRel, verifyBundleDir, packageDirUpward, applyAppBootBundleGuard, applyProfileBootBundleGuard } = require('./profile-bundle-heal');
 const { patchWebSearchBaseUrl } = require('./scripts/patch-web-search-baseurl');
 const { patchMenuViewport } = require('./scripts/patch-menu-viewport');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
@@ -1128,6 +1129,7 @@ async function startServer(unsafePortRetries = 4, overlays = []) {
     serverProc = null;
   }
   healProfilePatch();
+  logProfileBundleHealth();
   if (isWslMode()) {
     // WSL 托管模式：经 wsl.exe 在 WSL 内启动 dsh web（仍 --port 0 由 WSL 内 OS
     // 分配；稳定端口持久化只作用于本地 spawn）。受限端口重启走同一递归。
@@ -2138,6 +2140,7 @@ async function runUpdateFlow(manual) {
       applyImageSendFix();
       applyVisionKeyFix();
       applyProfilePatchGuard();
+      applyProfileBundleGuard();
       applySettingsSectionGuard();
       applyWorkspaceSearchRailFix();
       applyPluginInventoryTabMergeFix();
@@ -2152,6 +2155,7 @@ async function runUpdateFlow(manual) {
       applyImageSendFix();
       applyVisionKeyFix();
       applyProfilePatchGuard();
+      applyProfileBundleGuard();
       applySettingsSectionGuard();
       applyWorkspaceSearchRailFix();
       applyPluginInventoryTabMergeFix();
@@ -3125,6 +3129,40 @@ function syncDir(src, dest) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// profile bundle 健康检查（只读）：dsh web 启动前把每个 bundles 条目的装配
+// 状态落到 desktop.log —— 缺失 / 未声明 dsh.bundle.patch / 补丁层缺失都会让
+// 该层被启动防护跳过，这里让诊断在壳日志里可见（dsh-web.log 的 stderr 告警
+// 保留完整细节）。不修改任何文件。
+// ---------------------------------------------------------------------------
+function logProfileBundleHealth() {
+  try {
+    const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+    const profileDir = path.join(home, 'profiles', 'web');
+    let manifest = null;
+    try {
+      manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+    } catch (err) {
+      log('boot', 'profile bundle 健康检查: manifest 不可读（' + err.message + '），交由启动防护自愈');
+      return;
+    }
+    const bundles = (manifest && manifest.dsh && manifest.dsh.profile && Array.isArray(manifest.dsh.profile.bundles)) ? manifest.dsh.profile.bundles : [];
+    const installAnchor = path.dirname(dshPackageJson());
+    for (const name of bundles) {
+      if (typeof name !== 'string' || name === '') continue;
+      const dir = packageDirUpward(installAnchor, name) || packageDirUpward(profileDir, name);
+      if (!dir) {
+        log('boot', 'profile bundle 缺失（该层将被启动防护跳过）: ' + name + ' —— 用 dsh plugin --profile web install 可修复');
+        continue;
+      }
+      const check = verifyBundleDir(dir);
+      if (!check.ok) log('boot', 'profile bundle 不可用（该层将被启动防护跳过）: ' + name + ' —— ' + check.reason);
+    }
+  } catch (err) {
+    log('boot', 'profile bundle 健康检查失败: ' + err.message);
+  }
+}
+
 function syncCompanionPlugins() {
   if (!IS_WIN) return;
   try {
@@ -3170,7 +3208,7 @@ function syncCompanionPlugins() {
       if (!fs.existsSync(path.join(src, 'package.json'))) continue;
       let pkg = {};
       try { pkg = JSON.parse(fs.readFileSync(path.join(src, 'package.json'), 'utf8')); } catch {}
-      const isBundle = !!(pkg && pkg.dsh && pkg.dsh.bundle && pkg.dsh.bundle.patch);
+      const isBundle = bundlePatchRel(pkg) !== '';
       // @deepseek-ai 与 @dsh-external 两种 scope 都按包名落到 profile 的
       // node_modules 下；配套包自身的依赖由 dsh 的 profiles/node_modules
       // fallback（healProfilesModuleFallback）解析。
@@ -3206,7 +3244,19 @@ function syncCompanionPlugins() {
       }
       // Bundle 插件不写 patch 行：dsh 在启动时读取 profile 的
       // dsh.profile.bundles 并应用包内 cordis.patch.yml。
-      if (isBundle) bundleNames.add(p.name);
+      if (isBundle) {
+        // 落盘后校验 bundle 完整性：dsh 装配时会读取补丁层与入口文件，任一
+        // 缺失都会让整棵插件树加载失败（billion-context-dsh 上游缺 dist 构建
+        // 产物正是这类崩溃）。校验失败按「源缺失」处理：不注册、从 manifest
+        // 移除登记、日志告警，下次启动重试。
+        const check = verifyBundleDir(dest);
+        if (!check.ok) {
+          missingSourceNames.add(p.name);
+          log('boot', '配套 bundle 校验失败（按源缺失处理，不注册）: ' + p.name + ' —— ' + check.reason);
+        } else {
+          bundleNames.add(p.name);
+        }
+      }
     }
 
     // billion-context-dsh（compaction-acp）是模型驱动的 ACP 压缩后端：同一
@@ -3255,9 +3305,22 @@ function syncCompanionPlugins() {
     }
 
     const manifestFile = path.join(profileDir, 'package.json');
-    let manifest = {};
-    try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch { manifest = { name: 'dsh-profile-web', private: true }; }
-    if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) manifest = { name: 'dsh-profile-web', private: true };
+    let manifest = null;
+    try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch {}
+    if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+      // manifest 损坏：先备份原文件再重置（不可解析时原文是唯一现场），绝不
+      // 静默丢弃用户数据。全新 profile 没有文件，不产生备份。
+      if (fs.existsSync(manifestFile)) {
+        const backup = manifestFile + '.broken-' + Date.now();
+        try {
+          fs.copyFileSync(manifestFile, backup);
+          log('boot', 'profile manifest 损坏，原文件已备份到 ' + backup);
+        } catch (err) {
+          log('boot', 'profile manifest 备份失败: ' + err.message);
+        }
+      }
+      manifest = { name: 'dsh-profile-web', private: true };
+    }
     if (!manifest.dsh || typeof manifest.dsh !== 'object') manifest.dsh = {};
     if (!manifest.dsh.profile || typeof manifest.dsh.profile !== 'object') manifest.dsh.profile = {};
     // 全新 profile（dsh 尚未初始化）时 manifest 不存在、也没有 bundles。
@@ -3295,7 +3358,7 @@ function syncCompanionPlugins() {
       if (!bundlesUsable) break;
       if (!manifest.dsh.profile.bundles.includes(name)) {
         manifest.dsh.profile.bundles.push(name);
-        fs.writeFileSync(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+        writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
         log('boot', '已把 bundle 插件加入 web profile bundles: ' + name);
       }
     }
@@ -3910,6 +3973,72 @@ function applyProfilePatchGuard() {
       log('boot', 'profile patch 防护: 已注入自愈加载到 ' + file);
     } catch (err) {
       log('boot', 'profile patch 防护失败: ' + err.message);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// profile bundle 装配防护：官方 dsh-app-boot 对 profile bundle 缺失/损坏
+// fail-loud（resolveBundleDir 抛 cannot resolve profile bundle、无
+// dsh.bundle.patch 声明抛 declares no dsh.bundle、bundle 补丁层损坏抛
+// failed to parse overlay），都会让 dsh web 以退出码 1 启动失败。这里像
+// applyProfilePatchGuard 一样幂等地改写 @deepseek-ai/dsh-app-boot：bundle
+// 层逐个跳过（stderr 诊断，profile manifest 损坏则备份 + 模板重建）；同时
+// 改写 dsh 的 profile-boot 装配（家级 cordis.patch.yml 与 profile 补丁层
+// 损坏时备份 + 重置，覆盖启动与 HMR 热重载）。变换逻辑收口在
+// profile-bundle-heal.js；dsh 更新后本函数会在下次启动重新应用。
+// ---------------------------------------------------------------------------
+function applyProfileBundleGuard() {
+  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+  const appBootCandidates = [
+    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
+  ];
+  for (const file of appBootCandidates) {
+    if (!fs.existsSync(file)) continue;
+    try {
+      const src = readFileCached(file);
+      if (src === null) { log('boot', 'profile bundle 防护: 读取失败，跳过 ' + file); continue; }
+      const out = applyAppBootBundleGuard(src);
+      if (!out.changed) {
+        if (!src.includes(PROFILE_BUNDLE_GUARD_MARKER)) {
+          log('boot', 'profile bundle 防护: ' + file + ' 锚点未匹配（dsh 版本可能已变化），跳过');
+        }
+        continue;
+      }
+      fs.writeFileSync(file, out.src, { encoding: 'utf8' });
+      log('boot', 'profile bundle 防护: 已注入自愈装配到 ' + file);
+    } catch (err) {
+      log('boot', 'profile bundle 防护失败(' + file + '): ' + err.message);
+    }
+  }
+  const profileBootDirs = [
+    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
+  ];
+  for (const dir of profileBootDirs) {
+    let names;
+    try { names = fs.readdirSync(dir).filter((f) => /^profile-boot-.+\.js$/.test(f)); } catch { continue; }
+    for (const name of names) {
+      const file = path.join(dir, name);
+      try {
+        const src = readFileCached(file);
+        if (src === null) { log('boot', 'profile bundle 防护: 读取失败，跳过 ' + file); continue; }
+        const out = applyProfileBootBundleGuard(src);
+        if (!out.changed) {
+          if (!src.includes(PROFILE_BOOT_GUARD_MARKER)) {
+            log('boot', 'profile bundle 防护: ' + file + ' 锚点未匹配（dsh 版本可能已变化），跳过');
+          }
+          continue;
+        }
+        fs.writeFileSync(file, out.src, { encoding: 'utf8' });
+        log('boot', 'profile bundle 防护: 已注入自愈装配到 ' + file);
+      } catch (err) {
+        log('boot', 'profile bundle 防护失败(' + file + '): ' + err.message);
+      }
     }
   }
 }
@@ -4752,6 +4881,7 @@ async function boot() {
     applyImageSendFix();
     applyVisionKeyFix();
     applyProfilePatchGuard();
+    applyProfileBundleGuard();
     applySettingsSectionGuard();
     applyWorkspaceSearchRailFix();
     applyPluginInventoryTabMergeFix();
@@ -4768,6 +4898,7 @@ async function boot() {
     applyImageSendFix();
     applyVisionKeyFix();
     applyProfilePatchGuard();
+    applyProfileBundleGuard();
     applySettingsSectionGuard();
     applyWorkspaceSearchRailFix();
     applyPluginInventoryTabMergeFix();

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -33,7 +33,7 @@ const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
 const { ensureCoreBundles, CORE_BUNDLE_NAMES } = require('./profile-manifest');
 const { dedupePatchEntries, dropBlocksByIds, parseFailedLoaderIds, mapPackagesToPatchIds } = require('./profile-patch-heal');
-const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, bundlePatchRel, verifyBundleDir, packageDirUpward, applyAppBootBundleGuard, applyProfileBootBundleGuard } = require('./profile-bundle-heal');
+const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, bundlePatchRel, verifyBundleDir, packageDirUpward, scanProfileBundles, recoverManifestBundles, applyAppBootBundleGuard, applyProfileBootBundleGuard } = require('./profile-bundle-heal');
 const { patchWebSearchBaseUrl } = require('./scripts/patch-web-search-baseurl');
 const { patchMenuViewport } = require('./scripts/patch-menu-viewport');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
@@ -938,6 +938,25 @@ function notifySafeBoot(ids) {
     n.show();
   } catch (err) {
     log('boot', '安全模式通知失败: ' + err.message);
+  }
+}
+
+// issue #48：profile manifest 重置是数据丢失类事件，除了日志还要给用户可见
+// 提示。集成测试实例与用户正在使用的桌面端并存（showBox 抑制的同一原因），
+// 测试态不弹真实通知，断言走 desktop.log。
+function notifyManifestResetRecovered(recovered) {
+  if (process.env.DSH_DESKTOP_TEST === '1') return;
+  try {
+    const n = new Notification({
+      title: 'DSH Desktop 配置自愈',
+      body: Array.isArray(recovered) && recovered.length > 0
+        ? 'profile 配置损坏，已备份并重建；检测到您安装的插件并已自动恢复：' + recovered.join(', ')
+        : 'profile 配置损坏，已备份并重建（原文件保留在 profile 目录的 .broken- 备份中，可对比找回原配置）',
+      icon: path.join(__dirname, 'assets', 'icon.png'),
+    });
+    n.show();
+  } catch (err) {
+    log('boot', '配置自愈通知失败: ' + err.message);
   }
 }
 
@@ -3306,8 +3325,10 @@ function syncCompanionPlugins() {
 
     const manifestFile = path.join(profileDir, 'package.json');
     let manifest = null;
-    try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch {}
+    let manifestReset = false; // 解析失败或顶层非法触发的重置（issue #48 数据恢复标记）
+    try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch { manifestReset = true; }
     if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+      manifestReset = true;
       // manifest 损坏：先备份原文件再重置（不可解析时原文是唯一现场），绝不
       // 静默丢弃用户数据。全新 profile 没有文件，不产生备份。
       if (fs.existsSync(manifestFile)) {
@@ -3372,6 +3393,23 @@ function syncCompanionPlugins() {
         writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
         log('boot', '配套 bundle 源缺失，已从 web profile bundles 移除（视为禁用）: ' + [...missingSourceNames].join(', '));
       }
+    }
+    // issue #48 数据恢复：manifest 重置分支会丢掉用户手动安装的第三方 bundle
+    // 登记（dependencies + bundles 条目）。这些包仍实际落在 profile node_modules
+    // 里，扫描并校验后合并回 manifest，用户插件在自愈后照常装配，无需手工恢复
+    // 备份。只动重置分支；正常启动时既有登记零改动（幂等）。
+    if (manifestReset && bundlesUsable && Array.isArray(manifest.dsh.profile.bundles)) {
+      const recovered = recoverManifestBundles(manifest, scanProfileBundles(
+        path.join(profileDir, 'node_modules'),
+        new Set([...CORE_BUNDLE_NAMES, ...COMPANION_PLUGINS.map((p) => p.name)]),
+      ));
+      if (recovered.length > 0) {
+        writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+        log('boot', 'profile manifest 重置后已恢复用户安装的 bundle 插件: ' + recovered.join(', '));
+      } else {
+        log('boot', 'profile manifest 已重置（原文件已备份），未发现需要恢复的用户 bundle');
+      }
+      notifyManifestResetRecovered(recovered);
     }
 
     // 非 bundle 插件注册到 profile 的 patch 层（幂等）。

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -32,8 +32,15 @@ const { installBuiltinPresets } = require('./scripts/install-minimal-win-preset'
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
 const { ensureCoreBundles, CORE_BUNDLE_NAMES } = require('./profile-manifest');
-const { dedupePatchEntries, dropBlocksByIds, parseFailedLoaderIds, mapPackagesToPatchIds } = require('./profile-patch-heal');
-const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, bundlePatchRel, verifyBundleDir, packageDirUpward, scanProfileBundles, recoverManifestBundles, applyAppBootBundleGuard, applyProfileBootBundleGuard } = require('./profile-bundle-heal');
+const { dedupePatchEntries, parseFailedLoaderIds, mapPackagesToPatchIds } = require('./profile-patch-heal');
+const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, verifyBundleDir, packageDirUpward, scanProfileBundles, recoverManifestBundles, applyAppBootBundleGuard, applyProfileBootBundleGuard } = require('./profile-bundle-heal');
+// 统一补丁引擎与共享数据源（scripts/lib/）：main.js 的运行时补丁、同步脚本
+// 与 after-pack 共用同一实现，杜绝重复与漂移。
+const { COMPANION_PLUGINS } = require('./scripts/lib/companion-plugins');
+const { writeFileAtomic } = require('./scripts/lib/patch-io');
+const { applyPatchToFiles } = require('./scripts/lib/patch-engine');
+const { FLASH_PKG_REL, EXPOSE_PKG_REL, patchTargets, transformFlashFix, transformExposeFix } = require('./scripts/lib/runtime-patches');
+const { ACP_DISABLE_BLOCK, PET_DISABLE_BLOCK, removeLegacyMarketplacePatchLines, ensureDisabledPatchEntry, registerCompanionPatchEntries, syncCompanionFiles } = require('./scripts/lib/companion-profile');
 const { patchWebSearchBaseUrl } = require('./scripts/patch-web-search-baseurl');
 const { patchMenuViewport } = require('./scripts/patch-menu-viewport');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
@@ -185,33 +192,6 @@ function log(tag, msg) {
   const line = `[${new Date().toISOString()}] [${tag}] ${msg}\n`;
   try { if (desktopLog) desktopLog.write(line); } catch {}
   if (process.env.DSH_DESKTOP_DEBUG) process.stdout.write(line);
-}
-
-// 启动提速：运行时补丁对同一物理文件（profile junction 别名、内置副本、
-// overlay 副本）反复整读。按 realpath 归一化 + size/mtime 校验做进程级读
-// 缓存；任何写入都会更新 mtime，缓存自动失效，不存在陈旧内容。
-const fileReadMemo = new Map(); // realpath -> { size, mtimeMs, text }
-const fileRealKeyMemo = new Map(); // path -> realpath（路径本身是固定常量）
-function fileRealKey(file) {
-  let key = fileRealKeyMemo.get(file);
-  if (key === undefined) {
-    try { key = fs.realpathSync(file); } catch { key = file; }
-    fileRealKeyMemo.set(file, key);
-  }
-  return key;
-}
-function readFileCached(file) {
-  try {
-    const st = fs.statSync(file);
-    const key = fileRealKey(file);
-    const hit = fileReadMemo.get(key);
-    if (hit && hit.size === st.size && hit.mtimeMs === st.mtimeMs) return hit.text;
-    const text = fs.readFileSync(file, 'utf8');
-    fileReadMemo.set(key, { size: st.size, mtimeMs: st.mtimeMs, text });
-    return text;
-  } catch {
-    return null;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2869,84 +2849,11 @@ function startBalanceLoop() {
 // ---------------------------------------------------------------------------
 // 配套 dsh 插件同步（注入 web profile：余额小部件 + 文件更改追踪/还原）
 // ---------------------------------------------------------------------------
-
-const COMPANION_PLUGINS = [
-  { id: 'balance', name: '@deepseek-ai/dsh-balance' },
-  { id: 'file-changes', name: '@deepseek-ai/dsh-file-changes' },
-  { id: 'client-file-changes', name: '@deepseek-ai/dsh-client-file-changes' },
-  { id: 'terminal', name: '@deepseek-ai/dsh-terminal-tab' },
-  { id: 'plugin-market', name: 'zat-dsh-engine' },
-  { id: 'better-sidebar', name: 'dsh-better-sidebar' },
-  { id: 'harness-pet', name: 'harness-pet' },
-  { id: 'float-window', name: '@deepseek-ai/dsh-float-window' },
-  // 对话节点导航条（vlln/dsh-navbar，MIT）：对话区右缘节点串快速跳转
-  // user 消息（悬停预览/点击跳转/滚轮切换），取代 conversation-tweaks
-  // 内置的会话滑轨。
-  { id: 'dsh-navbar', name: '@vlln/dsh-navbar' },
-  // 对话删除与归档管理（本仓库内置）：会话行菜单删除按钮 + 设置内归档管理
-  // 面板（恢复/删除）。依赖 patch-session-manage.js 的官方包运行时补丁。
-  { id: 'dsh-session-manager', name: 'dsh-session-manager' },
-  { id: 'conversation-tweaks', name: '@deepseek-ai/dsh-conversation-tweaks' },
-  { id: 'super-injector', name: '@dsh-external/dsh-super-injector' },
-  { id: 'prompt-custom', name: '@deepseek-ai/dsh-prompt-custom' },
-  { id: 'third-party-thinking', name: '@deepseek-ai/dsh-third-party-thinking' },
-  { id: 'wsl-settings', name: '@deepseek-ai/dsh-wsl-settings' },
-  { id: 'dsh-vision', name: '@dsh-external/dsh-vision' },
-  { id: 'side-session', name: '@dsh-external/dsh-side-session' },
-  { id: 'compaction-acp', name: 'billion-context-dsh' },
-  { id: 'plugin-manager', name: '@deepseek-ai/dsh-plugin-manager' },
-];
-
-function companionDirName(p) {
-  const slash = p.name.indexOf('/');
-  return slash >= 0 ? p.name.slice(slash + 1) : p.name;
-}
-
-function removeStaleCompanionPlugins(profileModules, expectedDirs) {
-  let entries;
-  try { entries = fs.readdirSync(profileModules, { withFileTypes: true }); } catch { return; }
-  for (const entry of entries) {
-    if (!entry.isDirectory() || expectedDirs.has(entry.name)) continue;
-    const pkgPath = path.join(profileModules, entry.name, 'package.json');
-    let pkg;
-    try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')); } catch { continue; }
-    // 只清理「DSH Desktop 配套插件」遗留的旧包名（例如改名为 dsh-terminal-tab
-    // 之前同步进 profile 的 dsh-terminal）。判定依据是该包由本壳层私有同步而来，
-    // 避免误删用户自己安装或官方预设依赖的同名包。
-    if (pkg && pkg.private === true && typeof pkg.description === 'string' && /DSH Desktop/.test(pkg.description)) {
-      try {
-        fs.rmSync(path.join(profileModules, entry.name), { recursive: true, force: true });
-        log('boot', '已清理过期配套插件: ' + entry.name);
-      } catch (err) {
-        log('boot', '清理过期配套插件失败 ' + entry.name + ': ' + err.message);
-      }
-    }
-  }
-}
-
-function removeLegacyMarketplace(profileWebModules, profileDir) {
-  // v0.3.5 起插件市场整体切换为 zat-dsh-engine（MIT）：
-  // 清理旧版 @deepseek-ai/dsh-plugin-marketplace 的同步副本与 patch 行。
-  const oldPkg = path.join(profileWebModules, '@deepseek-ai', 'dsh-plugin-marketplace');
-  try {
-    if (fs.existsSync(oldPkg)) {
-      fs.rmSync(oldPkg, { recursive: true, force: true });
-      log('boot', '已移除旧插件市场包: @deepseek-ai/dsh-plugin-marketplace');
-    }
-  } catch (err) {
-    log('boot', '移除旧插件市场包失败: ' + err.message);
-  }
-  const patchFile = path.join(profileDir, 'cordis.patch.yml');
-  try {
-    let patch = fs.readFileSync(patchFile, 'utf8');
-    const before = patch;
-    patch = patch.replace(/^\s*-\s*insert:\s*$\n^\s*-\s*id:\s*plugin-marketplace\s*$\n^\s*name:\s*['"]@deepseek-ai\/dsh-plugin-marketplace['"]\s*$\n?/gm, '');
-    if (patch !== before) {
-      fs.writeFileSync(patchFile, patch);
-      log('boot', '已从 cordis.patch.yml 移除旧插件市场条目');
-    }
-  } catch {}
-}
+// 配套插件清单 COMPANION_PLUGINS 的唯一数据源在 scripts/lib/companion-plugins.js
+//（与 scripts/sync-companion-plugins.js 共用，杜绝两处清单漂移）。
+// 过期插件清理 / 旧市场清理 / 文件同步 / bundle 校验 / 补丁条目注册等纯逻辑
+// 也统一收口在 scripts/lib/companion-profile.js，本文件只保留与桌面壳耦合的
+// manifest 恢复流程。
 
 // ---------------------------------------------------------------------------
 // profile patch 自愈：cordis.patch.yml 损坏会让 dsh web 装配 profile 时抛错并
@@ -2963,13 +2870,6 @@ function removeLegacyMarketplace(profileWebModules, profileDir) {
 function profilePatchFile() {
   const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
   return path.join(home, 'profiles', 'web', 'cordis.patch.yml');
-}
-
-/** 原子写入（临时文件 + rename），避免与 dsh 的 HMR 观察者撕裂读。 */
-function writePatchAtomic(file, content) {
-  const tmp = file + '.tmp';
-  fs.writeFileSync(tmp, content, 'utf8');
-  fs.renameSync(tmp, file);
 }
 
 // 惰性加载 js-yaml（随内置 dsh 存在于 resources/app/node_modules，传递依赖）；
@@ -3056,7 +2956,7 @@ function healProfilePatch() {
     const hasEntries = /^\s*-\s+(?:id|insert)\s*:/m.test(text);
     if (bareArray && hasEntries) {
       text = text.replace(/^\s*\[\]\s*$\n?/m, '');
-      writePatchAtomic(file, text);
+      writeFileAtomic(file, text);
       log('boot', 'profile patch 自愈: 移除了与列表混存的顶层 []（cordis.patch.yml）');
     }
     const yaml = loadDshYamlDialect();
@@ -3073,7 +2973,7 @@ function healProfilePatch() {
       if (dedupe.removed.length > 0) {
         const backup = file + '.dup-' + Date.now();
         try { fs.copyFileSync(file, backup); } catch {}
-        writePatchAtomic(file, dedupe.text);
+        writeFileAtomic(file, dedupe.text);
         log('boot', 'profile patch 自愈: 移除了重复注册的 loader 条目 ' + [...new Set(dedupe.removed)].join(', ') + '，原文件已备份到 ' + backup);
         text = dedupe.text;
       }
@@ -3111,42 +3011,8 @@ function resolvableCoreBundles() {
   });
 }
 
-// 递归比对 src/dest 的 size+mtime，任一文件缺失或不一致返回 true（需要同步）。
-// dest 目录整体不存在时直接返回 true，避免逐文件 stat 异常。
-function dirNeedsSync(src, dest) {
-  if (!fs.existsSync(dest)) return true;
-  let entries;
-  try { entries = fs.readdirSync(src, { withFileTypes: true }); } catch { return true; }
-  for (const e of entries) {
-    const s = path.join(src, e.name);
-    const d = path.join(dest, e.name);
-    if (e.isDirectory()) {
-      if (dirNeedsSync(s, d)) return true;
-    } else {
-      try {
-        const ss = fs.statSync(s);
-        const ds = fs.statSync(d);
-        if (ds.size !== ss.size || Math.round(ds.mtimeMs) !== Math.round(ss.mtimeMs)) return true;
-      } catch {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-// 目录级同步：内容一致时跳过，避免每次启动全量递归复制
-// （临时目录 + 杀软实时扫描下重复写盘最费时）。cpSync 必须保留时间戳，
-// 否则复制后的 mtime 每次都是"现在"，跳过比对永远不成立。
-function syncDir(src, dest) {
-  if (!fs.existsSync(src)) return;
-  try {
-    if (fs.existsSync(dest) && !dirNeedsSync(src, dest)) return;
-    fs.cpSync(src, dest, { recursive: true, force: true, preserveTimestamps: true });
-  } catch (err) {
-    log('boot', '同步目录失败 ' + src + ': ' + err.message);
-  }
-}
+// 目录级同步（dirNeedsSync + syncDir）收口在 scripts/lib/companion-profile.js，
+// 由 syncCompanionFiles 使用；本文件不再维护副本。
 
 // ---------------------------------------------------------------------------
 // profile bundle 健康检查（只读）：dsh web 启动前把每个 bundles 条目的装配
@@ -3189,110 +3055,45 @@ function syncCompanionPlugins() {
     const home = effectiveDshHome();
     if (!home) { log('boot', 'DSH_HOME 未解析，跳过配套插件同步'); return; }
     const profileDir = path.join(home, 'profiles', 'web');
-    const profileModules = path.join(profileDir, 'node_modules', '@deepseek-ai');
-    fs.mkdirSync(profileModules, { recursive: true });
-    const expectedDirs = new Set(COMPANION_PLUGINS.map(companionDirName));
-    removeStaleCompanionPlugins(profileModules, expectedDirs);
-    removeLegacyMarketplace(path.join(profileDir, 'node_modules'), profileDir);
+    const patchFile = path.join(profileDir, 'cordis.patch.yml');
+    // 插件文件同步 / 过期插件清理 / 旧市场目录清理 / 源缺失扫描 / bundle
+    // 落盘校验：与 scripts/sync-companion-plugins.js 共用 scripts/lib/
+    // companion-profile.js 的同一实现（日志文案经回调保持本函数原有输出）。
+    // 源缺失原则（issue #34 诊断的自愈死循环）：缺失源一律不写 patch 注册
+    //（否则「注册了但包不存在」会让 dsh web 启动崩溃）；若 manifest 仍登记
+    // 为 bundle，则视为用户意图禁用，从 bundles 移除。
+    const { bundleNames, missingNames: missingSourceNames } = syncCompanionFiles({
+      assetsRoot: path.join(__dirname, 'assets', 'plugins'),
+      profileDir,
+      vendorRoot: path.join(__dirname, 'node_modules'),
+      log: (m) => log('boot', m),
+      fail: (m) => log('boot', m),
+      onCopyFail: (sf, err) => log('boot', '同步配套插件文件失败 ' + sf + ': ' + err.message),
+      onVerifyFail: (name, reason) => log('boot', '配套 bundle 校验失败（按源缺失处理，不注册）: ' + name + ' —— ' + reason),
+    });
 
-    // 源缺失的配套插件（用户从 assets 删除 / 开发中裁剪 / 安装包损坏）：
-    // 既不能复制、也无法从源码确认 bundle 身份。处理原则（issue #34 诊断
-    // 的自愈死循环）：缺失源一律不写 patch 注册（否则「注册了但包不存在」
-    // 会让 dsh web 启动崩溃）；若 manifest 仍登记为 bundle，则视为用户
-    // 意图禁用，从 bundles 移除。
-    const missingSourceNames = new Set();
-    for (const p of COMPANION_PLUGINS) {
-      const sdir = path.join(__dirname, 'assets', 'plugins', companionDirName(p));
-      if (!fs.existsSync(path.join(sdir, 'package.json'))) missingSourceNames.add(p.name);
-    }
-
-    const bundleNames = new Set();
-    const copyFiles = [
-      'package.json', 'cordis.patch.yml', 'LICENSE', 'README.md', 'README.zh.md',
-      'lib/index.js', 'lib/index.mjs', 'lib/client.js', 'lib/vlm.js', 'lib/typert.host.js', 'lib/typert.host.d.ts',
-      'dsh.plugin.json',
-    ];
-    // 配套插件引用了不在 dsh 核心依赖闭包里的 npm 包时（例如 dsh-better-sidebar
-    // 使用的 schemastery / cosmokit），把内置副本一并落到 profile web node_modules，
-    // 保证 bundle 的宿主端能在 profile 内解析到这些依赖。
-    const vendorDeps = ['schemastery', 'cosmokit', '@standard-schema/spec'];
-    for (const name of vendorDeps) {
-      const sdir = path.join(__dirname, 'node_modules', name);
-      if (!fs.existsSync(sdir)) continue;
-      syncDir(sdir, path.join(profileDir, 'node_modules', name));
-    }
-    for (const p of COMPANION_PLUGINS) {
-      const rel = companionDirName(p);
-      const src = path.join(__dirname, 'assets', 'plugins', rel);
-      if (!fs.existsSync(path.join(src, 'package.json'))) continue;
-      let pkg = {};
-      try { pkg = JSON.parse(fs.readFileSync(path.join(src, 'package.json'), 'utf8')); } catch {}
-      const isBundle = bundlePatchRel(pkg) !== '';
-      // @deepseek-ai 与 @dsh-external 两种 scope 都按包名落到 profile 的
-      // node_modules 下；配套包自身的依赖由 dsh 的 profiles/node_modules
-      // fallback（healProfilesModuleFallback）解析。
-      const dest = path.join(profileModules, '..', p.name);
-      fs.mkdirSync(path.join(dest, 'lib'), { recursive: true });
-      for (const f of copyFiles) {
-        const sf = path.join(src, f);
-        if (!fs.existsSync(sf)) continue;
-        const df = path.join(dest, f);
-        // 逐文件比对大小+mtime，一致则跳过复制，避免每次启动都写盘
-        // （临时目录 + 杀软实时扫描下重复写入最费时）。注意 fs.copyFileSync
-        // 不保留时间戳（复制的目标 mtime=现在），会让比对永远不成立；这里
-        // 用 cpSync + preserveTimestamps 写，保证第二次启动能命中跳过。
-        try {
-          const sst = fs.statSync(sf);
-          const dst = fs.statSync(df);
-          if (dst.size === sst.size && Math.round(dst.mtimeMs) === Math.round(sst.mtimeMs)) continue;
-        } catch { /* 目标缺失或不可读 → 照常复制 */ }
-        try {
-          fs.cpSync(sf, df, { force: true, preserveTimestamps: true });
-        } catch (err) {
-          log('boot', '同步配套插件文件失败 ' + sf + ': ' + err.message);
-        }
+    // v0.3.5 起插件市场整体切换为 zat-dsh-engine（MIT）：清理旧版
+    // @deepseek-ai/dsh-plugin-marketplace 的 patch 行（幂等）。
+    try {
+      let legacyPatch = fs.readFileSync(patchFile, 'utf8');
+      const legacy = removeLegacyMarketplacePatchLines(legacyPatch);
+      if (legacy.changed) {
+        writeFileAtomic(patchFile, legacy.patch);
+        log('boot', '已从 cordis.patch.yml 移除旧插件市场条目');
       }
-      // 完整同步插件自带的 lib/assets/src/dist/node_modules 目录：第三方插件
-      // （如 dsh-better-sidebar 的懒加载 chunk、harness-pet 的动画素材、
-      // billion-context-dsh 的 dist 构建产物）不都落在固定文件清单里，递归
-      // 复制保证打包产物与资源随插件一起进 profile；node_modules 用于随包
-      // 分发插件的私有依赖（如 billion-context-dsh 的 acp-kernel），保证
-      // bundle 在 profile 内可解析。
-      for (const sub of ['lib', 'assets', 'src', 'dist', 'node_modules']) {
-        syncDir(path.join(src, sub), path.join(dest, sub));
-      }
-      // Bundle 插件不写 patch 行：dsh 在启动时读取 profile 的
-      // dsh.profile.bundles 并应用包内 cordis.patch.yml。
-      if (isBundle) {
-        // 落盘后校验 bundle 完整性：dsh 装配时会读取补丁层与入口文件，任一
-        // 缺失都会让整棵插件树加载失败（billion-context-dsh 上游缺 dist 构建
-        // 产物正是这类崩溃）。校验失败按「源缺失」处理：不注册、从 manifest
-        // 移除登记、日志告警，下次启动重试。
-        const check = verifyBundleDir(dest);
-        if (!check.ok) {
-          missingSourceNames.add(p.name);
-          log('boot', '配套 bundle 校验失败（按源缺失处理，不注册）: ' + p.name + ' —— ' + check.reason);
-        } else {
-          bundleNames.add(p.name);
-        }
-      }
-    }
+    } catch {}
 
     // billion-context-dsh（compaction-acp）是模型驱动的 ACP 压缩后端：同一
     // realm 内与 dsh 默认的 compaction-basic 不能并存（插件 README 的官方
     // 安装说明）。幂等写入禁用条目：patch 中已存在 compaction-basic 条目
     // （含用户手写的 disabled 块）则不动，尊重用户配置。
     if (bundleNames.has('billion-context-dsh')) {
-      const acpPatchFile = path.join(profileDir, 'cordis.patch.yml');
       try {
         let patch = '';
-        try { patch = fs.readFileSync(acpPatchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
-        if (!/(?:^|\n)\s*-?\s*id\s*:\s*compaction-basic\b/.test('\n' + patch)) {
-          const block = '\n# billion-context-dsh：禁用 preset realm 的 compaction-basic（ACP 模型驱动后端接管压缩决策）\n- id: compaction-basic\n  disabled: true\n';
-          if (/^\s*\[\]\s*$/m.test(patch)) patch = patch.replace(/\[\]/m, block.trim());
-          else if (patch.trim() === '') patch = '# dsh web profile patch（由 DSH Desktop 维护）\n' + block.trim();
-          else patch = patch.replace(/\s*$/, '\n') + block;
-          fs.writeFileSync(acpPatchFile, patch);
+        try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
+        const entry = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*compaction-basic\\b'), ACP_DISABLE_BLOCK);
+        if (entry.changed) {
+          writeFileAtomic(patchFile, entry.patch);
           log('boot', '已禁用 compaction-basic（billion-context-dsh 接管压缩后端）');
         }
       } catch (err) {
@@ -3300,22 +3101,18 @@ function syncCompanionPlugins() {
       }
     }
 
-    // 桌面宠物（harness-pet）默认关闭：客户端常驻 rAF 逐帧绘制 320x320
-    // canvas（issue #34 诊断为软渲染/流式输出下的持续阻塞源），且旧版保存的
-    // 开关值会覆盖客户端默认。插件级 disabled 条目一票否决任何已保存状态；
-    // 需要时可在 设置 → 插件 → 管理 一键开启（与 dsh-plugin-manager 同机制）。
-    // 幂等：patch 中已存在 harness-pet 条目（含用户手写）则不动，尊重用户配置。
+    // 桌面宠物（harness-pet）默认关闭：客户端常驻 rAF 逐帧绘制 canvas（issue
+    // #34 诊断为软渲染/流式输出下的持续阻塞源），且旧版保存的开关值会覆盖
+    // 客户端默认。插件级 disabled 条目一票否决任何已保存状态；需要时可在
+    // 设置 → 插件 → 管理 一键开启（与 dsh-plugin-manager 同机制）。幂等：
+    // patch 中已存在 harness-pet 条目（含用户手写）则不动，尊重用户配置。
     if (bundleNames.has('harness-pet')) {
-      const petPatchFile = path.join(profileDir, 'cordis.patch.yml');
       try {
         let patch = '';
-        try { patch = fs.readFileSync(petPatchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
-        if (!/(?:^|\n)\s*-?\s*id\s*:\s*harness-pet\b/.test('\n' + patch)) {
-          const block = '\n# harness-pet：桌面宠物默认关闭（设置 → 插件 → 管理 可一键开启）\n- id: harness-pet\n  disabled: true\n';
-          if (/^\s*\[\]\s*$/m.test(patch)) patch = patch.replace(/\[\]/m, block.trim());
-          else if (patch.trim() === '') patch = '# dsh web profile patch（由 DSH Desktop 维护）\n' + block.trim();
-          else patch = patch.replace(/\s*$/, '\n') + block;
-          fs.writeFileSync(petPatchFile, patch);
+        try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
+        const entry = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*harness-pet\\b'), PET_DISABLE_BLOCK);
+        if (entry.changed) {
+          writeFileAtomic(patchFile, entry.patch);
           log('boot', '已默认关闭桌面宠物（harness-pet，可在插件管理开启）');
         }
       } catch (err) {
@@ -3371,7 +3168,7 @@ function syncCompanionPlugins() {
       const healed = ensureCoreBundles(manifest.dsh.profile.bundles, resolvableCoreBundles());
       if (healed) {
         manifest.dsh.profile.bundles = healed.next;
-        writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
         log('boot', 'profile manifest 自愈: 旧版本写坏的 bundles 缺少核心 ' + healed.added.join(', ') + '，已补齐到最前');
       }
     }
@@ -3379,7 +3176,7 @@ function syncCompanionPlugins() {
       if (!bundlesUsable) break;
       if (!manifest.dsh.profile.bundles.includes(name)) {
         manifest.dsh.profile.bundles.push(name);
-        writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
         log('boot', '已把 bundle 插件加入 web profile bundles: ' + name);
       }
     }
@@ -3390,7 +3187,7 @@ function syncCompanionPlugins() {
       const before = manifest.dsh.profile.bundles.length;
       manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((n) => !missingSourceNames.has(n));
       if (manifest.dsh.profile.bundles.length !== before) {
-        writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
         log('boot', '配套 bundle 源缺失，已从 web profile bundles 移除（视为禁用）: ' + [...missingSourceNames].join(', '));
       }
     }
@@ -3404,7 +3201,7 @@ function syncCompanionPlugins() {
         new Set([...CORE_BUNDLE_NAMES, ...COMPANION_PLUGINS.map((p) => p.name)]),
       ));
       if (recovered.length > 0) {
-        writePatchAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
         log('boot', 'profile manifest 重置后已恢复用户安装的 bundle 插件: ' + recovered.join(', '));
       } else {
         log('boot', 'profile manifest 已重置（原文件已备份），未发现需要恢复的用户 bundle');
@@ -3412,73 +3209,21 @@ function syncCompanionPlugins() {
       notifyManifestResetRecovered(recovered);
     }
 
-    // 非 bundle 插件注册到 profile 的 patch 层（幂等）。
-    const patchFile = path.join(profileDir, 'cordis.patch.yml');
+    // 非 bundle 插件注册到 profile 的 patch 层（幂等）。bundle 迁移自愈
+    //（issue #17 同族：升级为 bundle 的插件残留 insert 行会造成同 id 双登记）、
+    // 源缺失残留移除、用户已有条目尊重与 name 就地改名统一收口在共享实现
+    // registerCompanionPatchEntries（与 scripts/sync-companion-plugins.js 同一
+    // 数据源；用户手写的 config/disabled 覆盖条目由 dropBlocksByIds 语义原样保留）。
     let patch = '';
     try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { patch = ''; }
-    let changed = false;
-    // bundle 迁移自愈（issue #17 同族）：旧版本把后来升级为 bundle 的配套插件
-    // 当非 bundle 写进了 patch（insert 行）；插件现经 dsh.profile.bundles 装配，
-    // 残留注册行会造成同 id 双登记 → cordis loader "duplicate loader entry id" →
-    // 整树加载失败（更新后首次启动崩溃）。幂等移除命中的注册行/块；用户手写
-    // 的 config 覆盖/disabled 禁用条目原样保留（PR #24 v2）。
-    const bundleIds = new Set();
-    for (const p of COMPANION_PLUGINS) {
-      if (bundleNames.has(p.name)) bundleIds.add(p.id);
-    }
-    if (bundleIds.size > 0 && patch.includes('- id:')) {
-      const migration = dropBlocksByIds(patch, [...bundleIds]);
-      if (migration.removed.length > 0) {
-        patch = migration.text;
-        changed = true;
-        log('boot', '已把 bundle 插件移出 profile patch（避免双登记）: ' + [...new Set(migration.removed)].join(', '));
-      }
-    }
-    // 源缺失插件的旧注册残留同样移除：不清理的话 loader 仍会尝试加载
-    // 不存在的包（issue #34 诊断的「Cannot find package」崩溃）；用户手写
-    // 的 config/disabled 覆盖条目由 dropBlocksByIds 语义原样保留。
-    if (missingSourceNames.size > 0 && patch.includes('- id:')) {
-      const missingIds = COMPANION_PLUGINS.filter((p) => missingSourceNames.has(p.name)).map((p) => p.id);
-      if (missingIds.length > 0) {
-        const drop = dropBlocksByIds(patch, missingIds);
-        if (drop.removed.length > 0) {
-          patch = drop.text;
-          changed = true;
-          log('boot', '已把源缺失插件移出 profile patch（避免注册不存在的包）: ' + [...new Set(drop.removed)].join(', '));
-        }
-      }
-    }
-    for (const p of COMPANION_PLUGINS) {
-      if (bundleNames.has(p.name)) continue;
-      // 源缺失：不写任何注册（复制循环已跳过它），避免「注册了但包不存在」
-      // 导致 dsh web 启动崩溃。
-      if (missingSourceNames.has(p.name)) continue;
-      // 该 id 在 patch 里已存在：若它现在的 name 与当前版本不一致（例如终端
-      // 包改名 @deepseek-ai/dsh-terminal → dsh-terminal-tab），就地改名为当前
-      // 值。否则旧名残留会让配套插件与 agent 内置终端重复注册路由、或加载
-      // 到已不属于本版本的包。只改 name 行，不动用户自己加的其它行。
-      const idNameRe = new RegExp('(id:\\s*' + p.id + '\\b[^\\n]*\\n\\s*name:\\s*\\x27)([^\\x27]*)(\\x27)');
-      const m = patch.match(idNameRe);
-      if (m) {
-        if (m[2] !== p.name) {
-          patch = patch.replace(idNameRe, '$1' + p.name + '$3');
-          changed = true;
-        }
-        continue;
-      }
-      // 尊重用户已有配置：id 只要出现过（例如用户手写的 disabled 条目）就不再
-      // 自动插入，避免「禁用后下次启动又被加回来」或同 id 重复条目导致 loader 报错。
-      if (new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*' + p.id + '\\b').test('\n' + patch)) {
-        continue;
-      }
-      const block = `- insert:\n    - id: ${p.id}\n      name: '${p.name}'\n`;
-      if (/^\s*\[\]\s*$/m.test(patch)) patch = patch.replace(/\[\]/m, block);
-      else if (patch.trim() === '') patch = '# dsh web profile patch（由 DSH Desktop 维护）\n' + block;
-      else patch = patch.replace(/\s*$/, '\n') + block;
-      changed = true;
-    }
-    if (changed) {
-      fs.writeFileSync(patchFile, patch);
+    const registration = registerCompanionPatchEntries(patch, {
+      plugins: COMPANION_PLUGINS,
+      bundleNames,
+      missingNames: missingSourceNames,
+      onDrop: (m) => log('boot', m),
+    });
+    if (registration.changed) {
+      writeFileAtomic(patchFile, registration.patch);
       log('boot', '已同步配套插件到 web profile: ' + COMPANION_PLUGINS.map((p) => p.id).join(', '));
     }
   } catch (err) {
@@ -3633,7 +3378,7 @@ function pluginManagerSetEnabled(id, enabled) {
     return { ok: false, error: String((err && err.message) || err) };
   }
   if (patched !== text) {
-    try { writePatchAtomic(file, patched); } catch (err) { return { ok: false, error: String((err && err.message) || err) }; }
+    try { writeFileAtomic(file, patched); } catch (err) { return { ok: false, error: String((err && err.message) || err) }; }
   }
   return { ok: true };
 }
@@ -3689,6 +3434,44 @@ function syncLocalAgentPresets() {
 }
 
 // ---------------------------------------------------------------------------
+// 运行时补丁候选路径（与旧实现逐项一致，仅消除逐函数复制的 path.join 样板）：
+//   本地模式三副本 = profile fallback（junction 写穿内置副本）→ 内置 app 副本
+//   → 用户更新过的 agent overlay；防护类补丁（app-boot / settings / workspace）
+//   另覆盖 overlay 嵌套 dsh 依赖副本，且内置副本优先。
+//   WSL 托管模式目标 = WSL 安装目录（profile fallback + agent，经 UNC 写穿），
+//   由 scripts/lib/runtime-patches.js 的 patchTargets 统一构造。
+// ---------------------------------------------------------------------------
+function runtimeCopyFiles(pkgRel) {
+  const home = dshHome || path.join(os.homedir(), '.dsh');
+  return [
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(__dirname, 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
+  ];
+}
+
+function runtimeGuardFiles(pkgRel) {
+  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+  return [
+    path.join(__dirname, 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
+  ];
+}
+
+// node_modules 根目录版本（web-search / menu-viewport / session-manage 三个
+// 包级补丁用）：WSL 模式下 home 为 UNC 等价路径（经 UNC 覆盖 WSL profile）。
+function runtimeNodeModulesRoots() {
+  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+  return [
+    path.join(home, 'profiles', 'node_modules'),
+    path.join(__dirname, 'node_modules'),
+    path.join(userDataDir, 'agent', 'node_modules'),
+  ];
+}
+
+// ---------------------------------------------------------------------------
 // dsh web 运行时闪跳修复：官方 dsh-client-runtime 在会话列表刷新
 // （mergeOrderedBaseline）时会丢弃「本地已创建、宿主全量列表尚未回显」的
 // 新会话，使 current 瞬时变 undefined，UI 闪回「选择工作区/无会话」状态。
@@ -3699,32 +3482,18 @@ function applyRuntimeFlashFix() {
   // wsl 托管模式目标换成 WSL 安装目录（profile fallback + agent，经 UNC 写穿，
   // fallback 符号链接未创建时由 agent 直连目标兜底）。
   const wslHome = effectiveDshHome();
-  const targets = isWslMode()
-    ? [
-        path.join(wslHome, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-runtime', 'lib', 'client.js'),
-        path.join(wslHome, 'agent', 'node_modules', '@deepseek-ai', 'dsh-client-runtime', 'lib', 'client.js'),
-      ]
-    : [
-        path.join(dshHome || path.join(os.homedir(), '.dsh'), 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-runtime', 'lib', 'client.js'),
-        path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-client-runtime', 'lib', 'client.js'),
-        path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-client-runtime', 'lib', 'client.js'),
-      ];
-  const oldPat = '(value) => baselineByKey.get(keyOf(value))).filter((value) => value !== void 0);';
-  const newPat = '(value) => baselineByKey.get(keyOf(value)) ?? value).filter((value) => value !== void 0);';
-  for (const file of targets) {
-    if (!file || !fs.existsSync(file)) continue;
-    try {
-      let src = readFileCached(file);
-      if (src === null) { log('boot', 'runtime 补丁: 读取失败，跳过 ' + file); continue; }
-      if (src.includes(newPat)) { log('boot', 'runtime 补丁: 已应用，跳过 ' + file); continue; }
-      if (!src.includes(oldPat)) { log('boot', 'runtime 补丁: 未匹配到目标代码（版本可能已变更），跳过 ' + file); continue; }
-      src = src.replace(oldPat, newPat);
-      fs.writeFileSync(file, src, { encoding: 'utf8' });
-      log('boot', 'runtime 补丁: 已修复会话列表刷新闪跳 ' + file);
-    } catch (err) {
-      log('boot', 'runtime 补丁失败(' + file + '): ' + err.message);
-    }
-  }
+  const files = isWslMode()
+    ? patchTargets(wslHome, FLASH_PKG_REL)
+    : runtimeCopyFiles(FLASH_PKG_REL);
+  applyPatchToFiles({
+    prefix: 'runtime 补丁',
+    files,
+    log: (m) => log('boot', m),
+    transform: transformFlashFix,
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file) => '已修复会话列表刷新闪跳 ' + file,
+    failLog: (file, err) => 'runtime 补丁失败(' + file + '): ' + err.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -3741,47 +3510,18 @@ function applyPromptExposeFix() {
   // 覆盖运行副本：profile fallback、内置 app 副本、更新 overlay；
   // wsl 托管模式目标换成 WSL 安装目录（profile fallback + agent，经 UNC 写穿）。
   const wslHome = effectiveDshHome();
-  const targets = isWslMode()
-    ? [
-        path.join(wslHome, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-        path.join(wslHome, 'agent', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-      ]
-    : [
-        path.join(dshHome || path.join(os.homedir(), '.dsh'), 'profiles', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-        path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-        path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-      ];
-  const namespaces = ['dsh-prompt', 'dsh-third-party-thinking', 'dsh-vision', 'dsh-conversation-tweaks'];
-  for (const file of targets) {
-    if (!file || !fs.existsSync(file)) continue;
-    try {
-      let src = readFileCached(file);
-      if (src === null) { log('boot', '提示词暴露补丁: 读取失败，跳过 ' + file); continue; }
-      const declIdx = src.indexOf('const WEB_SETTINGS_NAMESPACES = [');
-      if (declIdx === -1) {
-        log('boot', '提示词暴露补丁: 未找到 WEB_SETTINGS_NAMESPACES（版本可能已变更），跳过 ' + file);
-        continue;
-      }
-      // 只认声明之后最近的 `];`，避免插进文件里其它数组。
-      const closeIdx = src.indexOf('];', declIdx);
-      if (closeIdx === -1) {
-        log('boot', '提示词暴露补丁: 未匹配到命名空间数组收尾，跳过 ' + file);
-        continue;
-      }
-      const arrText = src.slice(declIdx, closeIdx);
-      const missing = namespaces.filter((ns) => !arrText.includes('"' + ns + '"'));
-      if (missing.length === 0) {
-        log('boot', '提示词暴露补丁: 已应用，跳过 ' + file);
-        continue;
-      }
-      const block = ',\n' + missing.map((ns) => '\t"' + ns + '"').join(',\n') + '\n';
-      src = src.slice(0, closeIdx) + block + src.slice(closeIdx);
-      fs.writeFileSync(file, src, { encoding: 'utf8' });
-      log('boot', '提示词暴露补丁: 已把 ' + missing.join(', ') + ' 加入设置白名单 ' + file);
-    } catch (err) {
-      log('boot', '提示词暴露补丁失败(' + file + '): ' + err.message);
-    }
-  }
+  const files = isWslMode()
+    ? patchTargets(wslHome, EXPOSE_PKG_REL)
+    : runtimeCopyFiles(EXPOSE_PKG_REL);
+  applyPatchToFiles({
+    prefix: '提示词暴露补丁',
+    files,
+    log: (m) => log('boot', m),
+    transform: transformExposeFix,
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file, note) => '已把 ' + note.join(', ') + ' 加入设置白名单 ' + file,
+    failLog: (file, err) => '提示词暴露补丁失败(' + file + '): ' + err.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -3791,11 +3531,6 @@ function applyPromptExposeFix() {
 // 详细文字（含 OCR）后再发送，文本模型也能“看图”。幂等，覆盖三处运行副本。
 // ---------------------------------------------------------------------------
 function applyImageSendFix() {
-  const targets = [
-    path.join(dshHome || path.join(os.homedir(), '.dsh'), 'profiles', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-  ];
   const HELPER_MARKER = 'async function describeImagesWithVision(ctx, content)';
   const HELPER_ANCHOR = '/** Validate one prompt as a batch before publishing any durable image object. */';
   const HELPER = `
@@ -3875,54 +3610,46 @@ async function describeImagesWithVision(ctx, content) {
 							}
 						}`;
 
-  for (const file of targets) {
-    if (!file || !fs.existsSync(file)) continue;
-    try {
-      let src = readFileCached(file);
-      if (src === null) { log('boot', '识图发送补丁: 读取失败，跳过 ' + file); continue; }
-      if (src.includes(HELPER_MARKER)) {
-        log('boot', '识图发送补丁: 已应用，跳过 ' + file);
-        continue;
-      }
+  applyPatchToFiles({
+    prefix: '识图发送补丁',
+    files: runtimeCopyFiles(EXPOSE_PKG_REL),
+    log: (m) => log('boot', m),
+    transform: (src, file) => {
+      if (src.includes(HELPER_MARKER)) return { status: 'already' };
       // 1) 插入转述 helper（此后所有索引必须基于插入后的 src 重新计算）
       const anchorIdx = src.indexOf(HELPER_ANCHOR);
       if (anchorIdx === -1) {
-        log('boot', '识图发送补丁: 未找到 helper 插入锚点（版本可能已变更），跳过 ' + file);
-        continue;
+        return { status: 'anchor-missing', detail: '未找到 helper 插入锚点（版本可能已变更），跳过 ' + file };
       }
       src = src.slice(0, anchorIdx) + HELPER + '\n' + src.slice(anchorIdx);
       // 2) prompt 入口：声明 admittedContent
       const hasImageIdx = src.indexOf('const hasImage = content.some((part) => part.type === "image");');
       if (hasImageIdx === -1) {
-        log('boot', '识图发送补丁: 未找到 hasImage 入口（版本可能已变更），跳过 ' + file);
-        continue;
+        return { status: 'anchor-missing', detail: '未找到 hasImage 入口（版本可能已变更），跳过 ' + file };
       }
       src = src.slice(0, hasImageIdx) + 'let admittedContent = content;\n\t\t\t\t' + src.slice(hasImageIdx);
       // 3) 把“模型不支持图片”的直接拒绝替换为自动转述
       const gateIdx = src.indexOf(GATE_MARKER);
       if (gateIdx === -1) {
-        log('boot', '识图发送补丁: 未找到模型图片门槛（版本可能已变更），跳过 ' + file);
-        continue;
+        return { status: 'anchor-missing', detail: '未找到模型图片门槛（版本可能已变更），跳过 ' + file };
       }
       const gateEnd = src.indexOf('});', gateIdx);
       if (gateEnd === -1) {
-        log('boot', '识图发送补丁: 图片门槛收尾异常，跳过 ' + file);
-        continue;
+        return { status: 'anchor-missing', detail: '图片门槛收尾异常，跳过 ' + file };
       }
       src = src.slice(0, gateIdx) + GATE_NEW + src.slice(gateEnd + 3);
       // 4) durablePromptContent 使用转述后的内容（从门槛之后查找调用点，避免命中函数定义）
       const callIdx = src.indexOf('durablePromptContent(ctx, content)', gateIdx);
       if (callIdx === -1) {
-        log('boot', '识图发送补丁: 未找到 durablePromptContent 调用，跳过 ' + file);
-        continue;
+        return { status: 'anchor-missing', detail: '未找到 durablePromptContent 调用，跳过 ' + file };
       }
       src = src.slice(0, callIdx) + 'durablePromptContent(ctx, admittedContent)' + src.slice(callIdx + 'durablePromptContent(ctx, content)'.length);
-      fs.writeFileSync(file, src, { encoding: 'utf8' });
-      log('boot', '识图发送补丁: 已启用文本模型图片自动转述 ' + file);
-    } catch (err) {
-      log('boot', '识图发送补丁失败(' + file + '): ' + err.message);
-    }
-  }
+      return { status: 'changed', src };
+    },
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file) => '已启用文本模型图片自动转述 ' + file,
+    failLog: (file, err) => '识图发送补丁失败(' + file + '): ' + err.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -3937,25 +3664,21 @@ function applyVisionKeyFix() {
   const guardMarker = 'dsh-desktop fix: read the resolved HOST-side value';
   const from = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
   const to = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.get === "function") {\n\t\t// dsh-desktop fix: read the resolved HOST-side value (settings.get), not the\n\t\t// redacted wire snapshot. redactSecrets strips role(\'secret\') fields, so\n\t\t// describe({redactSecrets:true}) drops apiKey and every keyed VLM endpoint\n\t\t// answers 401 — image sends failed for configured users.\n\t\tconst resolved = settings.get("dsh-vision");\n\t\tif (resolved !== void 0 && typeof resolved === "object") vision = resolved;\n\t}\n\tif (vision === null && settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
-  const targets = [
-    path.join(dshHome || path.join(os.homedir(), '.dsh'), 'profiles', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js'),
-  ];
-  for (const file of targets) {
-    if (!file || !fs.existsSync(file)) continue;
-    try {
-      let src2 = readFileCached(file);
-      if (src2 === null) { log('boot', '识图密钥补丁: 读取失败，跳过 ' + file); continue; }
-      if (src2.includes(guardMarker)) { log('boot', '识图密钥补丁: 已应用，跳过 ' + file); continue; }
-      if (!src2.includes(from)) { log('boot', '识图密钥补丁: 锚点未匹配（版本可能已变化），跳过 ' + file); continue; }
-      src2 = src2.replace(from, to);
-      fs.writeFileSync(file, src2, { encoding: 'utf8' });
-      log('boot', '识图密钥补丁: 已修复 apiKey 被脱敏截断 ' + file);
-    } catch (err) {
-      log('boot', '识图密钥补丁失败(' + file + '): ' + err.message);
-    }
-  }
+  applyPatchToFiles({
+    prefix: '识图密钥补丁',
+    files: runtimeCopyFiles(EXPOSE_PKG_REL),
+    log: (m) => log('boot', m),
+    transform: (src, file) => {
+      if (src.includes(guardMarker)) return { status: 'already' };
+      if (!src.includes(from)) {
+        return { status: 'anchor-missing', detail: '锚点未匹配（版本可能已变化），跳过 ' + file };
+      }
+      return { status: 'changed', src: src.replace(from, to) };
+    },
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file) => '已修复 apiKey 被脱敏截断 ' + file,
+    failLog: (file, err) => '识图密钥补丁失败(' + file + '): ' + err.message,
+  });
 }
 // ---------------------------------------------------------------------------
 // dsh 装配层防护：profile 自有的 cordis.patch.yml 属于用户数据，dsh 官方设计是
@@ -3988,31 +3711,21 @@ function applyProfilePatchGuard() {
     '\t\treturn [];\n' +
     '\t}\n' +
     '}';
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const candidates = [
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-  ];
-  for (const file of candidates) {
-    if (!fs.existsSync(file)) continue;
-    try {
-      let src = readFileCached(file);
-      if (src === null) { log('boot', 'profile patch 防护: 读取失败，跳过 ' + file); continue; }
-      if (src.includes(guardMarker)) continue; // 已应用（幂等）
+  applyPatchToFiles({
+    prefix: 'profile patch 防护',
+    files: runtimeGuardFiles(path.join('dsh-app-boot', 'lib', 'index.js')),
+    log: (m) => log('boot', m),
+    transform: (src, file) => {
+      if (src.includes(guardMarker)) return { status: 'already' }; // 已应用（幂等，静默）
       if (!src.includes(callSite) || !src.includes(insertAfter)) {
-        log('boot', 'profile patch 防护: ' + file + ' 锚点未匹配（dsh 版本可能已变化），跳过');
-        continue;
+        return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
       }
-      src = src.replace(callSite, callReplacement);
-      src = src.replace(insertAfter, insertAfter + '\n\n' + injected);
-      fs.writeFileSync(file, src, { encoding: 'utf8' });
-      log('boot', 'profile patch 防护: 已注入自愈加载到 ' + file);
-    } catch (err) {
-      log('boot', 'profile patch 防护失败: ' + err.message);
-    }
-  }
+      const out = src.replace(callSite, callReplacement);
+      return { status: 'changed', src: out.replace(insertAfter, insertAfter + '\n\n' + injected) };
+    },
+    doneLog: (file) => '已注入自愈加载到 ' + file,
+    failLog: (file, err) => 'profile patch 防护失败: ' + err.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -4027,58 +3740,57 @@ function applyProfilePatchGuard() {
 // profile-bundle-heal.js；dsh 更新后本函数会在下次启动重新应用。
 // ---------------------------------------------------------------------------
 function applyProfileBundleGuard() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const appBootCandidates = [
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
-  ];
-  for (const file of appBootCandidates) {
-    if (!fs.existsSync(file)) continue;
-    try {
-      const src = readFileCached(file);
-      if (src === null) { log('boot', 'profile bundle 防护: 读取失败，跳过 ' + file); continue; }
-      const out = applyAppBootBundleGuard(src);
-      if (!out.changed) {
-        if (!src.includes(PROFILE_BUNDLE_GUARD_MARKER)) {
-          log('boot', 'profile bundle 防护: ' + file + ' 锚点未匹配（dsh 版本可能已变化），跳过');
-        }
-        continue;
+  const appBootFiles = runtimeGuardFiles(path.join('dsh-app-boot', 'lib', 'index.js'));
+  const appBootTransform = (src, file) => {
+    const out = applyAppBootBundleGuard(src);
+    if (!out.changed) {
+      if (!src.includes(PROFILE_BUNDLE_GUARD_MARKER)) {
+        return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
       }
-      fs.writeFileSync(file, out.src, { encoding: 'utf8' });
-      log('boot', 'profile bundle 防护: 已注入自愈装配到 ' + file);
-    } catch (err) {
-      log('boot', 'profile bundle 防护失败(' + file + '): ' + err.message);
+      return { status: 'already' }; // 已注入（幂等，静默）
     }
-  }
+    return { status: 'changed', src: out.src };
+  };
+  applyPatchToFiles({
+    prefix: 'profile bundle 防护',
+    files: appBootFiles,
+    log: (m) => log('boot', m),
+    transform: appBootTransform,
+    doneLog: (file) => '已注入自愈装配到 ' + file,
+    failLog: (file, err) => 'profile bundle 防护失败(' + file + '): ' + err.message,
+  });
+
+  // dsh/lib/profile-boot-*.js：家级 cordis.patch.yml 与 profile 补丁层自愈。
+  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
   const profileBootDirs = [
     path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
     path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
     path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
   ];
+  const profileBootFiles = [];
   for (const dir of profileBootDirs) {
     let names;
     try { names = fs.readdirSync(dir).filter((f) => /^profile-boot-.+\.js$/.test(f)); } catch { continue; }
-    for (const name of names) {
-      const file = path.join(dir, name);
-      try {
-        const src = readFileCached(file);
-        if (src === null) { log('boot', 'profile bundle 防护: 读取失败，跳过 ' + file); continue; }
-        const out = applyProfileBootBundleGuard(src);
-        if (!out.changed) {
-          if (!src.includes(PROFILE_BOOT_GUARD_MARKER)) {
-            log('boot', 'profile bundle 防护: ' + file + ' 锚点未匹配（dsh 版本可能已变化），跳过');
-          }
-          continue;
-        }
-        fs.writeFileSync(file, out.src, { encoding: 'utf8' });
-        log('boot', 'profile bundle 防护: 已注入自愈装配到 ' + file);
-      } catch (err) {
-        log('boot', 'profile bundle 防护失败(' + file + '): ' + err.message);
-      }
-    }
+    for (const name of names) profileBootFiles.push(path.join(dir, name));
   }
+  const profileBootTransform = (src, file) => {
+    const out = applyProfileBootBundleGuard(src);
+    if (!out.changed) {
+      if (!src.includes(PROFILE_BOOT_GUARD_MARKER)) {
+        return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
+      }
+      return { status: 'already' }; // 已注入（幂等，静默）
+    }
+    return { status: 'changed', src: out.src };
+  };
+  applyPatchToFiles({
+    prefix: 'profile bundle 防护',
+    files: profileBootFiles,
+    log: (m) => log('boot', m),
+    transform: profileBootTransform,
+    doneLog: (file) => '已注入自愈装配到 ' + file,
+    failLog: (file, err) => 'profile bundle 防护失败(' + file + '): ' + err.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -4111,31 +3823,21 @@ function applySettingsSectionGuard() {
     '\t\t\treturn;\n' +
     '\t\t}\n' +
     '\t\thooks.setSource(() => scope.get());';
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const candidates = [
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-settings', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-settings', 'lib', 'index.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', 'dsh-settings', 'lib', 'index.js'),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-settings', 'lib', 'index.js'),
-  ];
-  for (const file of candidates) {
-    if (!fs.existsSync(file)) continue;
-    try {
-      let src = readFileCached(file);
-      if (src === null) { log('boot', 'settings 注册防护: 读取失败，跳过 ' + file); continue; }
-      if (src.includes(guardMarker)) continue; // 已应用（幂等）
+  const from2 = '\t\tconst scope = sctx.settings.register(ns, schema, {\n\t\t\tbase: entry,\n\t\t\t...hooks.validate === void 0 ? {} : { validate: hooks.validate }\n\t\t});\n\t\thooks.setSource(() => scope.get());';
+  applyPatchToFiles({
+    prefix: 'settings 注册防护',
+    files: runtimeGuardFiles(path.join('dsh-settings', 'lib', 'index.js')),
+    log: (m) => log('boot', m),
+    transform: (src, file) => {
+      if (src.includes(guardMarker)) return { status: 'already' }; // 已应用（幂等，静默）
       if (!src.includes(anchor)) {
-        log('boot', 'settings 注册防护: ' + file + ' 锚点未匹配（dsh 版本可能已变化），跳过');
-        continue;
+        return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
       }
-      const from2 = '\t\tconst scope = sctx.settings.register(ns, schema, {\n\t\t\tbase: entry,\n\t\t\t...hooks.validate === void 0 ? {} : { validate: hooks.validate }\n\t\t});\n\t\thooks.setSource(() => scope.get());';
-      src = src.replace(from2, guarded);
-      fs.writeFileSync(file, src, { encoding: 'utf8' });
-      log('boot', 'settings 注册防护: 已注入到 ' + file);
-    } catch (err) {
-      log('boot', 'settings 注册防护失败: ' + err.message);
-    }
-  }
+      return { status: 'changed', src: src.replace(from2, guarded) };
+    },
+    doneLog: (file) => '已注入到 ' + file,
+    failLog: (file, err) => 'settings 注册防护失败: ' + err.message,
+  });
 }
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
@@ -4146,35 +3848,26 @@ function applySettingsSectionGuard() {
 // 展开」。这里幂等地给监听加 searchOnExpand 宽限，并补进依赖数组。
 // ---------------------------------------------------------------------------
 function applyWorkspaceSearchRailFix() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
   const guardMarker = 'dsh-desktop fix: rail search expansion';
   const oldGuard = '\t\t\t\tif (!wide || !searchExpanded) return;';
   const newGuard = '\t\t\t\tif (!wide || !searchExpanded || searchOnExpand) return; // ' + guardMarker;
   const oldDeps = '\t\t\t}, [\n\t\t\t\tnormalizedQuery,\n\t\t\t\twide,\n\t\t\t\tsearchExpanded\n\t\t\t]);';
   const newDeps = '\t\t\t}, [\n\t\t\t\tnormalizedQuery,\n\t\t\t\twide,\n\t\t\t\tsearchExpanded,\n\t\t\t\tsearchOnExpand\n\t\t\t]);';
-  const candidates = [
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-client-ui-workspace', 'lib', 'client.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh-client-ui-workspace', 'lib', 'client.js'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', 'dsh-client-ui-workspace', 'lib', 'client.js'),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-ui-workspace', 'lib', 'client.js'),
-  ];
-  for (const file of candidates) {
-    if (!file || !fs.existsSync(file)) continue;
-    try {
-      let src = readFileCached(file);
-      if (src === null) { log('boot', 'workspace 搜索栏修复: 读取失败，跳过 ' + file); continue; }
-      if (src.includes(guardMarker)) { log('boot', 'workspace 搜索栏修复: 已应用，跳过 ' + file); continue; }
+  applyPatchToFiles({
+    prefix: 'workspace 搜索栏修复',
+    files: runtimeGuardFiles(path.join('dsh-client-ui-workspace', 'lib', 'client.js')),
+    log: (m) => log('boot', m),
+    transform: (src, file) => {
+      if (src.includes(guardMarker)) return { status: 'already' };
       if (!src.includes(oldGuard) || !src.includes(oldDeps)) {
-        log('boot', 'workspace 搜索栏修复: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file);
-        continue;
+        return { status: 'anchor-missing', detail: '锚点未匹配（dsh 版本可能已变化），跳过 ' + file };
       }
-      src = src.replace(oldGuard, newGuard).replace(oldDeps, newDeps);
-      fs.writeFileSync(file, src, { encoding: 'utf8' });
-      log('boot', 'workspace 搜索栏修复: 已注入到 ' + file);
-    } catch (err) {
-      log('boot', 'workspace 搜索栏修复失败(' + file + '): ' + err.message);
-    }
-  }
+      return { status: 'changed', src: src.replace(oldGuard, newGuard).replace(oldDeps, newDeps) };
+    },
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file) => '已注入到 ' + file,
+    failLog: (file, err) => 'workspace 搜索栏修复失败(' + file + '): ' + err.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -4188,23 +3881,25 @@ function applyPluginInventoryTabMergeFix() {
   const marker = 'dsh-desktop fix: hide inventory tab';
   const oldPat = 'tabs = ctx.slots.entries("settings.plugins.tab").map((entry) => ({';
   const newPat = 'tabs = ctx.slots.entries("settings.plugins.tab").filter((entry) => (entry.options.id ?? "") !== "all").map((entry) => ({ // ' + marker;
-  const candidates = [
+  const files = [
     path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
     path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
   ];
-  for (const file of candidates) {
-    if (!file || !fs.existsSync(file)) continue;
-    try {
-      let src = fs.readFileSync(file, 'utf8');
-      if (src.includes(marker)) { log('boot', '插件页标签合并: 已应用，跳过 ' + file); continue; }
-      if (!src.includes(oldPat)) { log('boot', '插件页标签合并: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file); continue; }
-      src = src.replace(oldPat, newPat);
-      fs.writeFileSync(file, src, { encoding: 'utf8' });
-      log('boot', '插件页标签合并: 已隐藏「全部」只读清单 ' + file);
-    } catch (err) {
-      log('boot', '插件页标签合并失败(' + file + '): ' + err.message);
-    }
-  }
+  applyPatchToFiles({
+    prefix: '插件页标签合并',
+    files,
+    log: (m) => log('boot', m),
+    transform: (src, file) => {
+      if (src.includes(marker)) return { status: 'already' };
+      if (!src.includes(oldPat)) {
+        return { status: 'anchor-missing', detail: '锚点未匹配（dsh 版本可能已变化），跳过 ' + file };
+      }
+      return { status: 'changed', src: src.replace(oldPat, newPat) };
+    },
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file) => '已隐藏「全部」只读清单 ' + file,
+    failLog: (file, err) => '插件页标签合并失败(' + file + '): ' + err.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -4215,12 +3910,7 @@ function applyPluginInventoryTabMergeFix() {
 // 自动跳过，绝不损坏文件。
 // ---------------------------------------------------------------------------
 function applyWebSearchBaseUrlFix() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const targets = [
-    path.join(home, 'profiles', 'node_modules'),
-    path.join(__dirname, 'node_modules'),
-    path.join(userDataDir, 'agent', 'node_modules'),
-  ];
+  const targets = runtimeNodeModulesRoots();
   for (const root of targets) {
     if (!root || !fs.existsSync(root)) continue;
     try {
@@ -4240,12 +3930,7 @@ function applyWebSearchBaseUrlFix() {
 // 更新过的 agent overlay。锚点不匹配（上游将来修复后）自动跳过，绝不损坏。
 // ---------------------------------------------------------------------------
 function applyMenuViewportFix() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const targets = [
-    path.join(home, 'profiles', 'node_modules'),
-    path.join(__dirname, 'node_modules'),
-    path.join(userDataDir, 'agent', 'node_modules'),
-  ];
+  const targets = runtimeNodeModulesRoots();
   for (const root of targets) {
     if (!root || !fs.existsSync(root)) continue;
     try {
@@ -4265,12 +3950,7 @@ function applyMenuViewportFix() {
 // 副本：profile fallback、内置 app 副本、用户更新过的 agent overlay。
 // ---------------------------------------------------------------------------
 function applySessionManageFix() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const targets = [
-    path.join(home, 'profiles', 'node_modules'),
-    path.join(__dirname, 'node_modules'),
-    path.join(userDataDir, 'agent', 'node_modules'),
-  ];
+  const targets = runtimeNodeModulesRoots();
   for (const root of targets) {
     if (!root || !fs.existsSync(root)) continue;
     try {

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -39,7 +39,7 @@ const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, verifyBundleDir,
 const { COMPANION_PLUGINS } = require('./scripts/lib/companion-plugins');
 const { writeFileAtomic } = require('./scripts/lib/patch-io');
 const { applyPatchToFiles } = require('./scripts/lib/patch-engine');
-const { FLASH_PKG_REL, EXPOSE_PKG_REL, patchTargets, transformFlashFix, transformExposeFix } = require('./scripts/lib/runtime-patches');
+const { FLASH_PKG_REL, EXPOSE_PKG_REL, patchTargets, localCopyFiles, guardCopyFiles, localNodeModulesRoots, transformFlashFix, transformExposeFix } = require('./scripts/lib/runtime-patches');
 const { ACP_DISABLE_BLOCK, PET_DISABLE_BLOCK, removeLegacyMarketplacePatchLines, ensureDisabledPatchEntry, registerCompanionPatchEntries, syncCompanionFiles } = require('./scripts/lib/companion-profile');
 const { patchWebSearchBaseUrl } = require('./scripts/patch-web-search-baseurl');
 const { patchMenuViewport } = require('./scripts/patch-menu-viewport');
@@ -1507,19 +1507,7 @@ function createWindow(opts = {}) {
   // Keep the window pinned to the local web UI; send external links out.
   // H1 修复：origin 精确比较（protocol+host+port），杜绝前缀/异域/userinfo 逃逸；
   // file: 一律拦截（同 webContents 下 file 页面仍持有 preload 桥）；will-redirect 同规则。
-  const isAllowedWebUrl = (url) => {
-    try {
-      const target = new URL(url);
-      if (target.protocol !== 'http:' && target.protocol !== 'https:') return false;
-      if (webUrl) {
-        const base = new URL(webUrl);
-        return target.origin === base.origin;
-      }
-      return target.hostname === '127.0.0.1' || target.hostname === 'localhost' || target.hostname === '::1';
-    } catch {
-      return false;
-    }
-  };
+  // 判定函数为模块级 isAllowedWebUrl（浮窗守卫共用同一实现，见会话浮窗小节）。
   const guardNavigation = (event, url) => {
     if (isAllowedWebUrl(url)) return;
     event.preventDefault();
@@ -2143,6 +2131,11 @@ async function runUpdateFlow(manual) {
       applySettingsSectionGuard();
       applyWorkspaceSearchRailFix();
       applyPluginInventoryTabMergeFix();
+      // 与 local 分支、与 WSL 启动分支一致：包级补丁同样立即重打（幂等），
+      // 避免「稍后重启」后以未修复的新 WSL agent 启动（历史漂移补齐）。
+      applyWebSearchBaseUrlFix();
+      applyMenuViewportFix();
+      applySessionManageFix();
     } else {
       await updater.applyUpdate(ctx, latest);
       // 新 overlay 已就位：立即重打运行时补丁（全部幂等），否则「稍后重启」后再
@@ -3434,41 +3427,29 @@ function syncLocalAgentPresets() {
 }
 
 // ---------------------------------------------------------------------------
-// 运行时补丁候选路径（与旧实现逐项一致，仅消除逐函数复制的 path.join 样板）：
+// 运行时补丁候选路径（构造收口在 scripts/lib/runtime-patches.js 的纯函数里，
+// 这里只绑定模块级变量）：
 //   本地模式三副本 = profile fallback（junction 写穿内置副本）→ 内置 app 副本
-//   → 用户更新过的 agent overlay；防护类补丁（app-boot / settings / workspace）
-//   另覆盖 overlay 嵌套 dsh 依赖副本，且内置副本优先。
+//   → 用户更新过的 agent overlay；防护类补丁（app-boot / settings / workspace /
+//   插件页标签合并）另覆盖 overlay 嵌套 dsh 依赖副本，且内置副本优先。
 //   WSL 托管模式目标 = WSL 安装目录（profile fallback + agent，经 UNC 写穿），
-//   由 scripts/lib/runtime-patches.js 的 patchTargets 统一构造。
+//   由 patchTargets 统一构造；包级补丁在 WSL 模式追加 WSL agent 直连根。
 // ---------------------------------------------------------------------------
 function runtimeCopyFiles(pkgRel) {
-  const home = dshHome || path.join(os.homedir(), '.dsh');
-  return [
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(__dirname, 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
-  ];
+  return localCopyFiles(dshHome || path.join(os.homedir(), '.dsh'), __dirname, userDataDir, pkgRel);
 }
 
 function runtimeGuardFiles(pkgRel) {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  return [
-    path.join(__dirname, 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
-  ];
+  return guardCopyFiles(effectiveDshHome() || path.join(os.homedir(), '.dsh'), __dirname, userDataDir, pkgRel);
 }
 
 // node_modules 根目录版本（web-search / menu-viewport / session-manage 三个
-// 包级补丁用）：WSL 模式下 home 为 UNC 等价路径（经 UNC 覆盖 WSL profile）。
+// 包级补丁用）：WSL 模式下 home 为 UNC 等价路径（经 UNC 覆盖 WSL profile），
+// 并追加 WSL agent 直连根兜底（与 patchTargets 的 agent 条目语义一致）。
 function runtimeNodeModulesRoots() {
   const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  return [
-    path.join(home, 'profiles', 'node_modules'),
-    path.join(__dirname, 'node_modules'),
-    path.join(userDataDir, 'agent', 'node_modules'),
-  ];
+  const extraRoots = isWslMode() ? [path.join(home, 'agent', 'node_modules')] : [];
+  return localNodeModulesRoots(home, __dirname, userDataDir, extraRoots);
 }
 
 // ---------------------------------------------------------------------------
@@ -3528,7 +3509,9 @@ function applyPromptExposeFix() {
 // 文本模型自动识图补丁：官方 apiproxy 在 session.prompt 入口检查模型是否支持
 // image 输入，不支持就直接拒绝。本补丁复用已安装的 dsh-vision 插件配置
 // （设置 → 识图插件（view_image）的 VLM baseURL/model/apiKey），把图片转述为
-// 详细文字（含 OCR）后再发送，文本模型也能“看图”。幂等，覆盖三处运行副本。
+// 详细文字（含 OCR）后再发送，文本模型也能“看图”。幂等；本地模式覆盖三处
+// 运行副本，WSL 托管模式覆盖 WSL profile fallback + agent（与闪跳/白名单
+// 补丁同模式，经 UNC 写穿）。
 // ---------------------------------------------------------------------------
 function applyImageSendFix() {
   const HELPER_MARKER = 'async function describeImagesWithVision(ctx, content)';
@@ -3610,9 +3593,13 @@ async function describeImagesWithVision(ctx, content) {
 							}
 						}`;
 
+  const wslHome = effectiveDshHome();
+  const files = isWslMode()
+    ? patchTargets(wslHome, EXPOSE_PKG_REL)
+    : runtimeCopyFiles(EXPOSE_PKG_REL);
   applyPatchToFiles({
     prefix: '识图发送补丁',
-    files: runtimeCopyFiles(EXPOSE_PKG_REL),
+    files,
     log: (m) => log('boot', m),
     transform: (src, file) => {
       if (src.includes(HELPER_MARKER)) return { status: 'already' };
@@ -3658,15 +3645,20 @@ async function describeImagesWithVision(ctx, content) {
 // 会把 role('secret') 的 apiKey 整字段删除，带密钥校验的 VLM 端点必然 401，
 // prompt 被拒、客户端提示「图片发送失败」。这里幂等改写为先读 settings.get()
 // 的宿主侧未脱敏解析值（保留 apiKey），describe 快照降级为回退。dsh 更新后
-// 本函数会在下次启动重新应用。
+// 本函数会在下次启动重新应用。本地模式覆盖三处运行副本；WSL 托管模式覆盖
+// WSL profile fallback + agent（与闪跳/白名单补丁同模式，经 UNC 写穿）。
 // ---------------------------------------------------------------------------
 function applyVisionKeyFix() {
   const guardMarker = 'dsh-desktop fix: read the resolved HOST-side value';
   const from = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
   const to = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.get === "function") {\n\t\t// dsh-desktop fix: read the resolved HOST-side value (settings.get), not the\n\t\t// redacted wire snapshot. redactSecrets strips role(\'secret\') fields, so\n\t\t// describe({redactSecrets:true}) drops apiKey and every keyed VLM endpoint\n\t\t// answers 401 — image sends failed for configured users.\n\t\tconst resolved = settings.get("dsh-vision");\n\t\tif (resolved !== void 0 && typeof resolved === "object") vision = resolved;\n\t}\n\tif (vision === null && settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
+  const wslHome = effectiveDshHome();
+  const files = isWslMode()
+    ? patchTargets(wslHome, EXPOSE_PKG_REL)
+    : runtimeCopyFiles(EXPOSE_PKG_REL);
   applyPatchToFiles({
     prefix: '识图密钥补丁',
-    files: runtimeCopyFiles(EXPOSE_PKG_REL),
+    files,
     log: (m) => log('boot', m),
     transform: (src, file) => {
       if (src.includes(guardMarker)) return { status: 'already' };
@@ -3874,17 +3866,14 @@ function applyWorkspaceSearchRailFix() {
 // 插件页标签合并补丁：官方「全部」只读清单与 dsh-plugin-manager 的「管理」标签
 // 功能重叠（管理已含全量列表 + 搜索 + 分类 + 开关）。幂等地从插件页标签列表
 // 中过滤掉 id 为 "all" 的只读清单，让「管理」成为唯一的插件列表入口。
-// 目标：内置副本 + profile fallback；锚点不匹配（上游将来修复后）自动跳过。
+// 目标与其它防护类补丁一致：内置副本 + 更新 overlay（含嵌套 dsh 依赖副本）+
+// profile fallback；锚点不匹配（上游将来修复后）自动跳过。
 // ---------------------------------------------------------------------------
 function applyPluginInventoryTabMergeFix() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
   const marker = 'dsh-desktop fix: hide inventory tab';
   const oldPat = 'tabs = ctx.slots.entries("settings.plugins.tab").map((entry) => ({';
   const newPat = 'tabs = ctx.slots.entries("settings.plugins.tab").filter((entry) => (entry.options.id ?? "") !== "all").map((entry) => ({ // ' + marker;
-  const files = [
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
-  ];
+  const files = runtimeGuardFiles(path.join('dsh-client-ui-settings-plugins', 'lib', 'client.js'));
   applyPatchToFiles({
     prefix: '插件页标签合并',
     files,

--- a/dsh-desktop/package.json
+++ b/dsh-desktop/package.json
@@ -2,7 +2,7 @@
     "name":  "dsh-desktop",
     "productName":  "DSH Desktop",
     "version":  "0.3.9",
-    "description":  "DeepSeek Harness (dsh) 寮€绠卞嵆鐢ㄧ殑 Windows 妗岄潰瀹㈡埛绔細鍐呯疆 dsh CLI 涓?Node 杩愯鏃讹紝涓€閿惎鍔?Web UI",
+    "description":  "DeepSeek Harness (dsh) 开箱即用的 Windows 桌面客户端：内置 dsh CLI 与 Node 运行时，一键启动 Web UI",
     "main":  "main.js",
     "author":  "DSH Desktop",
     "license":  "MIT",

--- a/dsh-desktop/preload.js
+++ b/dsh-desktop/preload.js
@@ -306,14 +306,14 @@ function renderMenu() {
     item.addEventListener('click', async () => {
       const act = item.dataset.act;
       if (act === 'toggle-notify' || act === 'toggle-close-to-tray' || act === 'toggle-balance') {
-        const next = await dshDesktop.menu.action(act);
+        const next = await dshDesktop.menu.action(act).catch(() => null);
         if (next) state = { ...state, ...next };
         renderMenu();
         return;
       }
       closeMenu();
       if (act === 'sponsor') { dshDesktop.sponsorWindow(); return; }
-      dshDesktop.menu.action(act);
+      dshDesktop.menu.action(act).catch(() => {});
     });
   });
   // 更新源复制按钮
@@ -323,7 +323,7 @@ function renderMenu() {
       const kind = btn.dataset.copy;
       const url = state.repoUrls && (kind === 'github' ? state.repoUrls.github : state.repoUrls.gitee);
       if (!url) return;
-      const r = await dshDesktop.copyText(url);
+      const r = await dshDesktop.copyText(url).catch(() => null);
       if (r && r.ok) {
         const prev = btn.textContent;
         btn.textContent = '已复制 ✓';
@@ -443,6 +443,8 @@ function injectChrome() {
   dshDesktop.getInfo().then((info) => {
     if (!info) return;
     state = { ...state, ...info };
+    // 回填旧字段 dshDesktop.appVersion（bridge 注释声明的契约，此前漏实现）。
+    if (typeof info.appVersion === 'string' && info.appVersion) dshDesktop.appVersion = info.appVersion;
     if (info.appVersion) badge.textContent = 'v' + info.appVersion;
     if (info.agentVersion) badge.title = 'agent v' + info.agentVersion + '（' + info.agentSource + '）';
     if (info.agentVersion) { badge.hidden = false; }

--- a/dsh-desktop/profile-bundle-heal.js
+++ b/dsh-desktop/profile-bundle-heal.js
@@ -97,6 +97,68 @@ function packageDirUpward(anchorDir, packageName) {
 }
 
 /**
+ * 扫描 profile node_modules 中实际落盘且可装配的第三方 bundle 包（issue #48
+ * 数据恢复用：manifest 重置后用户手动安装的插件仍留在磁盘上，据此恢复登记）。
+ * 只返回通过 verifyBundleDir 完整校验的包；excludeNames（核心 + 配套插件名）
+ * 与未声明 dsh.bundle 的普通依赖一律排除。结果按包名排序保证确定性。
+ * @returns [{ name: string, version: string }]
+ */
+function scanProfileBundles(modulesDir, excludeNames) {
+  const found = [];
+  let top;
+  try { top = fs.readdirSync(modulesDir, { withFileTypes: true }); } catch { return found; }
+  const candidates = [];
+  for (const entry of top) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('@')) {
+      let scoped;
+      try { scoped = fs.readdirSync(path.join(modulesDir, entry.name), { withFileTypes: true }); } catch { continue; }
+      for (const sub of scoped) {
+        if (!sub.isDirectory()) continue;
+        candidates.push({ name: entry.name + '/' + sub.name, dir: path.join(modulesDir, entry.name, sub.name) });
+      }
+    } else {
+      candidates.push({ name: entry.name, dir: path.join(modulesDir, entry.name) });
+    }
+  }
+  candidates.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  for (const { name, dir } of candidates) {
+    if (excludeNames.has(name)) continue;
+    let pkg = null;
+    try { pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')); } catch { continue; }
+    if (!pkg || typeof pkg !== 'object' || typeof pkg.name !== 'string' || pkg.name === '') continue;
+    if (!bundlePatchRel(pkg)) continue;
+    // 入口 / 补丁层缺失的包即使恢复登记也会被启动防护跳过，一律不登记。
+    if (!verifyBundleDir(dir).ok) continue;
+    found.push({ name: pkg.name, version: typeof pkg.version === 'string' ? pkg.version : '' });
+  }
+  return found;
+}
+
+/**
+ * 把扫描到的第三方 bundle 合并回 profile manifest：bundles 追加缺失项（保持
+ * 既有顺序），dependencies 补回包名（用包内声明的版本号；git 依赖等非常规
+ * 来源无法还原原始 spec，登记版本号可保证后续 pnpm 安装不把它当孤儿包清理）。
+ * @returns 本次实际恢复的包名列表。
+ */
+function recoverManifestBundles(manifest, found) {
+  const bundles = Array.isArray(manifest && manifest.dsh && manifest.dsh.profile && manifest.dsh.profile.bundles)
+    ? manifest.dsh.profile.bundles : [];
+  const dependencies = (manifest && manifest.dependencies && typeof manifest.dependencies === 'object' && !Array.isArray(manifest.dependencies))
+    ? manifest.dependencies : {};
+  const recovered = [];
+  for (const item of found) {
+    if (bundles.includes(item.name)) continue;
+    bundles.push(item.name);
+    if (typeof dependencies[item.name] !== 'string' || dependencies[item.name] === '') dependencies[item.name] = item.version;
+    recovered.push(item.name);
+  }
+  manifest.dsh.profile.bundles = bundles;
+  if (recovered.length > 0) manifest.dependencies = dependencies;
+  return recovered;
+}
+
+/**
  * 原子写（临时文件 + rename），避免与 dsh 的 HMR 观察者撕裂读。
  */
 function writeFileAtomic(file, content) {
@@ -282,6 +344,8 @@ module.exports = {
   bundleEntryOf,
   verifyBundleDir,
   packageDirUpward,
+  scanProfileBundles,
+  recoverManifestBundles,
   writeFileAtomic,
   applyAppBootBundleGuard,
   applyProfileBootBundleGuard,

--- a/dsh-desktop/profile-bundle-heal.js
+++ b/dsh-desktop/profile-bundle-heal.js
@@ -1,0 +1,288 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// profile bundle 装配链防护（main.js applyProfileBundleGuard 与
+// scripts/sync-companion-plugins.js 共用）：把 dsh 对 profile bundle 的
+// fail-loud 启动语义收口为「诊断 + 跳过该层 + 继续启动」。覆盖的崩溃形态
+// （均在最新 vendored dsh 0.1.0-rc.6 上实机复现）：
+//   1. cannot resolve profile bundle —— manifest 登记了未安装 / 被清理的包；
+//   2. declares no dsh.bundle —— 普通库或仅客户端 bundle（dsh.bundle 无
+//      patch 层）被登记为 profile 层；
+//   3. bundle 的 cordis.patch.yml 缺失 / 无法解析；
+//   4. profiles/<name>/package.json 读不出 / JSON 损坏 / 顶层非对象；
+//   5. $DSH_HOME/cordis.patch.yml（家级用户补丁层）损坏 —— 同时覆盖启动
+//      与 HMR 热重载路径。
+//
+// 本模块不持有任何 dsh 安装路径，只提供纯函数：幂等的源码字符串变换（锚点
+// 不匹配时原样返回）、bundle 目录只读校验与原子写；具体文件定位与写入时机由
+// main.js / 同步脚本决定。dsh 版本更新后锚点失配时，防护会跳过并在日志告警
+// （与既有运行时补丁一致），下次启动重试。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/** dsh-app-boot 注入代码的幂等标记。 */
+const PROFILE_BUNDLE_GUARD_MARKER = 'dsh-desktop guard: a broken profile bundle must not brick';
+/** dsh profile-boot 注入代码的幂等标记。 */
+const PROFILE_BOOT_GUARD_MARKER = 'function loadUserPatchLayerSafe';
+
+// ---------------------------------------------------------------------------
+// bundle 包描述解析（纯函数）
+// ---------------------------------------------------------------------------
+
+/**
+ * 取 package.json 声明的 dsh.bundle.patch 相对路径；未声明 / 空串 / 非字符串
+ * 一律返回空串（调用方按「不是可装配 bundle」处理）。
+ */
+function bundlePatchRel(pkg) {
+  const patch = pkg && pkg.dsh && pkg.dsh.bundle && pkg.dsh.bundle.patch;
+  return typeof patch === 'string' && patch.trim() !== '' ? patch : '';
+}
+
+/**
+ * 取 bundle 包的入口文件（exports["."] 优先，其次 main）；解析不出返回空串。
+ * dsh 装配 bundle 时会 import 该入口，入口文件缺失即整棵插件树加载失败。
+ */
+function bundleEntryOf(pkg) {
+  const ex = pkg && pkg.exports;
+  if (ex && typeof ex === 'object' && !Array.isArray(ex)) {
+    const dot = ex['.'];
+    if (typeof dot === 'string') return dot;
+    if (dot && typeof dot === 'object') return dot.import || dot.default || '';
+  }
+  return (pkg && typeof pkg.main === 'string') ? pkg.main : '';
+}
+
+// ---------------------------------------------------------------------------
+// 落盘 bundle 目录校验（同步写入侧防呆）
+// ---------------------------------------------------------------------------
+
+/**
+ * 校验一个已落盘的 bundle 目录：package.json 可解析、声明了 dsh.bundle.patch、
+ * 补丁层与入口文件都存在。任一不满足返回 { ok:false, reason } —— 同步方必须
+ * 按「源缺失」处理（不注册为 profile bundle），否则 dsh 启动时必然崩溃。
+ */
+function verifyBundleDir(dir) {
+  let pkg = null;
+  try {
+    pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+  } catch (err) {
+    return { ok: false, reason: 'package.json 不可读或不是合法 JSON: ' + ((err && err.message) || err) };
+  }
+  const patchRel = bundlePatchRel(pkg);
+  if (!patchRel) return { ok: false, reason: 'package.json 未声明 dsh.bundle.patch' };
+  const patchFile = path.join(dir, patchRel);
+  if (!fs.existsSync(patchFile)) return { ok: false, reason: '补丁层缺失: ' + patchRel };
+  const entry = bundleEntryOf(pkg);
+  if (entry && !fs.existsSync(path.join(dir, entry))) return { ok: false, reason: '入口文件缺失: ' + entry };
+  return { ok: true, reason: '' };
+}
+
+/**
+ * 沿 Node 的 node_modules 父目录查找顺序探测包目录（等价于
+ * resolveBundleDir 的第一锚点语义，且不依赖包导出 ./package.json）。
+ * 找不到返回空串。
+ */
+function packageDirUpward(anchorDir, packageName) {
+  const parts = packageName.split('/');
+  let dir = anchorDir;
+  for (;;) {
+    const candidate = path.join(dir, 'node_modules', ...parts);
+    if (fs.existsSync(path.join(candidate, 'package.json'))) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return '';
+    dir = parent;
+  }
+}
+
+/**
+ * 原子写（临时文件 + rename），避免与 dsh 的 HMR 观察者撕裂读。
+ */
+function writeFileAtomic(file, content) {
+  const tmp = file + '.tmp';
+  fs.writeFileSync(tmp, content, 'utf8');
+  fs.renameSync(tmp, file);
+}
+
+// ---------------------------------------------------------------------------
+// @deepseek-ai/dsh-app-boot/lib/index.js 变换
+// ---------------------------------------------------------------------------
+
+// loadProfile 中逐个 bundle 严格装配的原始代码块（built 文件为制表符缩进）。
+const APP_BOOT_LAYERS_ANCHOR = [
+  '\tconst layers = (normalizeShippedProfile(name, dir, readProfileManifest(binName, dir)).dsh?.profile?.bundles ?? []).map((packageName) => {',
+  '\t\tconst packageDir = resolveBundleDir(binName, packageName, installAnchor, dir);',
+  '\t\tconst declared = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).dsh?.bundle?.patch;',
+  '\t\tif (declared === void 0) throw new Error(`${binName}: profile bundle ${JSON.stringify(packageName)} declares no dsh.bundle in its package.json`);',
+  '\t\tconst patchPath = join(packageDir, declared);',
+  '\t\treturn {',
+  '\t\t\tpackageName,',
+  '\t\t\tpackageDir,',
+  '\t\t\tpatchPath,',
+  '\t\t\tpatches: loadOverlayPatches(binName, patchPath)',
+  '\t\t};',
+  '\t});',
+].join('\n');
+
+// 注入位置：composeEntries 函数声明前（模块作用域内所有被用符号均可见）。
+const APP_BOOT_INSERT_ANCHOR = 'function composeEntries(layers, warn = () => {}) {';
+
+const APP_BOOT_GUARD_CODE = [
+  '/** dsh-desktop guard: a broken profile bundle must not brick the surface. Every',
+  ' * `dsh.profile.bundles` entry is loaded through this helper: an unresolvable',
+  ' * package, an unreadable or unparsable bundle manifest, a missing',
+  ' * `dsh.bundle.patch` declaration, or a bundle patch layer that fails to load',
+  ' * no longer aborts the boot — the layer is skipped with a labelled stderr',
+  ' * diagnostic and the profile boots without it. A corrupt profile manifest is',
+  ' * backed up and re-initialized from the shipped template (its previous content',
+  ' * stays in the `.broken-` backup). */',
+  'function loadProfileManifestSafe(binName, name, dir) {',
+  '\ttry {',
+  '\t\treturn readProfileManifest(binName, dir);',
+  '\t} catch (error) {',
+  '\t\tconst file = join(dir, "package.json");',
+  '\t\tlet backup = null;',
+  '\t\ttry {',
+  '\t\t\tif (existsSync(file)) {',
+  '\t\t\t\tbackup = `' + '${file}.broken-${Date.now()}`' + ';',
+  '\t\t\t\twriteFileSync(backup, readFileSync(file, "utf8"));',
+  '\t\t\t}',
+  '\t\t\tconst manifest = {',
+  '\t\t\t\tname: `' + 'dsh-profile-${basename(dir)}`' + ',',
+  '\t\t\t\tprivate: true,',
+  '\t\t\t\tdependencies: {},',
+  '\t\t\t\tdsh: { profile: { bundles: [...(PROFILE_TEMPLATES[name] ?? DEFAULT_PROFILE_BUNDLES)] } }',
+  '\t\t\t};',
+  '\t\t\twriteFileSync(file, JSON.stringify(manifest, void 0, 2) + "\\n");',
+  '\t\t} catch (recoveryError) {',
+  '\t\t\tthrow new Error(`' + '${binName}: profile manifest ${file} is unusable (${String(error?.message ?? error)}) and recovery failed (${String(recoveryError?.message ?? recoveryError)})`' + ');',
+  '\t\t}',
+  '\t\tprocess.stderr.write(`' + '${binName}: profile manifest ${file} failed to load (${String(error?.message ?? error)})${backup !== null ? `; the broken file was backed up to ${backup}` : ""}; the profile was re-initialized with its shipped bundle template\\n`' + ');',
+  '\t\treturn readProfileManifest(binName, dir);',
+  '\t}',
+  '}',
+  'function loadBundleLayerSafe(binName, packageName, installAnchor, profileDir) {',
+  '\tconst skip = (reason) => {',
+  '\t\tprocess.stderr.write(`' + '${binName}: profile bundle ${JSON.stringify(packageName)} skipped — ${reason}\\n`' + ');',
+  '\t\treturn { packageName, packageDir: null, patchPath: null, patches: [] };',
+  '\t};',
+  '\tlet packageDir;',
+  '\ttry {',
+  '\t\tpackageDir = resolveBundleDir(binName, packageName, installAnchor, profileDir);',
+  '\t} catch (error) {',
+  '\t\treturn skip(`' + 'cannot resolve it from the dsh installation or ${profileDir} (${String(error?.message ?? error)}); run \'dsh plugin --profile ${basename(profileDir)} install\' if its dependency is not installed`' + ');',
+  '\t}',
+  '\tlet manifest;',
+  '\ttry {',
+  '\t\tmanifest = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));',
+  '\t} catch (error) {',
+  '\t\treturn skip(`' + 'its package.json cannot be read or parsed (${String(error?.message ?? error)}); reinstall it with \'dsh plugin --profile ${basename(profileDir)} install\'`' + ');',
+  '\t}',
+  '\tconst declared = manifest?.dsh?.bundle?.patch;',
+  '\tif (typeof declared !== "string" || declared === "") {',
+  '\t\tconst hint = manifest?.dsh?.bundle !== void 0',
+  '\t\t\t? "it declares dsh.bundle without a patch layer (a client-only bundle has no Node layer to mount)"',
+  '\t\t\t: "it declares no dsh.bundle in its package.json (not a dsh plugin bundle)";',
+  '\t\treturn skip(`' + '${hint}; it stays out of the profile layer stack`' + ');',
+  '\t}',
+  '\tconst patchPath = join(packageDir, declared);',
+  '\ttry {',
+  '\t\treturn { packageName, packageDir, patchPath, patches: loadOverlayPatches(binName, patchPath) };',
+  '\t} catch (error) {',
+  '\t\treturn skip(`' + 'its patch layer ${patchPath} failed to load (${String(error?.message ?? error)}); the bundle stays disabled until its files are restored`' + ');',
+  '\t}',
+  '}',
+  'function loadProfileLayers(binName, name, dir, installAnchor) {',
+  '\tconst manifest = loadProfileManifestSafe(binName, name, dir);',
+  '\tconst normalized = normalizeShippedProfile(name, dir, manifest);',
+  '\tconst bundles = normalized.dsh?.profile?.bundles;',
+  '\tif (bundles !== void 0 && !Array.isArray(bundles)) {',
+  '\t\tprocess.stderr.write(`' + '${binName}: profile ${JSON.stringify(name)}: dsh.profile.bundles must be an array (got ${typeof bundles}); booting without bundle layers — fix the profile manifest or run \'dsh plugin --profile ${name} install\'\\n`' + ');',
+  '\t\treturn [];',
+  '\t}',
+  '\treturn (bundles ?? []).map((packageName) => loadBundleLayerSafe(binName, packageName, installAnchor, dir));',
+  '}',
+].join('\n');
+
+/**
+ * 改写 dsh-app-boot/lib/index.js：把 loadProfile 的严格 bundle 装配替换为
+ * 自愈装配（bundle 层跳过 + manifest 备份重建）。已注入或锚点失配时原样返回。
+ * @returns {{ changed: boolean, src: string }}
+ */
+function applyAppBootBundleGuard(src) {
+  if (typeof src !== 'string') return { changed: false, src };
+  if (src.includes(PROFILE_BUNDLE_GUARD_MARKER)) return { changed: false, src };
+  if (!src.includes(APP_BOOT_LAYERS_ANCHOR) || !src.includes(APP_BOOT_INSERT_ANCHOR)) return { changed: false, src };
+  let out = src.replace(APP_BOOT_LAYERS_ANCHOR, '\tconst layers = loadProfileLayers(binName, name, dir, installAnchor);');
+  out = out.replace(APP_BOOT_INSERT_ANCHOR, APP_BOOT_GUARD_CODE + '\n\n' + APP_BOOT_INSERT_ANCHOR);
+  return { changed: true, src: out };
+}
+
+// ---------------------------------------------------------------------------
+// @deepseek-ai/dsh/lib/profile-boot-*.js 变换（家级补丁层自愈）
+// ---------------------------------------------------------------------------
+
+const PROFILE_BOOT_IMPORT_ANCHOR = 'import { writeFileSync } from "node:fs";';
+const PROFILE_BOOT_HOME_ANCHOR = '\tconst homePatches = loadOptionalPatches(NAME, homePatchPath()) ?? [];';
+const PROFILE_BOOT_LIVE_PROFILE_ANCHOR = '\t\t...loadOptionalPatches(NAME, composed.profile.patchPath) ?? [],';
+const PROFILE_BOOT_LIVE_HOME_ANCHOR = '\t\t...loadOptionalPatches(NAME, homePatchPath()) ?? [],';
+const PROFILE_BOOT_EXPORT_ANCHOR = 'export { resolveTelemetryPatch as a, prepareProfile as i, PROFILE_ROOT_FILENAME as n, runProfile as o, homePatchPath as r, INSTALL_ANCHOR as t };';
+
+const PROFILE_BOOT_GUARD_CODE = [
+  '/** dsh-desktop guard: the profile patch layer and the home-level patch layer',
+  ' * (`$DSH_HOME/cordis.patch.yml`) are user-owned data; a broken file must not',
+  ' * brick the boot or a hot-reload. Back the broken file up, reset the layer to',
+  ' * an empty list, warn, and continue without it. */',
+  'function loadUserPatchLayerSafe(binName, file) {',
+  '\ttry {',
+  '\t\treturn loadOptionalPatches(binName, file) ?? [];',
+  '\t} catch (error) {',
+  '\t\ttry {',
+  '\t\t\tconst backup = `' + '${file}.broken-${Date.now()}`' + ';',
+  '\t\t\twriteFileSync(backup, readFileSync(file, "utf8"));',
+  '\t\t\twriteFileSync(file, "# recovered by dsh: the previous content failed to parse and was moved to\\n# " + backup + "\\n[]\\n");',
+  '\t\t} catch {}',
+  '\t\tprocess.stderr.write(`' + '${binName}: ${file} failed to parse (${String(error?.message ?? error)}); the broken file was moved aside and the profile booted without this patch layer\\n`' + ');',
+  '\t\treturn [];',
+  '\t}',
+  '}',
+].join('\n');
+
+/**
+ * 改写 dsh/lib/profile-boot-*.js：家级 cordis.patch.yml 与 profile 补丁层的
+ * 加载（composeProfile 与 HMR composeLive 三处）换成「损坏备份 + 重置 + 继续」。
+ * 已注入或任一锚点失配时原样返回。
+ * @returns {{ changed: boolean, src: string }}
+ */
+function applyProfileBootBundleGuard(src) {
+  if (typeof src !== 'string') return { changed: false, src };
+  if (src.includes(PROFILE_BOOT_GUARD_MARKER)) return { changed: false, src };
+  const anchors = [
+    PROFILE_BOOT_IMPORT_ANCHOR,
+    PROFILE_BOOT_HOME_ANCHOR,
+    PROFILE_BOOT_LIVE_PROFILE_ANCHOR,
+    PROFILE_BOOT_LIVE_HOME_ANCHOR,
+    PROFILE_BOOT_EXPORT_ANCHOR,
+  ];
+  if (!anchors.every((anchor) => src.includes(anchor))) return { changed: false, src };
+  let out = src
+    .replace(PROFILE_BOOT_IMPORT_ANCHOR, 'import { readFileSync, writeFileSync } from "node:fs";')
+    .replace(PROFILE_BOOT_HOME_ANCHOR, '\tconst homePatches = loadUserPatchLayerSafe(NAME, homePatchPath());')
+    .replace(PROFILE_BOOT_LIVE_PROFILE_ANCHOR, '\t\t...loadUserPatchLayerSafe(NAME, composed.profile.patchPath),')
+    .replace(PROFILE_BOOT_LIVE_HOME_ANCHOR, '\t\t...loadUserPatchLayerSafe(NAME, homePatchPath()),');
+  out = out.replace(PROFILE_BOOT_EXPORT_ANCHOR, PROFILE_BOOT_EXPORT_ANCHOR + '\n\n' + PROFILE_BOOT_GUARD_CODE);
+  return { changed: true, src: out };
+}
+
+module.exports = {
+  PROFILE_BUNDLE_GUARD_MARKER,
+  PROFILE_BOOT_GUARD_MARKER,
+  bundlePatchRel,
+  bundleEntryOf,
+  verifyBundleDir,
+  packageDirUpward,
+  writeFileAtomic,
+  applyAppBootBundleGuard,
+  applyProfileBootBundleGuard,
+};

--- a/dsh-desktop/profile-bundle-heal.js
+++ b/dsh-desktop/profile-bundle-heal.js
@@ -160,12 +160,10 @@ function recoverManifestBundles(manifest, found) {
 
 /**
  * 原子写（临时文件 + rename），避免与 dsh 的 HMR 观察者撕裂读。
+ * 唯一实现在 scripts/lib/patch-io.js；这里转发导出，保证既有引用方
+ * （sync-companion-plugins.js 等）与本仓库其它原子写共用同一实现。
  */
-function writeFileAtomic(file, content) {
-  const tmp = file + '.tmp';
-  fs.writeFileSync(tmp, content, 'utf8');
-  fs.renameSync(tmp, file);
-}
+const { writeFileAtomic } = require('./scripts/lib/patch-io');
 
 // ---------------------------------------------------------------------------
 // @deepseek-ai/dsh-app-boot/lib/index.js 变换

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -26,6 +26,12 @@ const entryFiles = [
   'profile-manifest.js',
   'profile-patch-heal.js',
   'profile-bundle-heal.js',
+  // 统一补丁引擎与配套插件共享模块（main.js / 同步脚本 / after-pack 共用）。
+  'scripts/lib/patch-io.js',
+  'scripts/lib/patch-engine.js',
+  'scripts/lib/companion-plugins.js',
+  'scripts/lib/runtime-patches.js',
+  'scripts/lib/companion-profile.js',
   'scripts/patch-web-search-baseurl.js',
   'scripts/patch-menu-viewport.js',
   'scripts/patch-session-manage.js',

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -25,6 +25,7 @@ const entryFiles = [
   // 自愈 / 补丁模块（electron-builder files 清单内，随包分发，必须过语法门）。
   'profile-manifest.js',
   'profile-patch-heal.js',
+  'profile-bundle-heal.js',
   'scripts/patch-web-search-baseurl.js',
   'scripts/patch-menu-viewport.js',
   'scripts/patch-session-manage.js',

--- a/dsh-desktop/scripts/lib/companion-plugins.js
+++ b/dsh-desktop/scripts/lib/companion-plugins.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 配套 dsh 插件的唯一数据源。
+//
+// main.js 的 syncCompanionPlugins 与 scripts/sync-companion-plugins.js 曾
+// 各自维护一份 COMPANION_PLUGINS 清单，历史上已发生过一次漂移（同步脚本
+// 缺 better-sidebar / harness-pet）。新增或改名配套插件只改这里，两个同步
+// 入口（桌面壳运行时 / WSL·Linux CLI）自动保持一致。
+//
+// 条目字段约定：
+//   id    cordis.patch.yml 注册条目与插件管理页使用的 loader id；
+//   name  profile node_modules 下的包名（含 scope）。
+// ---------------------------------------------------------------------------
+
+const COMPANION_PLUGINS = [
+  { id: 'balance', name: '@deepseek-ai/dsh-balance' },
+  { id: 'file-changes', name: '@deepseek-ai/dsh-file-changes' },
+  { id: 'client-file-changes', name: '@deepseek-ai/dsh-client-file-changes' },
+  { id: 'terminal', name: '@deepseek-ai/dsh-terminal-tab' },
+  { id: 'plugin-market', name: 'zat-dsh-engine' },
+  { id: 'better-sidebar', name: 'dsh-better-sidebar' },
+  { id: 'harness-pet', name: 'harness-pet' },
+  { id: 'float-window', name: '@deepseek-ai/dsh-float-window' },
+  // 对话节点导航条（vlln/dsh-navbar，MIT）：对话区右缘节点串快速跳转
+  // user 消息（悬停预览/点击跳转/滚轮切换），取代 conversation-tweaks
+  // 内置的会话滑轨。
+  { id: 'dsh-navbar', name: '@vlln/dsh-navbar' },
+  // 对话删除与归档管理（本仓库内置）：会话行菜单删除按钮 + 设置内归档管理
+  // 面板（恢复/删除）。依赖 patch-session-manage.js 的官方包运行时补丁。
+  { id: 'dsh-session-manager', name: 'dsh-session-manager' },
+  { id: 'conversation-tweaks', name: '@deepseek-ai/dsh-conversation-tweaks' },
+  { id: 'super-injector', name: '@dsh-external/dsh-super-injector' },
+  { id: 'prompt-custom', name: '@deepseek-ai/dsh-prompt-custom' },
+  { id: 'third-party-thinking', name: '@deepseek-ai/dsh-third-party-thinking' },
+  { id: 'wsl-settings', name: '@deepseek-ai/dsh-wsl-settings' },
+  { id: 'dsh-vision', name: '@dsh-external/dsh-vision' },
+  { id: 'side-session', name: '@dsh-external/dsh-side-session' },
+  { id: 'compaction-acp', name: 'billion-context-dsh' },
+  { id: 'plugin-manager', name: '@deepseek-ai/dsh-plugin-manager' },
+];
+
+/** 包名 → assets/plugins 下的目录名（去 scope 前缀）。 */
+function companionDirName(p) {
+  const slash = p.name.indexOf('/');
+  return slash >= 0 ? p.name.slice(slash + 1) : p.name;
+}
+
+module.exports = { COMPANION_PLUGINS, companionDirName };

--- a/dsh-desktop/scripts/lib/companion-profile.js
+++ b/dsh-desktop/scripts/lib/companion-profile.js
@@ -385,13 +385,9 @@ function syncCompanionFiles(opts) {
 }
 
 module.exports = {
-  PLUGIN_FILES,
-  VENDOR_DEPS,
   PATCH_HEADER,
   ACP_DISABLE_BLOCK,
   PET_DISABLE_BLOCK,
-  dirNeedsSync,
-  syncDir,
   removeStaleCompanionPlugins,
   removeLegacyMarketplaceDir,
   removeLegacyMarketplacePatchLines,

--- a/dsh-desktop/scripts/lib/companion-profile.js
+++ b/dsh-desktop/scripts/lib/companion-profile.js
@@ -1,0 +1,401 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 配套插件同步的共享实现（唯一实现）。
+//
+// main.js 的 syncCompanionPlugins 与 scripts/sync-companion-plugins.js 曾各自
+// 维护一份「过期插件清理 / 旧市场清理 / 插件文件同步 / bundle 登记 / 补丁
+// 条目注册 / 默认禁用条目」逻辑，声明「完全一致」却在细节上逐步漂移
+// （注册循环缺 id 已存在跳过、缺 bundle 迁移去重、文件同步不比对时间戳等）。
+// 本模块把纯逻辑收口为一处，两个入口共用；dryRun 只影响是否落盘，
+// 语义与日志保持与旧实现一致（逐条变更文案由调用方注入）。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { COMPANION_PLUGINS, companionDirName } = require('./companion-plugins');
+const { dropBlocksByIds } = require('../../profile-patch-heal');
+const { writeFileAtomic } = require('./patch-io');
+const { bundlePatchRel, verifyBundleDir } = require('../../profile-bundle-heal');
+
+// 同步进 profile 的固定文件清单（旧 main.js copyFiles / 同步脚本 PLUGIN_FILES）。
+const PLUGIN_FILES = [
+  'package.json', 'cordis.patch.yml', 'LICENSE', 'README.md', 'README.zh.md',
+  'lib/index.js', 'lib/index.mjs', 'lib/client.js', 'lib/vlm.js', 'lib/typert.host.js', 'lib/typert.host.d.ts',
+  'dsh.plugin.json',
+];
+
+// 配套插件引用了不在 dsh 核心依赖闭包里的 npm 包时（例如 dsh-better-sidebar
+// 使用的 schemastery / cosmokit），把内置副本一并落到 profile web node_modules，
+// 保证 bundle 的宿主端能在 profile 内解析到这些依赖。
+const VENDOR_DEPS = ['schemastery', 'cosmokit', '@standard-schema/spec'];
+
+// 新 patch 文件的头部（旧实现两种入口逐字一致）。
+const PATCH_HEADER = '# dsh web profile patch（由 DSH Desktop 维护）\n';
+
+// billion-context-dsh（compaction-acp）是模型驱动的 ACP 压缩后端：同一 realm
+// 内与 dsh 默认的 compaction-basic 不能并存（插件 README 的官方安装说明）。
+const ACP_DISABLE_BLOCK = '\n# billion-context-dsh：禁用 preset realm 的 compaction-basic（ACP 模型驱动后端接管压缩决策）\n- id: compaction-basic\n  disabled: true\n';
+
+// 桌面宠物（harness-pet）默认关闭：客户端常驻 rAF 逐帧绘制 canvas，插件级
+// disabled 条目一票否决任何已保存状态（可在 设置 → 插件 → 管理 一键开启）。
+const PET_DISABLE_BLOCK = '\n# harness-pet：桌面宠物默认关闭（设置 → 插件 → 管理 可一键开启）\n- id: harness-pet\n  disabled: true\n';
+
+// ---------------------------------------------------------------------------
+// 目录/文件清理
+// ---------------------------------------------------------------------------
+
+/**
+ * 清理历史版本遗留的旧包名（私有 + 描述含 "DSH Desktop" 的才动，避免误删
+ * 用户自己安装或官方预设依赖的同名包）。
+ * @param {string} profileModules profiles/web/node_modules/@deepseek-ai
+ * @param {Set<string>} expectedDirs 当前配套插件目录名集合
+ * @param {Object} hooks
+ * @param {(msg:string)=>void} [hooks.log]      正常清理日志
+ * @param {(msg:string)=>void} [hooks.fail]     清理失败日志
+ * @param {(msg:string)=>void} [hooks.plan]     dry-run 计划输出
+ * @param {boolean} [hooks.dryRun]
+ */
+function removeStaleCompanionPlugins(profileModules, expectedDirs, hooks = {}) {
+  const { log, fail, plan, dryRun = false } = hooks;
+  let entries;
+  try { entries = fs.readdirSync(profileModules, { withFileTypes: true }); } catch { return; }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || expectedDirs.has(entry.name)) continue;
+    const pkgPath = path.join(profileModules, entry.name, 'package.json');
+    let pkg;
+    try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')); } catch { continue; }
+    if (pkg && pkg.private === true && typeof pkg.description === 'string' && /DSH Desktop/.test(pkg.description)) {
+      if (dryRun) {
+        if (plan) plan('dry-run: 将清理过期配套插件 ' + entry.name);
+        continue;
+      }
+      try {
+        fs.rmSync(path.join(profileModules, entry.name), { recursive: true, force: true });
+        if (log) log('已清理过期配套插件: ' + entry.name);
+      } catch (err) {
+        if (fail) fail('清理过期配套插件失败 ' + entry.name + ': ' + err.message);
+      }
+    }
+  }
+}
+
+/**
+ * 移除旧版 @deepseek-ai/dsh-plugin-marketplace 的同步副本（v0.3.5 起插件市场
+ * 整体切换为 zat-dsh-engine）。
+ */
+function removeLegacyMarketplaceDir(profileWebModules, hooks = {}) {
+  const { log, fail, plan, dryRun = false } = hooks;
+  const oldPkg = path.join(profileWebModules, '@deepseek-ai', 'dsh-plugin-marketplace');
+  if (!fs.existsSync(oldPkg)) return;
+  if (dryRun) {
+    if (plan) plan('dry-run: 将移除旧插件市场包 @deepseek-ai/dsh-plugin-marketplace');
+    return;
+  }
+  try {
+    fs.rmSync(oldPkg, { recursive: true, force: true });
+    if (log) log('已移除旧插件市场包: @deepseek-ai/dsh-plugin-marketplace');
+  } catch (err) {
+    if (fail) fail('移除旧插件市场包失败: ' + err.message);
+  }
+}
+
+/** 从 patch 文本移除旧插件市场的 insert 条目（纯函数，幂等）。 */
+function removeLegacyMarketplacePatchLines(patch) {
+  const before = patch;
+  const text = patch.replace(/^\s*-\s*insert:\s*$\n^\s*-\s*id:\s*plugin-marketplace\s*$\n^\s*name:\s*['"]@deepseek-ai\/dsh-plugin-marketplace['"]\s*$\n?/gm, '');
+  return { patch: text, changed: text !== before };
+}
+
+// ---------------------------------------------------------------------------
+// 目录级同步（递归比对 size+mtime，一致时跳过，避免每次启动全量递归复制；
+// cpSync 必须保留时间戳，否则跳过比对永远不成立）
+// ---------------------------------------------------------------------------
+
+function dirNeedsSync(src, dest) {
+  if (!fs.existsSync(dest)) return true;
+  let entries;
+  try { entries = fs.readdirSync(src, { withFileTypes: true }); } catch { return true; }
+  for (const e of entries) {
+    const s = path.join(src, e.name);
+    const d = path.join(dest, e.name);
+    if (e.isDirectory()) {
+      if (dirNeedsSync(s, d)) return true;
+    } else {
+      try {
+        const ss = fs.statSync(s);
+        const ds = fs.statSync(d);
+        if (ds.size !== ss.size || Math.round(ds.mtimeMs) !== Math.round(ss.mtimeMs)) return true;
+      } catch {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** 目录级同步：内容一致时跳过；源不存在时 no-op。失败仅告警不抛出。 */
+function syncDir(src, dest, log) {
+  if (!fs.existsSync(src)) return;
+  try {
+    if (fs.existsSync(dest) && !dirNeedsSync(src, dest)) return;
+    fs.cpSync(src, dest, { recursive: true, force: true, preserveTimestamps: true });
+  } catch (err) {
+    if (log) log('同步目录失败 ' + src + ': ' + err.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 补丁文本变换（纯函数）
+// ---------------------------------------------------------------------------
+
+/**
+ * 幂等写入默认禁用条目（compaction-basic / harness-pet）。
+ * patch 中已存在该 id（含用户手写的 disabled 块）则不动，尊重用户配置。
+ * @param {string} patch 当前 patch 文本（读取失败调用方传 ''）
+ * @param {RegExp} idPattern 条目 id 存在性判定（含用户手写形态）
+ * @param {string} block 待追加的禁用条目块（以 \n 开头，trim 后用于 []/空文件形态）
+ * @returns {{ patch: string, changed: boolean }}
+ */
+function ensureDisabledPatchEntry(patch, idPattern, block) {
+  if (idPattern.test('\n' + patch)) return { patch, changed: false };
+  if (/^\s*\[\]\s*$/m.test(patch)) return { patch: patch.replace(/\[\]/m, block.trim()), changed: true };
+  if (patch.trim() === '') return { patch: PATCH_HEADER + block.trim(), changed: true };
+  return { patch: patch.replace(/\s*$/, '\n') + block, changed: true };
+}
+
+/**
+ * 把非 bundle 配套插件注册进 profile patch 层（幂等，纯文本函数）。
+ * 规则（与旧 main.js 实现逐字一致，同步脚本一并收口到这里）：
+ *   1. bundle 化插件 / 源缺失插件的旧注册行按 dropBlocksByIds 语义移除
+ *      （用户手写的 config/disabled 覆盖条目原样保留）；
+ *   2. id 已存在 → 只做 name 就地改名（不动用户其它行）；
+ *   3. id 未出现 → 追加 insert 条目；[] 占位 / 空文件 / 正常文件三种形态
+ *      与旧实现逐字一致。
+ * @param {string} patch 当前 patch 文本（读取失败调用方传 ''）
+ * @param {Object} opts
+ * @param {Array<{id:string,name:string}>} opts.plugins
+ * @param {Set<string>} opts.bundleNames   已按 bundle 装配的包名
+ * @param {Set<string>} opts.missingNames  源缺失/校验失败的包名
+ * @param {(msg:string)=>void} [opts.onDrop]  移除残留注册行日志
+ * @param {(msg:string)=>void} [opts.onEntry] 改名/新增条目日志
+ * @returns {{ patch: string, changed: boolean, dropped: string[], updated: string[], added: string[] }}
+ */
+function registerCompanionPatchEntries(patch, opts) {
+  const { plugins, bundleNames, missingNames, onDrop, onEntry } = opts;
+  let text = patch;
+  let changed = false;
+  const dropped = [];
+  const updated = [];
+  const added = [];
+
+  // bundle 迁移自愈（issue #17 同族）：旧版本把后来升级为 bundle 的配套插件
+  // 当非 bundle 写进了 patch（insert 行）；插件现经 dsh.profile.bundles 装配，
+  // 残留注册行会造成同 id 双登记 → cordis loader "duplicate loader entry id" →
+  // 整树加载失败。幂等移除命中的注册行/块；用户手写的 config 覆盖/disabled
+  // 禁用条目由 dropBlocksByIds 语义原样保留。
+  const bundleIds = new Set();
+  for (const p of plugins) {
+    if (bundleNames.has(p.name)) bundleIds.add(p.id);
+  }
+  if (bundleIds.size > 0 && text.includes('- id:')) {
+    const migration = dropBlocksByIds(text, [...bundleIds]);
+    if (migration.removed.length > 0) {
+      text = migration.text;
+      changed = true;
+      const ids = [...new Set(migration.removed)];
+      dropped.push(...ids);
+      if (onDrop) onDrop('已把 bundle 插件移出 profile patch（避免双登记）: ' + ids.join(', '));
+    }
+  }
+  // 源缺失插件的旧注册残留同样移除：不清理的话 loader 仍会尝试加载
+  // 不存在的包；用户手写的 config/disabled 覆盖条目原样保留。
+  if (missingNames.size > 0 && text.includes('- id:')) {
+    const missingIds = plugins.filter((p) => missingNames.has(p.name)).map((p) => p.id);
+    if (missingIds.length > 0) {
+      const drop = dropBlocksByIds(text, missingIds);
+      if (drop.removed.length > 0) {
+        text = drop.text;
+        changed = true;
+        dropped.push(...drop.removed);
+        if (onDrop) onDrop('已把源缺失插件移出 profile patch（避免注册不存在的包）: ' + [...new Set(drop.removed)].join(', '));
+      }
+    }
+  }
+  for (const p of plugins) {
+    if (bundleNames.has(p.name)) continue;
+    // 源缺失：不写任何注册（复制循环已跳过它），避免「注册了但包不存在」
+    // 导致 dsh web 启动崩溃。
+    if (missingNames.has(p.name)) continue;
+    // 该 id 在 patch 里已存在：若它现在的 name 与当前版本不一致（例如终端
+    // 包改名 @deepseek-ai/dsh-terminal → dsh-terminal-tab），就地改名为当前
+    // 值。只改 name 行，不动用户自己加的其它行。
+    const idNameRe = new RegExp('(id:\\s*' + p.id + '\\b[^\\n]*\\n\\s*name:\\s*\\x27)([^\\x27]*)(\\x27)');
+    const m = text.match(idNameRe);
+    if (m) {
+      if (m[2] !== p.name) {
+        text = text.replace(idNameRe, '$1' + p.name + '$3');
+        changed = true;
+        updated.push(p.id);
+        if (onEntry) onEntry('已更新补丁条目 ' + p.id + ': ' + m[2] + ' → ' + p.name);
+      }
+      continue;
+    }
+    // 尊重用户已有配置：id 只要出现过（例如用户手写的 disabled 条目）就不再
+    // 自动插入，避免「禁用后下次启动又被加回来」或同 id 重复条目导致 loader 报错。
+    if (new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*' + p.id + '\\b').test('\n' + text)) {
+      continue;
+    }
+    const block = `- insert:\n    - id: ${p.id}\n      name: '${p.name}'\n`;
+    if (/^\s*\[\]\s*$/m.test(text)) text = text.replace(/\[\]/m, block);
+    else if (text.trim() === '') text = PATCH_HEADER + block;
+    else text = text.replace(/\s*$/, '\n') + block;
+    changed = true;
+    added.push(p.id);
+    if (onEntry) onEntry('已添加补丁条目 ' + p.id + ' → ' + p.name);
+  }
+  return { patch: text, changed, dropped, updated, added };
+}
+
+// ---------------------------------------------------------------------------
+// 插件文件同步（复制 + bundle 校验）
+// ---------------------------------------------------------------------------
+
+/**
+ * 把配套插件从 assets/plugins 同步进 profile web node_modules，并校验 bundle
+ * 完整性。与旧 main.js syncCompanionPlugins 的复制段逐字一致；同步脚本的
+ * dry-run 计划输出与逐条告警文案经 hooks 注入。
+ * @param {Object} opts
+ * @param {Array<{id:string,name:string}>} [opts.plugins]
+ * @param {string} opts.assetsRoot  assets/plugins 目录
+ * @param {string} opts.profileDir  profiles/web 目录
+ * @param {string} opts.vendorRoot   壳 node_modules（VENDOR_DEPS 源目录）
+ * @param {(msg:string)=>void} [opts.log]           常规日志
+ * @param {(msg:string)=>void} [opts.fail]          告警日志
+ * @param {(name:string, srcDir:string)=>void} [opts.onMissingSource]
+ * @param {(srcFile:string, err:Error)=>void} [opts.onCopyFail]
+ * @param {(name:string, reason:string)=>void} [opts.onVerifyFail]
+ * @param {(name:string, isBundle:boolean)=>void} [opts.onInstalled]
+ * @param {(name:string)=>void} [opts.onVendorSynced]
+ * @param {(msg:string)=>void} [opts.plan]          dry-run 计划输出
+ * @param {boolean} [opts.dryRun]
+ * @returns {{ bundleNames: Set<string>, missingNames: Set<string> }}
+ */
+function syncCompanionFiles(opts) {
+  const {
+    plugins = COMPANION_PLUGINS,
+    assetsRoot,
+    profileDir,
+    vendorRoot,
+    log,
+    fail,
+    onMissingSource,
+    onCopyFail,
+    onVerifyFail,
+    onInstalled,
+    onVendorSynced,
+    plan,
+    dryRun = false,
+  } = opts;
+  const profileModules = path.join(profileDir, 'node_modules', '@deepseek-ai');
+  if (!dryRun) fs.mkdirSync(profileModules, { recursive: true });
+  const expectedDirs = new Set(plugins.map(companionDirName));
+  removeStaleCompanionPlugins(profileModules, expectedDirs, { log, fail, plan, dryRun });
+  removeLegacyMarketplaceDir(path.join(profileDir, 'node_modules'), { log, fail, plan, dryRun });
+
+  const bundleNames = new Set();
+  for (const name of VENDOR_DEPS) {
+    const sdir = path.join(vendorRoot, name);
+    if (!fs.existsSync(sdir)) continue;
+    const ddir = path.join(profileDir, 'node_modules', name);
+    if (dryRun) {
+      if (plan) plan(`dry-run: 将同步私有依赖 ${name} → ${ddir}`);
+      continue;
+    }
+    syncDir(sdir, ddir, log);
+    if (onVendorSynced) onVendorSynced(name);
+  }
+  // 源缺失的配套插件（用户从 assets 删除 / 开发中裁剪 / 安装包损坏）：
+  // 既不能复制、也无法从源码确认 bundle 身份。处理原则：缺失源一律不写
+  // patch 注册（否则「注册了但包不存在」会让 dsh web 启动崩溃）；若 manifest
+  // 仍登记为 bundle，则视为用户意图禁用，从 bundles 移除。
+  const missingNames = new Set();
+  for (const p of plugins) {
+    const sdir = path.join(assetsRoot, companionDirName(p));
+    if (!fs.existsSync(path.join(sdir, 'package.json'))) {
+      missingNames.add(p.name);
+      if (onMissingSource) onMissingSource(p.name, sdir);
+    }
+  }
+  for (const p of plugins) {
+    const rel = companionDirName(p);
+    const src = path.join(assetsRoot, rel);
+    if (!fs.existsSync(path.join(src, 'package.json'))) continue;
+    let pkg = {};
+    try { pkg = JSON.parse(fs.readFileSync(path.join(src, 'package.json'), 'utf8')); } catch {}
+    const isBundle = bundlePatchRel(pkg) !== '';
+    // @deepseek-ai 与 @dsh-external 两种 scope 都按包名落到 profile 的
+    // node_modules 下；配套包自身的依赖由 dsh 的 profiles/node_modules
+    // fallback（healProfilesModuleFallback）解析。
+    const dest = path.join(profileModules, '..', p.name);
+    if (dryRun) {
+      if (plan) plan(`dry-run: 将安装 ${p.name} → ${dest}${isBundle ? '（bundle 插件）' : ''}`);
+      continue;
+    }
+    fs.mkdirSync(path.join(dest, 'lib'), { recursive: true });
+    for (const f of PLUGIN_FILES) {
+      const sf = path.join(src, f);
+      if (!fs.existsSync(sf)) continue;
+      const df = path.join(dest, f);
+      // 逐文件比对大小+mtime，一致则跳过复制，避免每次启动都写盘。注意
+      // fs.copyFileSync 不保留时间戳（复制的目标 mtime=现在），会让比对永远
+      // 不成立；这里用 cpSync + preserveTimestamps 写，保证第二次启动能命中跳过。
+      try {
+        const sst = fs.statSync(sf);
+        const dst = fs.statSync(df);
+        if (dst.size === sst.size && Math.round(dst.mtimeMs) === Math.round(sst.mtimeMs)) continue;
+      } catch { /* 目标缺失或不可读 → 照常复制 */ }
+      try {
+        fs.cpSync(sf, df, { force: true, preserveTimestamps: true });
+      } catch (err) {
+        if (onCopyFail) onCopyFail(sf, err);
+      }
+    }
+    // 完整同步插件自带的 lib/assets/src/dist/node_modules 目录：第三方插件
+    // 的懒加载 chunk、动画素材、dist 构建产物与随包分发的私有依赖
+    // （如 billion-context-dsh 的 acp-kernel）不都落在固定文件清单里。
+    for (const sub of ['lib', 'assets', 'src', 'dist', 'node_modules']) {
+      syncDir(path.join(src, sub), path.join(dest, sub), log);
+    }
+    // 落盘后校验 bundle 完整性：dsh 装配时会读取补丁层与入口文件，任一缺失
+    // 都会让整棵插件树加载失败。校验失败按「源缺失」处理：不注册、从
+    // manifest 移除登记、日志告警，下次启动重试。
+    if (isBundle) {
+      const check = verifyBundleDir(dest);
+      if (!check.ok) {
+        missingNames.add(p.name);
+        if (onVerifyFail) onVerifyFail(p.name, check.reason);
+      } else {
+        bundleNames.add(p.name);
+      }
+    }
+    if (onInstalled) onInstalled(p.name, isBundle);
+  }
+  return { bundleNames, missingNames };
+}
+
+module.exports = {
+  PLUGIN_FILES,
+  VENDOR_DEPS,
+  PATCH_HEADER,
+  ACP_DISABLE_BLOCK,
+  PET_DISABLE_BLOCK,
+  dirNeedsSync,
+  syncDir,
+  removeStaleCompanionPlugins,
+  removeLegacyMarketplaceDir,
+  removeLegacyMarketplacePatchLines,
+  ensureDisabledPatchEntry,
+  registerCompanionPatchEntries,
+  syncCompanionFiles,
+};

--- a/dsh-desktop/scripts/lib/patch-engine.js
+++ b/dsh-desktop/scripts/lib/patch-engine.js
@@ -38,7 +38,6 @@ const { writeFileAtomic, readFileCached } = require('./patch-io');
  *   | { status: 'changed', src: string, note?: any }} spec.transform
  * @param {(file: string) => string|null} [spec.alreadyLog]  已应用日志主体；null/缺省 = 静默
  * @param {(msg: string) => void} [spec.anchorLog]           锚点失配日志通道；缺省 = log
- * @param {(file: string) => string} [spec.readFailLog]      读取失败日志主体；缺省 '读取失败，跳过 ' + file
  * @param {(file: string, note?: any) => string} [spec.doneLog] 成功日志主体；缺省 '已应用 ' + file
  * @param {boolean} [spec.donePrefix]  成功行是否加 `${prefix}: `；缺省 true
  * @param {(file: string, err: Error) => string} [spec.failLog]
@@ -55,7 +54,6 @@ function applyPatchToFiles(spec) {
     transform,
     alreadyLog = null,
     anchorLog = log,
-    readFailLog = (file) => '读取失败，跳过 ' + file,
     doneLog = (file) => '已应用 ' + file,
     donePrefix = true,
     failLog = (file, err) => `${prefix}失败(${file}): ${err.message}`,
@@ -69,7 +67,7 @@ function applyPatchToFiles(spec) {
     try {
       const src = readFileCached(file);
       if (src === null) {
-        log(`${prefix}: ${readFailLog(file)}`);
+        log(`${prefix}: 读取失败，跳过 ${file}`);
         continue;
       }
       const result = transform(src, file);

--- a/dsh-desktop/scripts/lib/patch-engine.js
+++ b/dsh-desktop/scripts/lib/patch-engine.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 统一运行时补丁应用引擎（唯一实现）。
+//
+// main.js 的 12 个 apply* 函数与 scripts/sync-companion-plugins.js 的
+// applyRuntimePatches 曾各自手写同一套机械循环：「候选路径过滤 → 进程级读
+// → 读取失败日志 → 幂等已应用判定 → 锚点失配判定 → 写入 → 成功日志 → 异常
+// 日志」，只在文案与判定细节上各不相同，并逐步漂移出「原子写 vs 非原子写、
+// marker vs anchor-diff 幂等约定不一致」等问题。本模块把循环收口为一处：
+// 每个补丁只声明自己的变换函数与日志文案，不再复制机械性样板。
+//
+// 兼容性契约（对旧实现逐字一致）：
+//   - 文件不存在 / 空路径：静默跳过；
+//   - 读取失败：统一输出 `${prefix}: 读取失败，跳过 ${file}`；
+//   - 变换返回 already 且未提供 alreadyLog：静默跳过（与 profile patch 防护
+//     等旧实现一致）；提供 alreadyLog 则输出 `${prefix}: ${alreadyLog(file)}`；
+//   - 变换返回 anchor-missing：输出 `${prefix}: ${detail}`（detail 由变换方
+//     拼好，可含文件路径，与旧实现各补丁文案一致）；
+//   - 变换返回 changed：写入（默认原子写）+ 输出 `${prefix}: ${doneLog(file, note)}`；
+//   - dryRun 模式：不落盘，改用 dryRunChangedLog(file, note) 输出计划文案；
+//   - 任何异常：输出 failLog(file, err)，默认 `${prefix}失败(${file}): ${err.message}`。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const { writeFileAtomic, readFileCached } = require('./patch-io');
+
+/**
+ * 对一组候选文件依次应用同一个补丁变换。
+ *
+ * @param {Object} spec
+ * @param {string} spec.prefix           日志前缀（如 'runtime 补丁'）
+ * @param {string[]} spec.files          候选文件路径（空项/不存在的文件静默跳过）
+ * @param {(msg: string) => void} spec.log
+ * @param {(src: string, file: string) =>
+ *   { status: 'already' }
+ *   | { status: 'anchor-missing', detail: string }
+ *   | { status: 'changed', src: string, note?: any }} spec.transform
+ * @param {(file: string) => string|null} [spec.alreadyLog]  已应用日志主体；null/缺省 = 静默
+ * @param {(msg: string) => void} [spec.anchorLog]           锚点失配日志通道；缺省 = log
+ * @param {(file: string) => string} [spec.readFailLog]      读取失败日志主体；缺省 '读取失败，跳过 ' + file
+ * @param {(file: string, note?: any) => string} [spec.doneLog] 成功日志主体；缺省 '已应用 ' + file
+ * @param {boolean} [spec.donePrefix]  成功行是否加 `${prefix}: `；缺省 true
+ * @param {(file: string, err: Error) => string} [spec.failLog]
+ * @param {boolean} [spec.dryRun]        只判定不落盘（输出 dryRunChangedLog）
+ * @param {(file: string, note?: any) => string} [spec.dryRunChangedLog]
+ * @param {(file: string, content: string) => void} [spec.write] 写入实现；缺省原子写
+ * @returns {number} 实际写入的文件数
+ */
+function applyPatchToFiles(spec) {
+  const {
+    prefix,
+    files,
+    log,
+    transform,
+    alreadyLog = null,
+    anchorLog = log,
+    readFailLog = (file) => '读取失败，跳过 ' + file,
+    doneLog = (file) => '已应用 ' + file,
+    donePrefix = true,
+    failLog = (file, err) => `${prefix}失败(${file}): ${err.message}`,
+    dryRun = false,
+    dryRunChangedLog = null,
+    write = writeFileAtomic,
+  } = spec;
+  let written = 0;
+  for (const file of files) {
+    if (!file || !fs.existsSync(file)) continue;
+    try {
+      const src = readFileCached(file);
+      if (src === null) {
+        log(`${prefix}: ${readFailLog(file)}`);
+        continue;
+      }
+      const result = transform(src, file);
+      if (result.status === 'already') {
+        if (alreadyLog) log(`${prefix}: ${alreadyLog(file)}`);
+        continue;
+      }
+      if (result.status === 'anchor-missing') {
+        anchorLog(`${prefix}: ${result.detail}`);
+        continue;
+      }
+      if (dryRun) {
+        if (dryRunChangedLog) log(dryRunChangedLog(file, result.note));
+        continue;
+      }
+      write(file, result.src);
+      written += 1;
+      const body = doneLog(file, result.note);
+      log(donePrefix ? `${prefix}: ${body}` : body);
+    } catch (err) {
+      log(failLog(file, err));
+    }
+  }
+  return written;
+}
+
+module.exports = { applyPatchToFiles };

--- a/dsh-desktop/scripts/lib/patch-io.js
+++ b/dsh-desktop/scripts/lib/patch-io.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 统一补丁 I/O 原语（唯一实现）。
+//
+// main.js 的运行时补丁（12 个 apply*）、scripts/ 下的补丁脚本与
+// profile-bundle-heal.js 曾各自实现「原子写」与「进程级读缓存」，且
+// 原子写（writePatchAtomic / writeFileAtomic）与非原子 fs.writeFileSync
+// 混用、读缓存只覆盖部分调用方。本模块把这些机械性样板收口为一处，
+// 所有调用方共用，杜绝再次漂移。
+//
+// 约定：
+//   - writeFileAtomic：临时文件 + rename。临时文件与目标同目录，保证 rename
+//     同卷；替换整文件，避免与 dsh 的 HMR 观察者撕裂读。
+//   - readFileCached：按 realpath 归一化 + size/mtime 签名做进程级读缓存；
+//     任何写入都会更新 mtime，缓存自动失效，不存在陈旧内容（语义与旧 main.js
+//     内联实现完全一致，包括多路径指向同一物理文件时的去重读）。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+
+/** 原子写（临时文件 + rename），避免与 dsh 的观察者撕裂读。 */
+function writeFileAtomic(file, content) {
+  const tmp = file + '.tmp';
+  fs.writeFileSync(tmp, content, 'utf8');
+  fs.renameSync(tmp, file);
+}
+
+// realpath -> { size, mtimeMs, text }
+const fileReadMemo = new Map();
+// 路径本身是固定常量：realpath 解析结果缓存一次即可。
+const fileRealKeyMemo = new Map();
+
+function fileRealKey(file) {
+  let key = fileRealKeyMemo.get(file);
+  if (key === undefined) {
+    try { key = fs.realpathSync(file); } catch { key = file; }
+    fileRealKeyMemo.set(file, key);
+  }
+  return key;
+}
+
+/**
+ * 进程级读缓存：文件缺失/不可读返回 null（调用方按读取失败处理）。
+ * 缓存命中条件 = realpath 相同 + size 与 mtimeMs 精确一致；写入必改 mtime，
+ * 因此不存在陈旧内容。
+ * @param {string} file
+ * @returns {string|null}
+ */
+function readFileCached(file) {
+  try {
+    const st = fs.statSync(file);
+    const key = fileRealKey(file);
+    const hit = fileReadMemo.get(key);
+    if (hit && hit.size === st.size && hit.mtimeMs === st.mtimeMs) return hit.text;
+    const text = fs.readFileSync(file, 'utf8');
+    fileReadMemo.set(key, { size: st.size, mtimeMs: st.mtimeMs, text });
+    return text;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { writeFileAtomic, readFileCached, fileRealKey };

--- a/dsh-desktop/scripts/lib/patch-io.js
+++ b/dsh-desktop/scripts/lib/patch-io.js
@@ -61,4 +61,4 @@ function readFileCached(file) {
   }
 }
 
-module.exports = { writeFileAtomic, readFileCached, fileRealKey };
+module.exports = { writeFileAtomic, readFileCached };

--- a/dsh-desktop/scripts/lib/runtime-patches.js
+++ b/dsh-desktop/scripts/lib/runtime-patches.js
@@ -42,6 +42,43 @@ function patchTargets(home, pkgRel) {
   ];
 }
 
+// ---------------------------------------------------------------------------
+// 运行时补丁候选路径构造（纯函数：路径根由调用方传入，便于单测；main.js 绑定
+// 模块级变量）。三种布局与旧实现逐项一致，并补齐同系列补丁的历史覆盖缺口：
+//   - localCopyFiles         本地模式三副本（profile fallback → 内置副本 → 更新 overlay）；
+//   - guardCopyFiles         防护类补丁四副本（内置副本优先 + overlay 嵌套 dsh
+//                            依赖副本 + profile fallback）；
+//   - localNodeModulesRoots  包级补丁的 node_modules 根目录列表（extraRoots 用于
+//                            WSL 模式追加 WSL agent 直连根，与 patchTargets 的
+//                            agent 兜底语义一致）。
+// ---------------------------------------------------------------------------
+
+function localCopyFiles(home, appDir, userDataDir, pkgRel) {
+  return [
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(appDir, 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
+  ];
+}
+
+function guardCopyFiles(home, appDir, userDataDir, pkgRel) {
+  return [
+    path.join(appDir, 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', pkgRel),
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
+  ];
+}
+
+function localNodeModulesRoots(home, appDir, userDataDir, extraRoots = []) {
+  return [
+    path.join(home, 'profiles', 'node_modules'),
+    path.join(appDir, 'node_modules'),
+    path.join(userDataDir, 'agent', 'node_modules'),
+    ...extraRoots,
+  ];
+}
+
 /**
  * 闪跳修复变换（纯函数）。锚点失配的 detail 含文件路径，与两个调用方
  * （main.js / 同步脚本）的旧日志文案逐字一致。
@@ -83,6 +120,9 @@ module.exports = {
   FLASH_PKG_REL,
   EXPOSE_PKG_REL,
   patchTargets,
+  localCopyFiles,
+  guardCopyFiles,
+  localNodeModulesRoots,
   transformFlashFix,
   transformExposeFix,
 };

--- a/dsh-desktop/scripts/lib/runtime-patches.js
+++ b/dsh-desktop/scripts/lib/runtime-patches.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 运行时补丁定义（唯一实现）。
+//
+// 「会话列表刷新闪跳修复」（dsh-client-runtime）与「设置暴露白名单补丁」
+// （dsh-host-apiproxy）曾同时存在于 main.js（applyRuntimeFlashFix /
+// applyPromptExposeFix）与 scripts/sync-companion-plugins.js
+// （applyRuntimePatches，--with-patches）两处，是同一份补丁的第三次复制。
+// 这里把锚点常量、变换与 WSL / CLI 共用的目标路径收口为唯一数据源，两个
+// 入口只保留各自的候选路径选择与日志文案，杜绝漂移。
+//
+// 变换均为纯函数，字节级输出与旧实现一致；锚点失配时绝不改写文件内容。
+// ---------------------------------------------------------------------------
+
+const path = require('node:path');
+
+/** dsh-client-runtime 会话列表刷新闪跳修复（mergeOrderedBaseline 保留本地新会话）。 */
+const FLASH_OLD = '(value) => baselineByKey.get(keyOf(value))).filter((value) => value !== void 0);';
+const FLASH_NEW = '(value) => baselineByKey.get(keyOf(value)) ?? value).filter((value) => value !== void 0);';
+
+/** 设置暴露白名单（dsh-prompt / 第三方思考 / 识图 / 会话调整）。 */
+const SETTINGS_NAMESPACES = ['dsh-prompt', 'dsh-third-party-thinking', 'dsh-vision', 'dsh-conversation-tweaks'];
+
+/** 各补丁目标包内的相对路径（@deepseek-ai/<rel>）。 */
+const FLASH_PKG_REL = path.join('dsh-client-runtime', 'lib', 'client.js');
+const EXPOSE_PKG_REL = path.join('dsh-host-apiproxy', 'lib', 'index.js');
+
+/**
+ * WSL 托管模式 / sync CLI 共用目标：profile fallback + agent 两份副本。
+ * bundle 初始化后的 dsh 安装（npm 版）两份副本通常互为同一文件（fallback
+ * 符号链接写穿），逐文件幂等判定保证重复目标安全。
+ * @param {string} home 目标 dsh 数据目录（WSL 模式为 UNC 等价路径）
+ * @param {string} pkgRel @deepseek-ai/<pkgRel>
+ * @returns {string[]}
+ */
+function patchTargets(home, pkgRel) {
+  const mk = (root) => path.join(root, 'node_modules', '@deepseek-ai', pkgRel);
+  return [
+    mk(path.join(home, 'profiles')),
+    mk(path.join(home, 'agent')),
+  ];
+}
+
+/**
+ * 闪跳修复变换（纯函数）。锚点失配的 detail 含文件路径，与两个调用方
+ * （main.js / 同步脚本）的旧日志文案逐字一致。
+ * @returns {{status:'already'} | {status:'anchor-missing', detail: string} | {status:'changed', src: string}}
+ */
+function transformFlashFix(src, file) {
+  if (src.includes(FLASH_NEW)) return { status: 'already' };
+  if (!src.includes(FLASH_OLD)) {
+    return { status: 'anchor-missing', detail: '未匹配到目标代码（版本可能已变更），跳过 ' + file };
+  }
+  return { status: 'changed', src: src.replace(FLASH_OLD, FLASH_NEW) };
+}
+
+/**
+ * 设置暴露白名单变换（纯函数）。只认声明之后最近的 `];`，避免插进文件里
+ * 其它数组；缺失的命名空间以与旧实现逐字节一致的格式追加。
+ * @returns {{status:'already'} | {status:'anchor-missing', detail: string} | {status:'changed', src: string, note: string[]}}
+ */
+function transformExposeFix(src, file) {
+  const declIdx = src.indexOf('const WEB_SETTINGS_NAMESPACES = [');
+  if (declIdx === -1) {
+    return { status: 'anchor-missing', detail: '未找到 WEB_SETTINGS_NAMESPACES（版本可能已变更），跳过 ' + file };
+  }
+  const closeIdx = src.indexOf('];', declIdx);
+  if (closeIdx === -1) {
+    return { status: 'anchor-missing', detail: '未匹配到命名空间数组收尾，跳过 ' + file };
+  }
+  const arrText = src.slice(declIdx, closeIdx);
+  const missing = SETTINGS_NAMESPACES.filter((ns) => !arrText.includes('"' + ns + '"'));
+  if (missing.length === 0) return { status: 'already' };
+  const block = ',\n' + missing.map((ns) => '\t"' + ns + '"').join(',\n') + '\n';
+  return { status: 'changed', src: src.slice(0, closeIdx) + block + src.slice(closeIdx), note: missing };
+}
+
+module.exports = {
+  FLASH_OLD,
+  FLASH_NEW,
+  SETTINGS_NAMESPACES,
+  FLASH_PKG_REL,
+  EXPOSE_PKG_REL,
+  patchTargets,
+  transformFlashFix,
+  transformExposeFix,
+};

--- a/dsh-desktop/scripts/patch-menu-viewport.js
+++ b/dsh-desktop/scripts/patch-menu-viewport.js
@@ -19,6 +19,8 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+// 原子写与 main.js / 其它补丁脚本共用同一实现（scripts/lib/patch-io.js）。
+const { writeFileAtomic } = require('./lib/patch-io');
 
 const MARKER = 'dsh-desktop patch (issue #36)';
 
@@ -51,7 +53,7 @@ function patchFile(file, log = () => {}) {
   src = src.replace(OLD_Y_CLAMP, NEW_Y_CLAMP).replace(OLD_STYLE, NEW_STYLE);
   src = '// ' + MARKER + ': Menu portal 列表视口封顶（issue #36）\n' + src;
   try {
-    fs.writeFileSync(file, src, 'utf8');
+    writeFileAtomic(file, src);
     log('menu-viewport 补丁: 已应用 ' + file);
     return true;
   } catch (err) {

--- a/dsh-desktop/scripts/patch-session-manage.js
+++ b/dsh-desktop/scripts/patch-session-manage.js
@@ -29,6 +29,8 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+// 原子写与 main.js / 其它补丁脚本共用同一实现（scripts/lib/patch-io.js）。
+const { writeFileAtomic } = require('./lib/patch-io');
 
 const MARKER = 'dsh-desktop patch (session manage)';
 
@@ -125,7 +127,7 @@ function applyReplacements(file, replacements, upgradeRules, log) {
     }
     if (upgraded) {
       try {
-        fs.writeFileSync(file, src, 'utf8');
+        writeFileAtomic(file, src);
         log('session-manage 补丁: 已升级 ' + file);
         return true;
       } catch (err) {
@@ -145,7 +147,7 @@ function applyReplacements(file, replacements, upgradeRules, log) {
   }
   src = '// ' + MARKER + ': 对话删除/归档管理运行时补丁\n' + src;
   try {
-    fs.writeFileSync(file, src, 'utf8');
+    writeFileAtomic(file, src);
     log('session-manage 补丁: 已应用 ' + file);
     return true;
   } catch (err) {

--- a/dsh-desktop/scripts/patch-web-search-baseurl.js
+++ b/dsh-desktop/scripts/patch-web-search-baseurl.js
@@ -25,6 +25,8 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+// 原子写与 main.js / 其它补丁脚本共用同一实现（scripts/lib/patch-io.js）。
+const { writeFileAtomic } = require('./lib/patch-io');
 
 const MARKER = 'dsh-desktop patch (issue #20)';
 
@@ -149,7 +151,7 @@ function patchWebSearchBaseUrl(nmRoot, log = () => {}) {
       continue; // 已应用（幂等）
     }
     try {
-      fs.writeFileSync(file, result.src, 'utf8');
+      writeFileAtomic(file, result.src);
       changedFiles += 1;
       log('web-search baseURL 补丁: 已应用 ' + file);
     } catch (err) {

--- a/dsh-desktop/scripts/sync-companion-plugins.js
+++ b/dsh-desktop/scripts/sync-companion-plugins.js
@@ -1,11 +1,12 @@
 'use strict';
 
 // 把 DSH Desktop 的配套插件同步进任意 dsh 的 web profile（独立于 Electron 壳，
-// 逻辑与 main.js 的 syncCompanionPlugins 完全一致），并顺带把壳内置的 Agent
-// 预设（assets/agent-presets）同步进能找到的 dsh 包 config/agent-presets，
-// 避免 WSL / Linux 里的 dsh 模式列表比 Windows 内置 dsh 少。典型用途：把自己
-// WSL / Linux 里另装的 dsh（checkout 开发版或 npm 版）也配上壳自带的插件
-// （余额、文件改动视图、终端、浮窗、插件市场、自定义提示词、第三方思考、识图等）。
+// 同步逻辑与 main.js 的 syncCompanionPlugins 共用 scripts/lib/companion-profile.js
+// 的同一实现），并顺带把壳内置的 Agent 预设（assets/agent-presets）同步进能找到
+// 的 dsh 包 config/agent-presets，避免 WSL / Linux 里的 dsh 模式列表比 Windows
+// 内置 dsh 少。典型用途：把自己 WSL / Linux 里另装的 dsh（checkout 开发版或
+// npm 版）也配上壳自带的插件（余额、文件改动视图、终端、浮窗、插件市场、
+// 自定义提示词、第三方思考、识图等）。
 //
 // 用法（WSL / Linux / Windows 均可执行）：
 //   node scripts/sync-companion-plugins.js [DSH_HOME] [--with-patches] [--dry-run] [--dsh-package <目录>]
@@ -30,41 +31,18 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const { installBuiltinPresets } = require('./install-minimal-win-preset');
-const { bundlePatchRel, verifyBundleDir, writeFileAtomic } = require('../profile-bundle-heal');
-
-// 与 main.js COMPANION_PLUGINS 保持一致（保持同步时请两处一起改）。
-const COMPANION_PLUGINS = [
-  { id: 'balance', name: '@deepseek-ai/dsh-balance' },
-  { id: 'file-changes', name: '@deepseek-ai/dsh-file-changes' },
-  { id: 'client-file-changes', name: '@deepseek-ai/dsh-client-file-changes' },
-  { id: 'terminal', name: '@deepseek-ai/dsh-terminal-tab' },
-  { id: 'plugin-market', name: 'zat-dsh-engine' },
-  { id: 'better-sidebar', name: 'dsh-better-sidebar' },
-  { id: 'harness-pet', name: 'harness-pet' },
-  { id: 'float-window', name: '@deepseek-ai/dsh-float-window' },
-  { id: 'dsh-navbar', name: '@vlln/dsh-navbar' },
-  { id: 'dsh-session-manager', name: 'dsh-session-manager' },
-  { id: 'conversation-tweaks', name: '@deepseek-ai/dsh-conversation-tweaks' },
-  { id: 'super-injector', name: '@dsh-external/dsh-super-injector' },
-  { id: 'prompt-custom', name: '@deepseek-ai/dsh-prompt-custom' },
-  { id: 'third-party-thinking', name: '@deepseek-ai/dsh-third-party-thinking' },
-  { id: 'wsl-settings', name: '@deepseek-ai/dsh-wsl-settings' },
-  { id: 'dsh-vision', name: '@dsh-external/dsh-vision' },
-  { id: 'side-session', name: '@dsh-external/dsh-side-session' },
-  { id: 'compaction-acp', name: 'billion-context-dsh' },
-  { id: 'plugin-manager', name: '@deepseek-ai/dsh-plugin-manager' },
-];
-
-const PLUGIN_FILES = [
-  'package.json', 'cordis.patch.yml', 'LICENSE', 'README.md', 'README.zh.md',
-  'lib/index.js', 'lib/index.mjs', 'lib/client.js', 'lib/vlm.js', 'lib/typert.host.js', 'lib/typert.host.d.ts',
-  'dsh.plugin.json',
-];
-
-function companionDirName(p) {
-  const slash = p.name.indexOf('/');
-  return slash >= 0 ? p.name.slice(slash + 1) : p.name;
-}
+const { COMPANION_PLUGINS } = require('./lib/companion-plugins');
+const { writeFileAtomic } = require('./lib/patch-io');
+const { applyPatchToFiles } = require('./lib/patch-engine');
+const {
+  FLASH_PKG_REL, EXPOSE_PKG_REL, patchTargets,
+  transformFlashFix, transformExposeFix,
+} = require('./lib/runtime-patches');
+const {
+  ACP_DISABLE_BLOCK, PET_DISABLE_BLOCK,
+  ensureDisabledPatchEntry, removeLegacyMarketplacePatchLines,
+  registerCompanionPatchEntries, syncCompanionFiles,
+} = require('./lib/companion-profile');
 
 function log(msg) {
   console.log('[sync] ' + msg);
@@ -160,111 +138,30 @@ function syncBuiltinPresets(home, dshPackageArg, dryRun) {
 }
 
 // ---------------------------------------------------------------------------
-// 插件同步（与 main.js syncCompanionPlugins 同逻辑，dry-run 时只读不改）
+// 插件同步（与 main.js syncCompanionPlugins 共用同一实现；dry-run 时只读不改）
 // ---------------------------------------------------------------------------
 
 function syncPlugins(home, dryRun) {
   const profileDir = path.join(home, 'profiles', 'web');
-  const profileModules = path.join(profileDir, 'node_modules', '@deepseek-ai');
   if (dryRun) {
     log(`dry-run: 目标 profile ${profileDir}`);
-  } else {
-    fs.mkdirSync(profileModules, { recursive: true });
   }
-
-  // 清理本工具历史版本遗留的旧包名（私有 + 描述含 "DSH Desktop" 的才动）。
-  const expectedDirs = new Set(COMPANION_PLUGINS.map(companionDirName));
-  let entries;
-  try { entries = fs.readdirSync(profileModules, { withFileTypes: true }); } catch { entries = []; }
-  for (const entry of entries) {
-    if (!entry.isDirectory() || expectedDirs.has(entry.name)) continue;
-    const pkgPath = path.join(profileModules, entry.name, 'package.json');
-    let pkg;
-    try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')); } catch { continue; }
-    if (pkg && pkg.private === true && typeof pkg.description === 'string' && /DSH Desktop/.test(pkg.description)) {
-      if (dryRun) log(`dry-run: 将清理过期配套插件 ${entry.name}`);
-      else {
-        fs.rmSync(path.join(profileModules, entry.name), { recursive: true, force: true });
-        log(`已清理过期配套插件: ${entry.name}`);
-      }
-    }
-  }
-
-  // v0.3.5 起插件市场整体切换为 zat-dsh-engine（MIT）：
-  // 清理旧版 @deepseek-ai/dsh-plugin-marketplace 的同步副本与 patch 行。
-  const oldPkg = path.join(profileDir, 'node_modules', '@deepseek-ai', 'dsh-plugin-marketplace');
-  if (fs.existsSync(oldPkg)) {
-    if (dryRun) log('dry-run: 将移除旧插件市场包 @deepseek-ai/dsh-plugin-marketplace');
-    else {
-      fs.rmSync(oldPkg, { recursive: true, force: true });
-      log('已移除旧插件市场包: @deepseek-ai/dsh-plugin-marketplace');
-    }
-  }
-
-  // 配套插件引用了不在 dsh 核心依赖闭包里的 npm 包时（例如 dsh-better-sidebar
-  // 使用的 schemastery / cosmokit、dsh-side-session 使用的 schemastery），把
-  // 内置副本一并落到 profile web node_modules，保证 bundle 的宿主端能在
-  // profile 内解析到这些依赖（与 main.js syncCompanionPlugins 的 vendorDeps
-  // 一致；dsh 的 profiles/node_modules fallback 只覆盖 dsh 自身依赖闭包）。
-  const vendorDeps = ['schemastery', 'cosmokit', '@standard-schema/spec'];
-  for (const name of vendorDeps) {
-    const sdir = path.join(__dirname, '..', 'node_modules', name);
-    if (!fs.existsSync(sdir)) continue;
-    const ddir = path.join(profileDir, 'node_modules', ...name.split('/'));
-    if (dryRun) {
-      log(`dry-run: 将同步私有依赖 ${name} → ${ddir}`);
-      continue;
-    }
-    fs.cpSync(sdir, ddir, { recursive: true, force: true, preserveTimestamps: true });
-    log(`已同步私有依赖 ${name}`);
-  }
-
-  // 拷贝插件文件；bundle 插件（package.json 声明 dsh.bundle.patch）不写 patch 行。
-  const bundleNames = new Set();
-  const missingBundleNames = new Set(); // 源缺失或落盘校验失败的 bundle 包名
-  for (const p of COMPANION_PLUGINS) {
-    const rel = companionDirName(p);
-    const src = path.join(__dirname, '..', 'assets', 'plugins', rel);
-    if (!fs.existsSync(path.join(src, 'package.json'))) {
-      warn(`跳过（找不到源）: ${p.name}（${src}）`);
-      missingBundleNames.add(p.name);
-      continue;
-    }
-    let pkg = {};
-    try { pkg = JSON.parse(fs.readFileSync(path.join(src, 'package.json'), 'utf8')); } catch {}
-    const isBundle = bundlePatchRel(pkg) !== '';
-    const dest = path.join(profileModules, '..', p.name);
-    if (dryRun) {
-      log(`dry-run: 将安装 ${p.name} → ${dest}${isBundle ? '（bundle 插件）' : ''}`);
-      continue;
-    }
-    fs.mkdirSync(path.join(dest, 'lib'), { recursive: true });
-    for (const f of PLUGIN_FILES) {
-      const sf = path.join(src, f);
-      if (fs.existsSync(sf)) fs.copyFileSync(sf, path.join(dest, f));
-    }
-    // 随包分发的目录整体递归拷贝：lib/assets/src/dist 的打包产物与资源，
-    // 以及 node_modules（如 billion-context-dsh 的私有依赖 acp-kernel），
-    // 保证 bundle 在 profile 内可解析。
-    for (const sub of ['lib', 'assets', 'src', 'dist', 'node_modules']) {
-      const sdir = path.join(src, sub);
-      if (fs.existsSync(sdir)) {
-        fs.cpSync(sdir, path.join(dest, sub), { recursive: true, force: true, preserveTimestamps: true });
-      }
-    }
-    // 落盘后校验 bundle 完整性（补丁层 + 入口文件必须存在）：校验失败不注册，
-    // 否则 dsh 启动时会因整棵插件树加载失败而崩溃。下次运行本脚本会重试。
-    if (isBundle) {
-      const check = verifyBundleDir(dest);
-      if (!check.ok) {
-        missingBundleNames.add(p.name);
-        warn(`已复制但校验失败（不注册为 bundle）: ${p.name} —— ${check.reason}`);
-      } else {
-        bundleNames.add(p.name);
-      }
-    }
-    log(`已安装 ${p.name}${isBundle ? '（bundle 插件）' : ''}`);
-  }
+  // 文件同步 + 过期清理 + bundle 完整性校验（共享实现，文案经 hooks 注入，
+  // 与旧版本脚本输出逐字一致）。
+  const { bundleNames, missingNames } = syncCompanionFiles({
+    assetsRoot: path.join(__dirname, '..', 'assets', 'plugins'),
+    profileDir,
+    vendorRoot: path.join(__dirname, '..', 'node_modules'),
+    dryRun,
+    log: (m) => log(m),
+    fail: (m) => warn(m),
+    plan: (m) => log(m),
+    onMissingSource: (name, srcDir) => warn(`跳过（找不到源）: ${name}（${srcDir}）`),
+    onCopyFail: (sf, err) => warn('同步配套插件文件失败 ' + sf + ': ' + err.message),
+    onVerifyFail: (name, reason) => warn(`已复制但校验失败（不注册为 bundle）: ${name} —— ${reason}`),
+    onInstalled: (name, isBundle) => log(`已安装 ${name}${isBundle ? '（bundle 插件）' : ''}`),
+    onVendorSynced: (name) => log(`已同步私有依赖 ${name}`),
+  });
 
   // Bundle 插件注册进 profile manifest 的 dsh.profile.bundles（dsh 启动时读取
   // 包内 cordis.patch.yml）。本脚本不凭空创建 manifest（会顶替 dsh 的 profile
@@ -287,15 +184,15 @@ function syncPlugins(home, dryRun) {
     }
     // 源缺失 / 校验失败的 bundle 若仍登记在 manifest，会让 dsh 启动崩溃：
     // 幂等移除登记（视为用户禁用），包文件保留，下次运行本脚本重试。
-    if (missingBundleNames.size > 0) {
+    if (missingNames.size > 0) {
       const before = manifest.dsh.profile.bundles.length;
-      manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((n) => !missingBundleNames.has(n));
+      manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((n) => !missingNames.has(n));
       if (manifest.dsh.profile.bundles.length !== before) {
         if (dryRun) {
-          log('dry-run: 将把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingBundleNames].join(', '));
+          log('dry-run: 将把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingNames].join(', '));
         } else {
           writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-          log('已把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingBundleNames].join(', '));
+          log('已把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingNames].join(', '));
         }
       }
     }
@@ -303,48 +200,25 @@ function syncPlugins(home, dryRun) {
     log('profile manifest 尚无 bundles（可能尚未初始化），bundle 插件留待下次运行注册');
   }
 
-  // 非 bundle 插件注册到 profile 补丁层（幂等，保留用户自己加的条目）。
+  // 非 bundle 插件注册到 profile 补丁层（共享实现：幂等、尊重用户已有条目、
+  // bundle 迁移去重与源缺失残留移除；旧插件市场条目一并清理）。
   const patchFile = path.join(profileDir, 'cordis.patch.yml');
   let patch = '';
   try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { patch = ''; }
-  let changed = false;
-  for (const p of COMPANION_PLUGINS) {
-    if (bundleNames.has(p.name)) continue;
-    // 源缺失/校验失败：不写任何注册（复制循环已跳过），避免「注册了但包不存在」
-    // 导致 dsh web 启动崩溃。
-    if (missingBundleNames.has(p.name)) continue;
-    const idNameRe = new RegExp('(id:\\s*' + p.id + '\\b[^\\n]*\\n\\s*name:\\s*\\x27)([^\\x27]*)(\\x27)');
-    const m = patch.match(idNameRe);
-    if (m) {
-      if (m[2] !== p.name) {
-        patch = patch.replace(idNameRe, '$1' + p.name + '$3');
-        changed = true;
-        log(`已更新补丁条目 ${p.id}: ${m[2]} → ${p.name}`);
-      }
-      continue;
-    }
-    const block = `- insert:\n    - id: ${p.id}\n      name: '${p.name}'\n`;
-    if (/^\s*\[\]\s*$/m.test(patch)) patch = patch.replace(/\[\]/m, block);
-    else if (patch.trim() === '') patch = '# dsh web profile patch（由 DSH Desktop 维护）\n' + block;
-    else patch = patch.replace(/\s*$/, '\n') + block;
-    changed = true;
-    log(`已添加补丁条目 ${p.id} → ${p.name}`);
-  }
-  // 旧插件市场条目清理（幂等）。
-  const patchBefore = patch;
-  patch = patch.replace(/^\s*-\s*insert:\s*$\n^\s*-\s*id:\s*plugin-marketplace\s*$\n^\s*name:\s*['"]@deepseek-ai\/dsh-plugin-marketplace['"]\s*$\n?/gm, '');
-  if (patch !== patchBefore) {
+  const reg = registerCompanionPatchEntries(patch, {
+    plugins: COMPANION_PLUGINS,
+    bundleNames,
+    missingNames,
+    onDrop: (m) => log(m),
+    onEntry: (m) => log(m),
+  });
+  patch = reg.patch;
+  let changed = reg.changed;
+  const marketplace = removeLegacyMarketplacePatchLines(patch);
+  patch = marketplace.patch;
+  if (marketplace.changed) {
     changed = true;
     log('已从 cordis.patch.yml 移除旧插件市场条目');
-  }
-  if (changed) {
-    if (dryRun) log(`dry-run: 将写入 ${patchFile}`);
-    else {
-      writeFileAtomic(patchFile, patch);
-      log(`已写入 ${patchFile}`);
-    }
-  } else {
-    log('补丁层无变化（全部条目已存在）');
   }
 
   // billion-context-dsh（compaction-acp）是模型驱动的 ACP 压缩后端：同一
@@ -352,18 +226,12 @@ function syncPlugins(home, dryRun) {
   // 安装说明）。幂等写入禁用条目：patch 中已存在 compaction-basic 条目
   // （含用户手写的 disabled 块）则不动，尊重用户配置。
   if (bundleNames.has('billion-context-dsh')) {
-    let acpPatch = '';
-    try { acpPatch = fs.readFileSync(patchFile, 'utf8'); } catch { acpPatch = ''; }
-    if (!/(?:^|\n)\s*-?\s*id\s*:\s*compaction-basic\b/.test('\n' + acpPatch)) {
-      const block = '\n# billion-context-dsh：禁用 preset realm 的 compaction-basic（ACP 模型驱动后端接管压缩决策）\n- id: compaction-basic\n  disabled: true\n';
-      if (/^\s*\[\]\s*$/m.test(acpPatch)) acpPatch = acpPatch.replace(/\[\]/m, block.trim());
-      else if (acpPatch.trim() === '') acpPatch = '# dsh web profile patch（由 DSH Desktop 维护）\n' + block.trim();
-      else acpPatch = acpPatch.replace(/\s*$/, '\n') + block;
+    const acp = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*compaction-basic\\b'), ACP_DISABLE_BLOCK);
+    if (acp.changed) {
+      patch = acp.patch;
+      changed = true;
       if (dryRun) log(`dry-run: 将向 ${patchFile} 写入 compaction-basic 禁用条目`);
-      else {
-        writeFileAtomic(patchFile, acpPatch);
-        log('已写入 compaction-basic 禁用条目（billion-context-dsh 接管压缩后端）');
-      }
+      else log('已写入 compaction-basic 禁用条目（billion-context-dsh 接管压缩后端）');
     } else {
       log('compaction-basic 禁用条目已存在（跳过）');
     }
@@ -374,87 +242,65 @@ function syncPlugins(home, dryRun) {
   // 客户端默认。插件级 disabled 条目一票否决任何已保存状态；需要时可在
   // 设置 → 插件 → 管理 一键开启。幂等：已存在 harness-pet 条目则不动。
   if (bundleNames.has('harness-pet')) {
-    let petPatch = '';
-    try { petPatch = fs.readFileSync(patchFile, 'utf8'); } catch { petPatch = ''; }
-    if (!/(?:^|\n)\s*-?\s*id\s*:\s*harness-pet\b/.test('\n' + petPatch)) {
-      const block = '\n# harness-pet：桌面宠物默认关闭（设置 → 插件 → 管理 可一键开启）\n- id: harness-pet\n  disabled: true\n';
-      if (/^\s*\[\]\s*$/m.test(petPatch)) petPatch = petPatch.replace(/\[\]/m, block.trim());
-      else if (petPatch.trim() === '') petPatch = '# dsh web profile patch（由 DSH Desktop 维护）\n' + block.trim();
-      else petPatch = petPatch.replace(/\s*$/, '\n') + block;
+    const pet = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*harness-pet\\b'), PET_DISABLE_BLOCK);
+    if (pet.changed) {
+      patch = pet.patch;
+      changed = true;
       if (dryRun) log(`dry-run: 将向 ${patchFile} 写入 harness-pet 禁用条目`);
-      else {
-        fs.writeFileSync(patchFile, petPatch);
-        log('已写入 harness-pet 禁用条目（桌面宠物默认关闭）');
-      }
+      else log('已写入 harness-pet 禁用条目（桌面宠物默认关闭）');
     } else {
       log('harness-pet 禁用条目已存在（跳过）');
     }
   }
+
+  if (changed) {
+    if (dryRun) log(`dry-run: 将写入 ${patchFile}`);
+    else {
+      writeFileAtomic(patchFile, patch);
+      log(`已写入 ${patchFile}`);
+    }
+  } else {
+    log('补丁层无变化（全部条目已存在）');
+  }
 }
 
 // ---------------------------------------------------------------------------
-// 运行时补丁（与 main.js applyRuntimeFlashFix / applyPromptExposeFix 同逻辑）：
-// 覆盖 profile fallback 与壳托管安装目录 agent 两份副本；bundle 初始化后的
-// dsh 安装（npm 版）两份副本通常互为同一文件（fallback 符号链接写穿），幂等。
+// 运行时补丁（与 main.js applyRuntimeFlashFix / applyPromptExposeFix 共用
+// scripts/lib/runtime-patches.js 的同一变换）：覆盖 profile fallback 与壳托管
+// 安装目录 agent 两份副本；bundle 初始化后的 dsh 安装（npm 版）两份副本通常
+// 互为同一文件（fallback 符号链接写穿），幂等。
 // ---------------------------------------------------------------------------
-
-function patchTargets(home, pkgPath) {
-  const mk = (root) => path.join(root, 'node_modules', '@deepseek-ai', pkgPath);
-  return [
-    mk(path.join(home, 'profiles')),
-    mk(path.join(home, 'agent')),
-  ];
-}
 
 function applyRuntimePatches(home, dryRun) {
   // 会话列表刷新闪跳修复（mergeOrderedBaseline 保留本地新会话）。
-  const OLD_FLASH = '(value) => baselineByKey.get(keyOf(value))).filter((value) => value !== void 0);';
-  const NEW_FLASH = '(value) => baselineByKey.get(keyOf(value)) ?? value).filter((value) => value !== void 0);';
-  for (const file of patchTargets(home, path.join('dsh-client-runtime', 'lib', 'client.js'))) {
-    if (!fs.existsSync(file)) continue;
-    try {
-      const src = fs.readFileSync(file, 'utf8');
-      if (src.includes(NEW_FLASH)) { log('runtime 补丁: 已应用，跳过 ' + file); continue; }
-      if (!src.includes(OLD_FLASH)) { warn('runtime 补丁: 未匹配到目标代码（版本可能已变更），跳过 ' + file); continue; }
-      if (dryRun) { log('dry-run: 将应用会话列表闪跳修复 ' + file); continue; }
-      fs.writeFileSync(file, src.replace(OLD_FLASH, NEW_FLASH), 'utf8');
-      log('已应用会话列表闪跳修复 ' + file);
-    } catch (err) {
-      warn('runtime 补丁失败(' + file + '): ' + err.message);
-    }
-  }
+  applyPatchToFiles({
+    prefix: 'runtime 补丁',
+    files: patchTargets(home, FLASH_PKG_REL),
+    log: (m) => log(m),
+    anchorLog: (m) => warn(m),
+    transform: (src) => transformFlashFix(src),
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file) => '已应用会话列表闪跳修复 ' + file,
+    donePrefix: false,
+    failLog: (file, err) => 'runtime 补丁失败(' + file + '): ' + err.message,
+    dryRun,
+    dryRunChangedLog: (file) => 'dry-run: 将应用会话列表闪跳修复 ' + file,
+  });
 
   // 设置暴露白名单补丁（dsh-prompt / 第三方思考 / 识图 / 会话调整）。
-  const NAMESPACES = ['dsh-prompt', 'dsh-third-party-thinking', 'dsh-vision', 'dsh-conversation-tweaks'];
-  for (const file of patchTargets(home, path.join('dsh-host-apiproxy', 'lib', 'index.js'))) {
-    if (!fs.existsSync(file)) continue;
-    try {
-      const src = fs.readFileSync(file, 'utf8');
-      const declIdx = src.indexOf('const WEB_SETTINGS_NAMESPACES = [');
-      if (declIdx === -1) {
-        warn('提示词暴露补丁: 未找到 WEB_SETTINGS_NAMESPACES（版本可能已变更），跳过 ' + file);
-        continue;
-      }
-      // 只认声明之后最近的 `];`，避免插进文件里其它数组。
-      const closeIdx = src.indexOf('];', declIdx);
-      if (closeIdx === -1) {
-        warn('提示词暴露补丁: 未匹配到命名空间数组收尾，跳过 ' + file);
-        continue;
-      }
-      const arrText = src.slice(declIdx, closeIdx);
-      const missing = NAMESPACES.filter((ns) => !arrText.includes('"' + ns + '"'));
-      if (missing.length === 0) {
-        log('提示词暴露补丁: 已应用，跳过 ' + file);
-        continue;
-      }
-      const block = ',\n' + missing.map((ns) => '\t"' + ns + '"').join(',\n') + '\n';
-      if (dryRun) { log('dry-run: 将把 ' + missing.join(', ') + ' 加入设置白名单 ' + file); continue; }
-      fs.writeFileSync(file, src.slice(0, closeIdx) + block + src.slice(closeIdx), 'utf8');
-      log('已把 ' + missing.join(', ') + ' 加入设置白名单 ' + file);
-    } catch (err) {
-      warn('提示词暴露补丁失败(' + file + '): ' + err.message);
-    }
-  }
+  applyPatchToFiles({
+    prefix: '提示词暴露补丁',
+    files: patchTargets(home, EXPOSE_PKG_REL),
+    log: (m) => log(m),
+    anchorLog: (m) => warn(m),
+    transform: transformExposeFix,
+    alreadyLog: (file) => '已应用，跳过 ' + file,
+    doneLog: (file, note) => '已把 ' + note.join(', ') + ' 加入设置白名单 ' + file,
+    donePrefix: false,
+    failLog: (file, err) => '提示词暴露补丁失败(' + file + '): ' + err.message,
+    dryRun,
+    dryRunChangedLog: (file, note) => 'dry-run: 将把 ' + note.join(', ') + ' 加入设置白名单 ' + file,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/dsh-desktop/scripts/sync-companion-plugins.js
+++ b/dsh-desktop/scripts/sync-companion-plugins.js
@@ -30,6 +30,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const { installBuiltinPresets } = require('./install-minimal-win-preset');
+const { bundlePatchRel, verifyBundleDir, writeFileAtomic } = require('../profile-bundle-heal');
 
 // 与 main.js COMPANION_PLUGINS 保持一致（保持同步时请两处一起改）。
 const COMPANION_PLUGINS = [
@@ -200,19 +201,38 @@ function syncPlugins(home, dryRun) {
     }
   }
 
+  // 配套插件引用了不在 dsh 核心依赖闭包里的 npm 包时（例如 dsh-better-sidebar
+  // 使用的 schemastery / cosmokit、dsh-side-session 使用的 schemastery），把
+  // 内置副本一并落到 profile web node_modules，保证 bundle 的宿主端能在
+  // profile 内解析到这些依赖（与 main.js syncCompanionPlugins 的 vendorDeps
+  // 一致；dsh 的 profiles/node_modules fallback 只覆盖 dsh 自身依赖闭包）。
+  const vendorDeps = ['schemastery', 'cosmokit', '@standard-schema/spec'];
+  for (const name of vendorDeps) {
+    const sdir = path.join(__dirname, '..', 'node_modules', name);
+    if (!fs.existsSync(sdir)) continue;
+    const ddir = path.join(profileDir, 'node_modules', ...name.split('/'));
+    if (dryRun) {
+      log(`dry-run: 将同步私有依赖 ${name} → ${ddir}`);
+      continue;
+    }
+    fs.cpSync(sdir, ddir, { recursive: true, force: true, preserveTimestamps: true });
+    log(`已同步私有依赖 ${name}`);
+  }
+
   // 拷贝插件文件；bundle 插件（package.json 声明 dsh.bundle.patch）不写 patch 行。
   const bundleNames = new Set();
+  const missingBundleNames = new Set(); // 源缺失或落盘校验失败的 bundle 包名
   for (const p of COMPANION_PLUGINS) {
     const rel = companionDirName(p);
     const src = path.join(__dirname, '..', 'assets', 'plugins', rel);
     if (!fs.existsSync(path.join(src, 'package.json'))) {
       warn(`跳过（找不到源）: ${p.name}（${src}）`);
+      missingBundleNames.add(p.name);
       continue;
     }
     let pkg = {};
     try { pkg = JSON.parse(fs.readFileSync(path.join(src, 'package.json'), 'utf8')); } catch {}
-    const isBundle = !!(pkg && pkg.dsh && pkg.dsh.bundle && pkg.dsh.bundle.patch);
-    if (isBundle) bundleNames.add(p.name);
+    const isBundle = bundlePatchRel(pkg) !== '';
     const dest = path.join(profileModules, '..', p.name);
     if (dryRun) {
       log(`dry-run: 将安装 ${p.name} → ${dest}${isBundle ? '（bundle 插件）' : ''}`);
@@ -230,6 +250,17 @@ function syncPlugins(home, dryRun) {
       const sdir = path.join(src, sub);
       if (fs.existsSync(sdir)) {
         fs.cpSync(sdir, path.join(dest, sub), { recursive: true, force: true, preserveTimestamps: true });
+      }
+    }
+    // 落盘后校验 bundle 完整性（补丁层 + 入口文件必须存在）：校验失败不注册，
+    // 否则 dsh 启动时会因整棵插件树加载失败而崩溃。下次运行本脚本会重试。
+    if (isBundle) {
+      const check = verifyBundleDir(dest);
+      if (!check.ok) {
+        missingBundleNames.add(p.name);
+        warn(`已复制但校验失败（不注册为 bundle）: ${p.name} —— ${check.reason}`);
+      } else {
+        bundleNames.add(p.name);
       }
     }
     log(`已安装 ${p.name}${isBundle ? '（bundle 插件）' : ''}`);
@@ -251,8 +282,22 @@ function syncPlugins(home, dryRun) {
         continue;
       }
       manifest.dsh.profile.bundles.push(name);
-      fs.writeFileSync(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+      writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
       log(`已把 bundle 插件加入 web profile bundles: ${name}`);
+    }
+    // 源缺失 / 校验失败的 bundle 若仍登记在 manifest，会让 dsh 启动崩溃：
+    // 幂等移除登记（视为用户禁用），包文件保留，下次运行本脚本重试。
+    if (missingBundleNames.size > 0) {
+      const before = manifest.dsh.profile.bundles.length;
+      manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((n) => !missingBundleNames.has(n));
+      if (manifest.dsh.profile.bundles.length !== before) {
+        if (dryRun) {
+          log('dry-run: 将把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingBundleNames].join(', '));
+        } else {
+          writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+          log('已把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingBundleNames].join(', '));
+        }
+      }
     }
   } else if (bundleNames.size > 0) {
     log('profile manifest 尚无 bundles（可能尚未初始化），bundle 插件留待下次运行注册');
@@ -265,6 +310,9 @@ function syncPlugins(home, dryRun) {
   let changed = false;
   for (const p of COMPANION_PLUGINS) {
     if (bundleNames.has(p.name)) continue;
+    // 源缺失/校验失败：不写任何注册（复制循环已跳过），避免「注册了但包不存在」
+    // 导致 dsh web 启动崩溃。
+    if (missingBundleNames.has(p.name)) continue;
     const idNameRe = new RegExp('(id:\\s*' + p.id + '\\b[^\\n]*\\n\\s*name:\\s*\\x27)([^\\x27]*)(\\x27)');
     const m = patch.match(idNameRe);
     if (m) {
@@ -292,7 +340,7 @@ function syncPlugins(home, dryRun) {
   if (changed) {
     if (dryRun) log(`dry-run: 将写入 ${patchFile}`);
     else {
-      fs.writeFileSync(patchFile, patch);
+      writeFileAtomic(patchFile, patch);
       log(`已写入 ${patchFile}`);
     }
   } else {
@@ -313,7 +361,7 @@ function syncPlugins(home, dryRun) {
       else acpPatch = acpPatch.replace(/\s*$/, '\n') + block;
       if (dryRun) log(`dry-run: 将向 ${patchFile} 写入 compaction-basic 禁用条目`);
       else {
-        fs.writeFileSync(patchFile, acpPatch);
+        writeFileAtomic(patchFile, acpPatch);
         log('已写入 compaction-basic 禁用条目（billion-context-dsh 接管压缩后端）');
       }
     } else {

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -517,6 +517,145 @@ SCENARIOS['heal-dup-patch-keeps-config'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['heal-missing-bundle'] = async (t) => {
+  // 用户反馈崩溃类 1：manifest 登记了未安装的 bundle（dsh plugin 安装中途
+  // 失败 / 手工删除 / 迁移后缺 node_modules）→ 官方 loadProfile 抛
+  // "cannot resolve profile bundle" 并以退出码 1 启动失败。启动防护应跳过该
+  // 层并正常进入 Web UI；manifest 登记原样保留（等待用户重装，绝不破坏）。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const manifestFile = path.join(profileDir, 'package.json');
+  fs.writeFileSync(manifestFile, JSON.stringify({
+    name: 'dsh-profile-web',
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/dsh-skill-manager'] } },
+  }, null, 2) + '\n');
+  await t.waitFor('boot-ready', 240000, '缺失 bundle 应被跳过并正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('profile bundle 缺失'), '健康检查应记录缺失 bundle');
+  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
+  t.assert(/cannot resolve profile bundle "@dsh-external\/dsh-skill-manager"/.test(webLog), 'dsh-web.log 应含 cannot resolve 诊断');
+  t.assert(/profile bundle "@dsh-external\/dsh-skill-manager" skipped/.test(webLog), 'dsh-web.log 应记录该层被跳过');
+  const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  t.assert(after.dsh.profile.bundles.includes('@dsh-external/dsh-skill-manager'), 'manifest 登记应原样保留');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-manifestless-bundle'] = async (t) => {
+  // 用户反馈崩溃类 2：bundle 包已安装但 package.json 未声明 dsh.bundle.patch
+  // （普通库 / 仅客户端 bundle）→ 官方 loadProfile 抛 "declares no
+  // dsh.bundle" 并启动失败。启动防护应跳过该层并正常进入 Web UI，登记保留。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  const pkgDir = path.join(profileDir, 'node_modules', '@dsh-external', 'dsh-gold-luxe');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@dsh-external/dsh-gold-luxe', version: '1.0.0' }, null, 2) + '\n');
+  const manifestFile = path.join(profileDir, 'package.json');
+  fs.writeFileSync(manifestFile, JSON.stringify({
+    name: 'dsh-profile-web',
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/dsh-gold-luxe'] } },
+  }, null, 2) + '\n');
+  await t.waitFor('boot-ready', 240000, '无 dsh.bundle 声明的 bundle 应被跳过并正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
+  t.assert(/profile bundle "@dsh-external\/dsh-gold-luxe" skipped/.test(webLog), 'dsh-web.log 应记录该层被跳过');
+  const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  t.assert(after.dsh.profile.bundles.includes('@dsh-external/dsh-gold-luxe'), 'manifest 登记应原样保留');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-broken-manifest'] = async (t) => {
+  // profile manifest JSON 损坏（手改 / 写盘撕裂）→ 壳层同步先备份原文件再
+  // 重置为核心 bundles 模板，dsh web 正常启动。备份必须存在（不丢用户现场）。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(path.join(profileDir, 'package.json'), '{"name": "dsh-profile-web", "private": true, "dsh": {"profile": {"bundles": [', 'utf8');
+  await t.waitFor('boot-ready', 240000, '损坏的 manifest 应被备份重建后正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('profile manifest 损坏，原文件已备份'), '应记录 manifest 备份日志');
+  const backups = fs.readdirSync(profileDir).filter((f) => f.startsWith('package.json.broken-'));
+  t.assert(backups.length >= 1, '损坏的 manifest 应备份为 package.json.broken-<ts>');
+  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  const bundles = manifest && manifest.dsh && manifest.dsh.profile && manifest.dsh.profile.bundles;
+  t.assert(Array.isArray(bundles) && bundles.includes('@deepseek-ai/dsh-base'), `重建后的 manifest 应含核心 bundles，实际=${JSON.stringify(bundles)}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-broken-home-patch'] = async (t) => {
+  // 家级补丁层 $DSH_HOME/cordis.patch.yml 损坏 → 官方 composeProfile 抛
+  // "failed to parse patches" 并启动失败。profile-boot 防护应备份 + 重置为
+  // 空列表后正常启动；损坏原文保留在 .broken- 备份里。
+  fs.writeFileSync(path.join(t.dshHome, 'cordis.patch.yml'), '- id: [BAD', 'utf8');
+  await t.waitFor('boot-ready', 240000, '损坏的家级补丁层应被自愈后正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
+  t.assert(/cordis\.patch\.yml failed to parse/.test(webLog), 'dsh-web.log 应记录家级补丁层解析失败');
+  const backups = fs.readdirSync(t.dshHome).filter((f) => f.startsWith('cordis.patch.yml.broken-'));
+  t.assert(backups.length >= 1, '损坏的家级补丁层应备份为 cordis.patch.yml.broken-<ts>');
+  const healed = fs.readFileSync(path.join(t.dshHome, 'cordis.patch.yml'), 'utf8');
+  t.assert(/\[\]/.test(healed), `自愈后应为最小合法文件，实际=${healed}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-broken-bundle-patch'] = async (t) => {
+  // bundle 的 cordis.patch.yml 损坏 → 官方 loadOverlayPatches 抛 "failed to
+  // parse overlay" 并启动失败。启动防护应跳过该层并正常进入 Web UI；bundle
+  // 文件不修改（重装该插件即可恢复）。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  const pkgDir = path.join(profileDir, 'node_modules', '@dsh-external', 'dsh-broken');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@dsh-external/dsh-broken', version: '1.0.0', dsh: { bundle: { patch: './cordis.patch.yml' } } }, null, 2) + '\n');
+  const brokenPatch = '- id: [BAD';
+  fs.writeFileSync(path.join(pkgDir, 'cordis.patch.yml'), brokenPatch, 'utf8');
+  const manifestFile = path.join(profileDir, 'package.json');
+  fs.writeFileSync(manifestFile, JSON.stringify({
+    name: 'dsh-profile-web',
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/dsh-broken'] } },
+  }, null, 2) + '\n');
+  await t.waitFor('boot-ready', 240000, '损坏的 bundle 补丁层应被跳过并正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
+  t.assert(/profile bundle "@dsh-external\/dsh-broken" skipped/.test(webLog), 'dsh-web.log 应记录该层被跳过');
+  t.assert(fs.readFileSync(path.join(pkgDir, 'cordis.patch.yml'), 'utf8') === brokenPatch, 'bundle 文件不应被修改');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['companion-bundle-invariant'] = async (t) => {
+  // 写盘侧防呆不变量：配套 bundle 只有在「补丁层 + 入口文件」都实际落盘后才
+  // 会登记进 manifest（billion-context-dsh 上游缺 dist 构建产物时必须不登记，
+  // 否则 dsh web 启动崩溃）。场景对两种资产状态都成立：
+  // manifest 含 billion-context-dsh ⟺ profile node_modules 里该包入口存在。
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  let bundles = [];
+  try {
+    const m = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+    bundles = (m && m.dsh && m.dsh.profile && Array.isArray(m.dsh.profile.bundles)) ? m.dsh.profile.bundles : [];
+  } catch {}
+  let entryExists = false;
+  const pkgPath = path.join(profileDir, 'node_modules', 'billion-context-dsh', 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      const entry = (pkg && pkg.main) || (pkg && pkg.exports && pkg.exports['.'] && pkg.exports['.'].import);
+      entryExists = !!entry && fs.existsSync(path.join(path.dirname(pkgPath), ...String(entry).split('/')));
+    } catch {}
+  }
+  t.assert(bundles.includes('billion-context-dsh') === entryExists,
+    `登记状态应与入口文件存在性一致，实际 bundles=${JSON.stringify(bundles)} entryExists=${entryExists}`);
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
 SCENARIOS['web-search-patch'] = async (t) => {
   // issue #20：启动时必须把 web-search baseURL 契约补丁落到生效的 profile
   // fallback 副本（junction 写穿内置包），并记录日志。

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -586,6 +586,45 @@ SCENARIOS['heal-broken-manifest'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['heal-broken-manifest-recovers'] = async (t) => {
+  // issue #48 数据恢复：manifest 损坏被重置后，用户手动安装的第三方 bundle
+  // 仍实际落在 profile node_modules 里。启动自愈应把它们合并回 manifest
+  // （bundles + dependencies），用户插件照常装配；非 bundle 的普通依赖与
+  // 损坏包不得恢复登记。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const fixture = path.join(profileDir, 'node_modules', '@dsh-external', 'dsh-recovery-fixture');
+  fs.mkdirSync(path.join(fixture, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(fixture, 'package.json'), JSON.stringify({
+    name: '@dsh-external/dsh-recovery-fixture',
+    version: '1.0.0',
+    main: 'lib/index.js',
+    dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(fixture, 'cordis.patch.yml'), '[]\n', 'utf8');
+  fs.writeFileSync(path.join(fixture, 'lib', 'index.js'), 'export {};\n', 'utf8');
+  // 普通库：不得被恢复登记
+  const plainDir = path.join(profileDir, 'node_modules', '@dsh-external', 'plain-lib');
+  fs.mkdirSync(plainDir, { recursive: true });
+  fs.writeFileSync(path.join(plainDir, 'package.json'), JSON.stringify({ name: '@dsh-external/plain-lib', version: '1.0.0' }, null, 2) + '\n');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), '{"name": "dsh-profile-web", "private": true, "dsh": {"profile": {"bundles": [', 'utf8');
+  await t.waitFor('boot-ready', 240000, '损坏的 manifest 应自愈并恢复用户 bundle 后正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('已恢复用户安装的 bundle 插件'), '应记录第三方 bundle 恢复日志');
+  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  const bundles = manifest && manifest.dsh && manifest.dsh.profile && manifest.dsh.profile.bundles;
+  t.assert(Array.isArray(bundles) && bundles.includes('@deepseek-ai/dsh-base'), `应含核心 bundles，实际=${JSON.stringify(bundles)}`);
+  t.assert(Array.isArray(bundles) && bundles.includes('@dsh-external/dsh-recovery-fixture'),
+    `用户安装的 bundle 应被恢复登记，实际=${JSON.stringify(bundles)}`);
+  t.assert(!(Array.isArray(bundles) && bundles.includes('@dsh-external/plain-lib')), '普通库不得恢复登记');
+  t.assert(manifest && manifest.dependencies && manifest.dependencies['@dsh-external/dsh-recovery-fixture'] === '1.0.0',
+    `dependencies 应补回用户 bundle，实际=${JSON.stringify(manifest && manifest.dependencies)}`);
+  const backups = fs.readdirSync(profileDir).filter((f) => f.startsWith('package.json.broken-'));
+  t.assert(backups.length >= 1, '损坏原文应保留备份');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
 SCENARIOS['heal-broken-home-patch'] = async (t) => {
   // 家级补丁层 $DSH_HOME/cordis.patch.yml 损坏 → 官方 composeProfile 抛
   // "failed to parse patches" 并启动失败。profile-boot 防护应备份 + 重置为

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -716,6 +716,67 @@ SCENARIOS['web-search-patch'] = async (t) => {
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
+SCENARIOS['runtime-patches-suite'] = async (t) => {
+  // 统一补丁引擎重构的端到端防线：一次真实启动后，全部 12 个运行时补丁家族
+  // 必须已落盘（幂等标记/锚点产物）或留下对应日志。静默幂等的三个防护类
+  // 补丁（profile patch / bundle / settings）以文件标记断言。
+  await t.waitFor('boot-ready', 240000, 'Web UI 就绪');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  const logText = fs.readFileSync(t.desktopLog, 'utf8');
+  // 有日志产出的补丁家族（已应用/锚点失配/写入成功均有前缀日志）
+  for (const prefix of [
+    'runtime 补丁:', '提示词暴露补丁:', '识图发送补丁:', '识图密钥补丁:',
+    'workspace 搜索栏修复:', '插件页标签合并:', 'web-search baseURL 补丁',
+    'menu-viewport 补丁', 'session-manage 补丁',
+  ]) {
+    t.assert(logText.includes(prefix), '启动日志应包含补丁前缀: ' + prefix);
+  }
+  const nm = path.join(t.dshHome, 'profiles', 'node_modules', '@deepseek-ai');
+  const pkgFile = (rel) => path.join(nm, rel);
+  const readOf = (rel) => {
+    const f = pkgFile(rel);
+    t.assert(fs.existsSync(f), 'profile fallback 应存在: ' + rel);
+    return fs.readFileSync(f, 'utf8');
+  };
+  // 闪跳修复（dsh-client-runtime）
+  const runtime = readOf(path.join('dsh-client-runtime', 'lib', 'client.js'));
+  t.assert(runtime.includes('(value) => baselineByKey.get(keyOf(value)) ?? value).filter((value) => value !== void 0);'), '闪跳修复应落盘');
+  // host-apiproxy：白名单 + 识图转述 + 密钥修复 + 会话删除 RPC
+  const apiproxy = readOf(path.join('dsh-host-apiproxy', 'lib', 'index.js'));
+  for (const marker of ['"dsh-conversation-tweaks"', 'describeImagesWithVision', 'dsh-desktop fix: read the resolved HOST-side value', 'unarchiveSession']) {
+    t.assert(apiproxy.includes(marker), 'host-apiproxy 应包含补丁标记: ' + marker);
+  }
+  // 三个静默幂等的防护类补丁（app-boot / settings）
+  const appBoot = readOf(path.join('dsh-app-boot', 'lib', 'index.js'));
+  t.assert(appBoot.includes('function loadUserPatchLayer'), 'profile patch 防护应注入');
+  t.assert(appBoot.includes('dsh-desktop guard: a broken profile bundle must not brick'), 'profile bundle 防护应注入');
+  const settings = readOf(path.join('dsh-settings', 'lib', 'index.js'));
+  t.assert(settings.includes('dsh-desktop guard: an invalid stored section must not brick'), 'settings 注册防护应注入');
+  // workspace 搜索栏 / 插件页标签合并 / menu 视口 / web-search 契约 / 会话删除
+  const workspaceUi = readOf(path.join('dsh-client-ui-workspace', 'lib', 'client.js'));
+  t.assert(workspaceUi.includes('dsh-desktop fix: rail search expansion'), 'workspace 搜索栏修复应落盘');
+  const pluginsUi = readOf(path.join('dsh-client-ui-settings-plugins', 'lib', 'client.js'));
+  t.assert(pluginsUi.includes('dsh-desktop fix: hide inventory tab'), '插件页标签合并应落盘');
+  const primitives = readOf(path.join('dsh-client-ui-primitives', 'lib', 'index.js'));
+  t.assert(primitives.includes('dsh-desktop patch (issue #36)'), 'menu 视口补丁应落盘');
+  const webSearch = readOf(path.join('dsh-web-search-deepseek', 'lib', 'index.js'));
+  t.assert(webSearch.includes('normalizedBase'), 'web-search baseURL 补丁应落盘');
+  const workspacePkg = readOf(path.join('dsh-workspace', 'lib', 'index.js'));
+  t.assert(workspacePkg.includes('unarchiveSession'), '会话删除补丁（workspace）应落盘');
+  // dsh/lib/profile-boot-*.js 家级补丁层防护（同名 stub re-export 文件不含
+  // 锚点、按设计跳过；真实装配模块必须已注入）。
+  const dshLib = path.join(nm, 'dsh', 'lib');
+  const bootFiles = fs.existsSync(dshLib)
+    ? fs.readdirSync(dshLib).filter((f) => /^profile-boot-.+\.js$/.test(f))
+    : [];
+  t.assert(bootFiles.length > 0, '应存在 profile-boot-*.js 装配文件');
+  const guardedBoot = bootFiles.filter((name) =>
+    fs.readFileSync(path.join(dshLib, name), 'utf8').includes('loadUserPatchLayerSafe'));
+  t.assert(guardedBoot.length > 0, 'profile-boot 家级补丁层防护应注入到真实装配模块（stub 文件按设计跳过）');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
 SCENARIOS['vision-key-keep'] = async (t) => {
   // 识图 apiKey 保存回归：role('secret') 字段永不回显，旧版卡片在「改其它
   // 字段后保存」时会把已存密钥静默清空（用户反馈“密钥没法保存”）。修复后：

--- a/dsh-desktop/scripts/test/unit-meta.test.js
+++ b/dsh-desktop/scripts/test/unit-meta.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// 仓库元数据卫生测试（node --test）：
+//   - package.json description 必须是无乱码的正确 UTF-8 中文（历史 GBK 乱码回归防线）；
+//   - COMPANION_PLUGINS 清单与共享模块的一致性由 unit-patch-engine.test.js 覆盖。
+// 用法：node --test scripts/test/unit-meta.test.js
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+test('package.json description 为正确 UTF-8 文案（无 GBK 乱码）', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  assert.strictEqual(typeof pkg.description, 'string');
+  assert.strictEqual(
+    pkg.description,
+    'DeepSeek Harness (dsh) 开箱即用的 Windows 桌面客户端：内置 dsh CLI 与 Node 运行时，一键启动 Web UI',
+    'description 必须与预期文案逐字一致'
+  );
+  // 历史 GBK 乱码特征字符（寮€/绠卞嵆鐢 等）不得出现。
+  assert.ok(!/[\u5bee\u20ac\u7ba0\u4e0b\u5d86\u9432]/.test(pkg.description), '不得包含 GBK 乱码特征字符');
+});
+
+test('package.json 关键字段完整（版本/入口/私有标记）', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  assert.strictEqual(pkg.name, 'dsh-desktop');
+  assert.strictEqual(pkg.main, 'main.js');
+  assert.strictEqual(pkg.private, true);
+  assert.ok(/^\d+\.\d+\.\d+$/.test(String(pkg.version)), 'version 应为 x.y.z 形式');
+});

--- a/dsh-desktop/scripts/test/unit-patch-engine.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-engine.test.js
@@ -1,0 +1,367 @@
+'use strict';
+
+// 统一补丁引擎与配套插件共享模块的单元测试（node --test）：
+//   A. patch-io：原子写、进程级读缓存（命中/失效/缺失）；
+//   B. patch-engine：已应用/锚点失配/读取失败/写入失败/dry-run 全分支；
+//   C. runtime-patches：闪跳与白名单变换的字节级断言（含真实 vendored 文件）；
+//   D. companion-plugins：唯一数据源清单与目录名约定；
+//   E. companion-profile：禁用条目/旧市场清理/注册循环纯函数 + 真实 assets
+//      全量同步（幂等零写入、dry-run 零落盘、bundle 校验）。
+// 用法：node --test scripts/test/unit-patch-engine.test.js
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { writeFileAtomic, readFileCached } = require('../lib/patch-io');
+const { applyPatchToFiles } = require('../lib/patch-engine');
+const {
+  FLASH_OLD, FLASH_NEW, SETTINGS_NAMESPACES,
+  FLASH_PKG_REL, EXPOSE_PKG_REL, patchTargets,
+  transformFlashFix, transformExposeFix,
+} = require('../lib/runtime-patches');
+const { COMPANION_PLUGINS, companionDirName } = require('../lib/companion-plugins');
+const {
+  PATCH_HEADER, ACP_DISABLE_BLOCK, PET_DISABLE_BLOCK,
+  ensureDisabledPatchEntry, removeLegacyMarketplacePatchLines,
+  registerCompanionPatchEntries, syncCompanionFiles,
+} = require('../lib/companion-profile');
+const { bundlePatchRel, verifyBundleDir } = require('../../profile-bundle-heal');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function tmpdir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-engine-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function sha256(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// A. patch-io
+// ---------------------------------------------------------------------------
+
+test('patch-io: 原子写内容完整、无 .tmp 残留、可覆盖已有文件', (t) => {
+  const dir = tmpdir(t);
+  const file = path.join(dir, 'x.txt');
+  writeFileAtomic(file, 'first');
+  assert.strictEqual(fs.readFileSync(file, 'utf8'), 'first');
+  assert.ok(!fs.existsSync(file + '.tmp'), '写入后不应残留临时文件');
+  writeFileAtomic(file, 'second');
+  assert.strictEqual(fs.readFileSync(file, 'utf8'), 'second', '覆盖写入');
+});
+
+test('patch-io: 读缓存命中、外部写入后失效、缺失返回 null', (t) => {
+  const dir = tmpdir(t);
+  const file = path.join(dir, 'c.txt');
+  fs.writeFileSync(file, 'v1');
+  assert.strictEqual(readFileCached(file), 'v1');
+  assert.strictEqual(readFileCached(file), 'v1', '缓存命中');
+  fs.writeFileSync(file, 'v1-longer-content');
+  assert.strictEqual(readFileCached(file), 'v1-longer-content', '内容变化后缓存失效');
+  assert.strictEqual(readFileCached(path.join(dir, 'missing.txt')), null, '缺失返回 null');
+});
+
+// ---------------------------------------------------------------------------
+// B. patch-engine
+// ---------------------------------------------------------------------------
+
+test('patch-engine: changed/already/anchor-missing/dry-run 全分支与日志文案', (t) => {
+  const dir = tmpdir(t);
+  const file = path.join(dir, 'target.js');
+  fs.writeFileSync(file, 'OLD');
+  const logs = [];
+  const spec = () => ({
+    prefix: '测试补丁',
+    files: [file],
+    log: (m) => logs.push(m),
+    transform: (src) => {
+      if (src.includes('DONE')) return { status: 'already' };
+      if (!src.includes('OLD')) return { status: 'anchor-missing', detail: '锚点未匹配，跳过 ' + file };
+      return { status: 'changed', src: src.replace('OLD', 'DONE'), note: ['x'] };
+    },
+    alreadyLog: (f) => '已应用，跳过 ' + f,
+    doneLog: (f, note) => '已修复 ' + f + ' (' + note.join(',') + ')',
+  });
+  // changed
+  let n = applyPatchToFiles(spec());
+  assert.strictEqual(n, 1, '应写入 1 份文件');
+  assert.strictEqual(fs.readFileSync(file, 'utf8'), 'DONE');
+  assert.deepStrictEqual(logs, ['测试补丁: 已修复 ' + file + ' (x)']);
+  // already
+  logs.length = 0;
+  n = applyPatchToFiles(spec());
+  assert.strictEqual(n, 0);
+  assert.deepStrictEqual(logs, ['测试补丁: 已应用，跳过 ' + file]);
+  // anchor-missing（文件内容换成不含锚点）
+  fs.writeFileSync(file, 'OTHER');
+  logs.length = 0;
+  n = applyPatchToFiles(spec());
+  assert.strictEqual(n, 0);
+  assert.deepStrictEqual(logs, ['测试补丁: 锚点未匹配，跳过 ' + file]);
+  assert.strictEqual(fs.readFileSync(file, 'utf8'), 'OTHER', '锚点失配绝不改写文件');
+  // dry-run：不落盘，输出计划
+  fs.writeFileSync(file, 'OLD');
+  logs.length = 0;
+  n = applyPatchToFiles({ ...spec(), dryRun: true, dryRunChangedLog: (f) => 'dry-run: 将修复 ' + f });
+  assert.strictEqual(n, 0, 'dry-run 零写入');
+  assert.strictEqual(fs.readFileSync(file, 'utf8'), 'OLD', 'dry-run 不落盘');
+  assert.deepStrictEqual(logs, ['dry-run: 将修复 ' + file]);
+});
+
+test('patch-engine: 空路径/文件不存在静默跳过；读取失败与写入失败走对应日志', (t) => {
+  const dir = tmpdir(t);
+  const file = path.join(dir, 't.js');
+  fs.writeFileSync(file, 'OLD');
+  const logs = [];
+  const base = {
+    prefix: '测试补丁',
+    log: (m) => logs.push(m),
+    transform: (src) => ({ status: 'changed', src: src.replace('OLD', 'DONE') }),
+    doneLog: (f) => '已应用 ' + f,
+  };
+  // 不存在与空路径：静默
+  const n = applyPatchToFiles({ ...base, files: [null, '', path.join(dir, 'nope.js')] });
+  assert.strictEqual(n, 0);
+  assert.deepStrictEqual(logs, []);
+  // 读取失败：目录路径 stat 成功但 readFile 抛 EISDIR → 读取失败日志
+  const sub = path.join(dir, 'as-dir.js');
+  fs.mkdirSync(sub);
+  const n2 = applyPatchToFiles({ ...base, files: [sub] });
+  assert.strictEqual(n2, 0);
+  assert.deepStrictEqual(logs, ['测试补丁: 读取失败，跳过 ' + sub]);
+  // 写入失败：目标设为只读 → 原子写 rename 失败 → failLog（默认文案），原文件不损坏
+  logs.length = 0;
+  const ro = path.join(dir, 'ro.js');
+  fs.writeFileSync(ro, 'OLD');
+  fs.chmodSync(ro, 0o444);
+  const n3 = applyPatchToFiles({ ...base, files: [ro] });
+  assert.strictEqual(n3, 0);
+  assert.strictEqual(logs.length, 1, '应输出失败日志');
+  assert.ok(logs[0].startsWith('测试补丁失败(' + ro + '):'), '默认失败文案含前缀与文件: ' + logs[0]);
+  fs.chmodSync(ro, 0o666);
+  fs.rmSync(ro + '.tmp', { force: true });
+  assert.strictEqual(fs.readFileSync(ro, 'utf8'), 'OLD', '写入失败不得损坏原文件');
+});
+
+// ---------------------------------------------------------------------------
+// C. runtime-patches
+// ---------------------------------------------------------------------------
+
+test('runtime-patches: 闪跳变换 already/失配/changed 字节级正确', () => {
+  const file = 'C:\\x\\client.js';
+  const fake = `const keep = "${FLASH_OLD}";\nrest();`;
+  assert.deepStrictEqual(transformFlashFix(fake.replace(FLASH_OLD, FLASH_NEW), file), { status: 'already' });
+  assert.deepStrictEqual(transformFlashFix('nothing to patch', file), {
+    status: 'anchor-missing',
+    detail: '未匹配到目标代码（版本可能已变更），跳过 ' + file,
+  });
+  const out = transformFlashFix(fake, file);
+  assert.strictEqual(out.status, 'changed');
+  assert.strictEqual(out.src, fake.replace(FLASH_OLD, FLASH_NEW), '替换结果与旧实现逐字节一致');
+  assert.ok(!out.src.includes(FLASH_OLD) && out.src.includes(FLASH_NEW));
+});
+
+test('runtime-patches: 白名单变换 声明缺失/收尾缺失/部分缺失/已应用', () => {
+  const file = 'C:\\x\\index.js';
+  assert.deepStrictEqual(transformExposeFix('export const x = 1;', file), {
+    status: 'anchor-missing',
+    detail: '未找到 WEB_SETTINGS_NAMESPACES（版本可能已变更），跳过 ' + file,
+  });
+  // 声明存在但缺少 `];` 收尾 → anchor-missing（收尾缺失）
+  assert.deepStrictEqual(
+    transformExposeFix('const WEB_SETTINGS_NAMESPACES = [\n\t"a"\n', file),
+    { status: 'anchor-missing', detail: '未匹配到命名空间数组收尾，跳过 ' + file }
+  );
+  const src = 'const WEB_SETTINGS_NAMESPACES = [\n\t"dsh-prompt"\n];\nrest();';
+  const out = transformExposeFix(src, file);
+  assert.strictEqual(out.status, 'changed');
+  assert.deepStrictEqual(out.note, ['dsh-third-party-thinking', 'dsh-vision', 'dsh-conversation-tweaks']);
+  const expectedBlock = ',\n' + out.note.map((ns) => '\t"' + ns + '"').join(',\n') + '\n';
+  assert.strictEqual(out.src, src.slice(0, src.indexOf('];')) + expectedBlock + src.slice(src.indexOf('];')), '插入格式与旧实现逐字节一致');
+  assert.deepStrictEqual(transformExposeFix(out.src, file), { status: 'already' }, '二次应用幂等');
+  // 真实 vendored 文件：已应用状态
+  const real = path.join(repoRoot, 'node_modules', '@deepseek-ai', EXPOSE_PKG_REL);
+  assert.strictEqual(transformExposeFix(fs.readFileSync(real, 'utf8'), real).status, 'already', 'vendored 副本应判定为已应用');
+});
+
+test('runtime-patches: WSL/CLI 目标路径约定', () => {
+  const home = 'C:\\home';
+  const rel = path.join('dsh-client-runtime', 'lib', 'client.js');
+  assert.deepStrictEqual(patchTargets(home, rel), [
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+    path.join(home, 'agent', 'node_modules', '@deepseek-ai', rel),
+  ]);
+  assert.strictEqual(FLASH_PKG_REL, path.join('dsh-client-runtime', 'lib', 'client.js'));
+  assert.strictEqual(EXPOSE_PKG_REL, path.join('dsh-host-apiproxy', 'lib', 'index.js'));
+  assert.deepStrictEqual(SETTINGS_NAMESPACES, ['dsh-prompt', 'dsh-third-party-thinking', 'dsh-vision', 'dsh-conversation-tweaks']);
+});
+
+// ---------------------------------------------------------------------------
+// D. companion-plugins 唯一数据源
+// ---------------------------------------------------------------------------
+
+test('companion-plugins: 19 条清单与既有 id 顺序完全一致（漂移防线）', () => {
+  assert.deepStrictEqual(
+    COMPANION_PLUGINS.map((p) => p.id),
+    [
+      'balance', 'file-changes', 'client-file-changes', 'terminal', 'plugin-market',
+      'better-sidebar', 'harness-pet', 'float-window', 'dsh-navbar', 'dsh-session-manager',
+      'conversation-tweaks', 'super-injector', 'prompt-custom', 'third-party-thinking',
+      'wsl-settings', 'dsh-vision', 'side-session', 'compaction-acp', 'plugin-manager',
+    ],
+    '清单 id 顺序不得漂移（新增/改名须同步更新本测试）'
+  );
+  assert.strictEqual(companionDirName({ name: '@deepseek-ai/dsh-balance' }), 'dsh-balance');
+  assert.strictEqual(companionDirName({ name: 'harness-pet' }), 'harness-pet');
+});
+
+// ---------------------------------------------------------------------------
+// E. companion-profile 纯函数
+// ---------------------------------------------------------------------------
+
+test('ensureDisabledPatchEntry: 已存在/[] 形态/空文件/追加 四种形态', () => {
+  const idRe = (id) => new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*' + id + '\\b');
+  // 已存在（用户手写 disabled 块）：不动
+  const user = '# 用户配置\n- id: compaction-basic\n  disabled: true\n';
+  assert.deepStrictEqual(ensureDisabledPatchEntry(user, idRe('compaction-basic'), ACP_DISABLE_BLOCK), { patch: user, changed: false });
+  // [] 形态：'[]' 被替换为 trim 后的块，原字符串其余部分（'\n'）保留
+  const emptyList = ensureDisabledPatchEntry('[]\n', idRe('compaction-basic'), ACP_DISABLE_BLOCK);
+  assert.strictEqual(emptyList.changed, true);
+  assert.strictEqual(emptyList.patch,
+    '# billion-context-dsh：禁用 preset realm 的 compaction-basic（ACP 模型驱动后端接管压缩决策）\n- id: compaction-basic\n  disabled: true\n');
+  // 空文件形态
+  const empty = ensureDisabledPatchEntry('', idRe('harness-pet'), PET_DISABLE_BLOCK);
+  assert.strictEqual(empty.changed, true);
+  assert.strictEqual(empty.patch, PATCH_HEADER + PET_DISABLE_BLOCK.trim());
+  // 追加形态
+  const base = '# dsh web profile patch（由 DSH Desktop 维护）\n- insert:\n    - id: balance\n';
+  const appended = ensureDisabledPatchEntry(base, idRe('compaction-basic'), ACP_DISABLE_BLOCK);
+  assert.strictEqual(appended.changed, true);
+  assert.strictEqual(appended.patch, base.replace(/\s*$/, '\n') + ACP_DISABLE_BLOCK);
+});
+
+test('removeLegacyMarketplacePatchLines: 移除旧市场 insert 条目且幂等', () => {
+  const patch = '# dsh web profile patch（由 DSH Desktop 维护）\n- insert:\n    - id: plugin-marketplace\n      name: \'@deepseek-ai/dsh-plugin-marketplace\'\n- insert:\n    - id: balance\n      name: \'@deepseek-ai/dsh-balance\'\n';
+  const r1 = removeLegacyMarketplacePatchLines(patch);
+  assert.strictEqual(r1.changed, true);
+  assert.ok(!r1.patch.includes('dsh-plugin-marketplace'), '旧市场条目应被移除');
+  assert.ok(r1.patch.includes('dsh-balance'), '其它条目原样保留');
+  assert.deepStrictEqual(removeLegacyMarketplacePatchLines(r1.patch), { patch: r1.patch, changed: false }, '幂等');
+});
+
+test('registerCompanionPatchEntries: 空文件注册/幂等/改名/尊重用户禁用/迁移去重', () => {
+  const nonBundleNames = new Set(['@deepseek-ai/dsh-balance', '@deepseek-ai/dsh-terminal-tab']);
+  const plugins = [
+    { id: 'balance', name: '@deepseek-ai/dsh-balance' },
+    { id: 'terminal', name: '@deepseek-ai/dsh-terminal-tab' },
+    { id: 'sidebar', name: 'dsh-better-sidebar' },
+  ];
+  const bundleNames = new Set(); // 先全部按非 bundle 注册
+  const missingNames = new Set();
+  // 空文件 → header + insert
+  const r1 = registerCompanionPatchEntries('', { plugins, bundleNames, missingNames });
+  assert.strictEqual(r1.changed, true);
+  assert.deepStrictEqual(r1.added, ['balance', 'terminal', 'sidebar']);
+  assert.strictEqual(r1.patch, PATCH_HEADER
+    + '- insert:\n    - id: balance\n      name: \'@deepseek-ai/dsh-balance\'\n'
+    + '- insert:\n    - id: terminal\n      name: \'@deepseek-ai/dsh-terminal-tab\'\n'
+    + '- insert:\n    - id: sidebar\n      name: \'dsh-better-sidebar\'\n');
+  // 幂等：二次零变化
+  const r2 = registerCompanionPatchEntries(r1.patch, { plugins, bundleNames, missingNames });
+  assert.strictEqual(r2.changed, false);
+  assert.strictEqual(r2.patch, r1.patch);
+  // 改名：terminal 的 name 改成旧包名 → 就地改回
+  const renamed = r1.patch.replace('@deepseek-ai/dsh-terminal-tab', '@deepseek-ai/dsh-terminal');
+  const r3 = registerCompanionPatchEntries(renamed, { plugins, bundleNames, missingNames });
+  assert.strictEqual(r3.changed, true);
+  assert.deepStrictEqual(r3.updated, ['terminal']);
+  assert.ok(r3.patch.includes('@deepseek-ai/dsh-terminal-tab'));
+  // 尊重用户禁用：balance 有 disabled 条目 → 不再 insert（已在第一次注册后存在 insert……
+  // 这里用全新文本验证「id 已出现则跳过」）
+  const userDisabled = '# 用户配置\n- id: balance\n  disabled: true\n';
+  const r4 = registerCompanionPatchEntries(userDisabled, { plugins, bundleNames, missingNames });
+  assert.ok(r4.patch.includes('disabled: true'), '用户禁用条目原样保留');
+  assert.strictEqual((r4.patch.match(/id: balance/g) || []).length, 1, '已存在 id 不得重复 insert');
+  // bundle 迁移：sidebar 升级为 bundle → 其 insert 块被移除，用户覆盖保留
+  const r5 = registerCompanionPatchEntries(r1.patch, {
+    plugins, bundleNames: new Set(['dsh-better-sidebar']), missingNames,
+  });
+  assert.strictEqual(r5.changed, true);
+  assert.deepStrictEqual(r5.dropped, ['sidebar']);
+  assert.ok(!r5.patch.includes('dsh-better-sidebar'), 'bundle 化插件的 insert 应被移除');
+  // 源缺失：不注册 + 残留移除
+  const r6 = registerCompanionPatchEntries(r1.patch, {
+    plugins, bundleNames: new Set(), missingNames: new Set(['@deepseek-ai/dsh-balance']),
+  });
+  assert.deepStrictEqual(r6.dropped, ['balance']);
+  assert.ok(!r6.patch.includes('@deepseek-ai/dsh-balance'), '源缺失插件的注册应被移除');
+});
+
+test('companion-profile: 真实 assets 全量同步到隔离 profile（幂等零写入 + dry-run 零落盘）', (t) => {
+  const dir = tmpdir(t);
+  const profileDir = path.join(dir, 'profiles', 'web');
+  const assetsRoot = path.join(repoRoot, 'assets', 'plugins');
+  const vendorRoot = path.join(repoRoot, 'node_modules');
+  const opts = { assetsRoot, profileDir, vendorRoot };
+  // 第一次：真实同步
+  const r1 = syncCompanionFiles(opts);
+  const nm = path.join(profileDir, 'node_modules');
+  for (const p of COMPANION_PLUGINS) {
+    assert.ok(fs.existsSync(path.join(nm, p.name, 'package.json')), '包应落盘: ' + p.name);
+  }
+  // bundle 判定与 assets 源的可装配性一致（verify 相关文件会原样复制，因此对
+  // 源目录直接校验等价于对落盘副本校验；billion-context-dsh 上游缺 dist 构建
+  // 产物时必须按「源缺失」处理，不注册）。
+  const declaredBundles = COMPANION_PLUGINS.filter((p) => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(assetsRoot, companionDirName(p), 'package.json'), 'utf8'));
+    return bundlePatchRel(pkg) !== '';
+  }).map((p) => p.name);
+  const expectedBundles = declaredBundles.filter((name) => {
+    const rel = companionDirName(COMPANION_PLUGINS.find((p) => p.name === name));
+    return verifyBundleDir(path.join(assetsRoot, rel)).ok;
+  });
+  const expectedMissing = declaredBundles.filter((name) => !expectedBundles.includes(name));
+  assert.deepStrictEqual([...r1.bundleNames].sort(), expectedBundles.sort(), 'bundleNames 应与源可装配性一致');
+  assert.deepStrictEqual([...r1.missingNames].sort(), expectedMissing.sort(), '校验失败的 bundle 应计入缺失源');
+  if (expectedMissing.length > 0) {
+    assert.ok(!r1.bundleNames.has('billion-context-dsh'), '缺 dist 的 bundle 不得注册');
+  }
+  // 记录全树 (path, size, mtimeMs)
+  const snapshot = () => {
+    const map = new Map();
+    const walk = (d) => {
+      for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+        const full = path.join(d, e.name);
+        if (e.isDirectory()) walk(full);
+        else {
+          const st = fs.statSync(full);
+          map.set(full, st.size + ':' + st.mtimeMs);
+        }
+      }
+    };
+    walk(nm);
+    return map;
+  };
+  const before = snapshot();
+  // 第二次：零写入（size+mtime 全部不变）
+  const r2 = syncCompanionFiles(opts);
+  assert.deepStrictEqual([...r2.bundleNames].sort(), expectedBundles.sort());
+  assert.deepStrictEqual([...r2.missingNames].sort(), expectedMissing.sort());
+  assert.deepStrictEqual(snapshot(), before, '二次同步必须零写入（size+mtime 逐文件一致）');
+  // dry-run：目标目录完全不落盘
+  const dryDir = path.join(dir, 'dry');
+  const dryProfile = path.join(dryDir, 'profiles', 'web');
+  syncCompanionFiles({ ...opts, profileDir: dryProfile, dryRun: true, plan: () => {} });
+  assert.ok(!fs.existsSync(dryDir), 'dry-run 不得创建任何目录');
+  // 内容抽查：bundle 插件的补丁层已就位
+  const sidebar = path.join(nm, 'dsh-better-sidebar', 'cordis.patch.yml');
+  assert.ok(fs.existsSync(sidebar), 'bundle 补丁层应落盘');
+  assert.ok(sha256(path.join(nm, 'dsh-better-sidebar', 'package.json')) === sha256(path.join(assetsRoot, 'dsh-better-sidebar', 'package.json')), '同步内容与源一致');
+});

--- a/dsh-desktop/scripts/test/unit-patch-engine.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-engine.test.js
@@ -21,6 +21,7 @@ const { applyPatchToFiles } = require('../lib/patch-engine');
 const {
   FLASH_OLD, FLASH_NEW, SETTINGS_NAMESPACES,
   FLASH_PKG_REL, EXPOSE_PKG_REL, patchTargets,
+  localCopyFiles, guardCopyFiles, localNodeModulesRoots,
   transformFlashFix, transformExposeFix,
 } = require('../lib/runtime-patches');
 const { COMPANION_PLUGINS, companionDirName } = require('../lib/companion-plugins');
@@ -201,6 +202,38 @@ test('runtime-patches: WSL/CLI 目标路径约定', () => {
   assert.strictEqual(FLASH_PKG_REL, path.join('dsh-client-runtime', 'lib', 'client.js'));
   assert.strictEqual(EXPOSE_PKG_REL, path.join('dsh-host-apiproxy', 'lib', 'index.js'));
   assert.deepStrictEqual(SETTINGS_NAMESPACES, ['dsh-prompt', 'dsh-third-party-thinking', 'dsh-vision', 'dsh-conversation-tweaks']);
+});
+
+test('runtime-patches: 候选路径构造器（本地三副本/防护四副本/WSL agent 直连根）', () => {
+  const home = 'C:\\home';
+  const appDir = 'C:\\app';
+  const userData = 'C:\\ud';
+  const rel = path.join('dsh-host-apiproxy', 'lib', 'index.js');
+  // 本地模式三副本：profile fallback → 内置副本 → 更新 overlay
+  assert.deepStrictEqual(localCopyFiles(home, appDir, userData, rel), [
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+    path.join(appDir, 'node_modules', '@deepseek-ai', rel),
+    path.join(userData, 'agent', 'node_modules', '@deepseek-ai', rel),
+  ]);
+  // 防护类四副本：内置副本优先 + overlay + overlay 嵌套 dsh 依赖副本 + profile fallback
+  assert.deepStrictEqual(guardCopyFiles(home, appDir, userData, rel), [
+    path.join(appDir, 'node_modules', '@deepseek-ai', rel),
+    path.join(userData, 'agent', 'node_modules', '@deepseek-ai', rel),
+    path.join(userData, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', rel),
+    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+  ]);
+  // 包级补丁根目录：本地三件套；WSL 模式追加 WSL agent 直连根
+  assert.deepStrictEqual(localNodeModulesRoots(home, appDir, userData), [
+    path.join(home, 'profiles', 'node_modules'),
+    path.join(appDir, 'node_modules'),
+    path.join(userData, 'agent', 'node_modules'),
+  ]);
+  assert.deepStrictEqual(localNodeModulesRoots(home, appDir, userData, [path.join(home, 'agent', 'node_modules')]), [
+    path.join(home, 'profiles', 'node_modules'),
+    path.join(appDir, 'node_modules'),
+    path.join(userData, 'agent', 'node_modules'),
+    path.join(home, 'agent', 'node_modules'),
+  ]);
 });
 
 // ---------------------------------------------------------------------------

--- a/dsh-desktop/scripts/test/unit-profile-bundle-heal.test.js
+++ b/dsh-desktop/scripts/test/unit-profile-bundle-heal.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+// profile-bundle-heal 单元测试：纯函数（bundlePatchRel / bundleEntryOf /
+// verifyBundleDir / packageDirUpward / writeFileAtomic）与两个源码变换
+// （app-boot / profile-boot）的幂等性、锚点匹配与语法有效性。变换针对
+// vendored dsh built 文件（只读）；产出写入临时 .mjs 用 node --check 验证。
+//
+// 注意：集成测试（真实 Electron 启动）会把这些防护实际应用到 node_modules，
+// 因此本测试对「文件已注入」与「文件未注入」两种状态都给出有意义断言：
+// 未注入 → 变换必须命中锚点并产出合法语法；已注入 → 变换必须识别标记并
+// 原样返回（幂等）。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const {
+  PROFILE_BUNDLE_GUARD_MARKER,
+  PROFILE_BOOT_GUARD_MARKER,
+  bundlePatchRel,
+  bundleEntryOf,
+  verifyBundleDir,
+  packageDirUpward,
+  writeFileAtomic,
+  applyAppBootBundleGuard,
+  applyProfileBootBundleGuard,
+} = require('../../profile-bundle-heal');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const appBootFile = path.join(repoRoot, 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js');
+const profileBootFile = path.join(repoRoot, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'profile-boot-DG5t9aNs.js');
+
+function syntaxCheck(name, src) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pbg-unit-'));
+  const file = path.join(dir, name + '.mjs');
+  fs.writeFileSync(file, src, 'utf8');
+  try {
+    execFileSync(process.execPath, ['--check', file], { stdio: 'pipe' });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function tmpFixture(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pbg-fix-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const file = path.join(dir, ...rel.split('/'));
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content, 'utf8');
+  }
+  return dir;
+}
+
+test('bundlePatchRel: 只接受非空字符串 patch 声明', () => {
+  assert.equal(bundlePatchRel({ dsh: { bundle: { patch: './cordis.patch.yml' } } }), './cordis.patch.yml');
+  assert.equal(bundlePatchRel({ dsh: { bundle: { client: './lib/client.js' } } }), '');
+  assert.equal(bundlePatchRel({ dsh: { bundle: {} } }), '');
+  assert.equal(bundlePatchRel({}), '');
+  assert.equal(bundlePatchRel(null), '');
+  assert.equal(bundlePatchRel({ dsh: { bundle: { patch: 123 } } }), '');
+  assert.equal(bundlePatchRel({ dsh: { bundle: { patch: '' } } }), '');
+  assert.equal(bundlePatchRel({ dsh: { bundle: { patch: '   ' } } }), '');
+});
+
+test('bundleEntryOf: exports["."] 优先，其次 main', () => {
+  assert.equal(bundleEntryOf({ exports: { '.': './dist/index.js' } }), './dist/index.js');
+  assert.equal(bundleEntryOf({ exports: { '.': { import: './dist/index.js' } } }), './dist/index.js');
+  assert.equal(bundleEntryOf({ exports: { '.': { default: './dist/index.js' } } }), './dist/index.js');
+  assert.equal(bundleEntryOf({ exports: { '.': { types: './dist/index.d.ts' } }, main: './dist/index.js' }), '', 'exports["."] 无 import/default 时 Node 无法 import 该包，入口判定为空');
+  assert.equal(bundleEntryOf({ exports: ['./dist/index.js'] }), '');
+  assert.equal(bundleEntryOf({ main: './lib/index.js' }), './lib/index.js');
+  assert.equal(bundleEntryOf({}), '');
+  assert.equal(bundleEntryOf(null), '');
+});
+
+test('verifyBundleDir: 健康目录通过，缺失/损坏逐项拒绝', () => {
+  const ok = tmpFixture({
+    'package.json': JSON.stringify({ name: 'x', main: 'dist/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
+    'cordis.patch.yml': '[]\n',
+    'dist/index.js': 'export {};\n',
+  });
+  assert.deepEqual(verifyBundleDir(ok), { ok: true, reason: '' });
+
+  const noPatchFile = tmpFixture({
+    'package.json': JSON.stringify({ name: 'x', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
+  });
+  const r1 = verifyBundleDir(noPatchFile);
+  assert.equal(r1.ok, false);
+  assert.match(r1.reason, /补丁层缺失/);
+
+  const noEntry = tmpFixture({
+    'package.json': JSON.stringify({ name: 'x', main: 'dist/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
+    'cordis.patch.yml': '[]\n',
+  });
+  const r2 = verifyBundleDir(noEntry);
+  assert.equal(r2.ok, false);
+  assert.match(r2.reason, /入口文件缺失/);
+
+  const noDecl = tmpFixture({
+    'package.json': JSON.stringify({ name: 'x', main: 'dist/index.js' }),
+  });
+  const r3 = verifyBundleDir(noDecl);
+  assert.equal(r3.ok, false);
+  assert.match(r3.reason, /未声明 dsh\.bundle\.patch/);
+
+  const badJson = tmpFixture({ 'package.json': '{"name": "x", BAD' });
+  const r4 = verifyBundleDir(badJson);
+  assert.equal(r4.ok, false);
+  assert.match(r4.reason, /不可读或不是合法 JSON/);
+});
+
+test('packageDirUpward: 沿 node_modules 父目录链解析，未找到返回空串', () => {
+  const base = tmpFixture({
+    'node_modules/@scope/pkg/package.json': '{}',
+  });
+  assert.equal(packageDirUpward(path.join(base, 'a', 'b', 'c'), '@scope/pkg'), path.join(base, 'node_modules', '@scope', 'pkg'));
+  assert.equal(packageDirUpward(path.join(base, 'a'), 'missing-pkg'), '');
+});
+
+test('writeFileAtomic: 落盘内容正确且不留 .tmp', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pbg-wa-'));
+  const file = path.join(dir, 'package.json');
+  writeFileAtomic(file, '{"a":1}\n');
+  assert.equal(fs.readFileSync(file, 'utf8'), '{"a":1}\n');
+  assert.equal(fs.existsSync(file + '.tmp'), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// 变换锚点合成源（必须与 profile-bundle-heal.js 内的锚点字节一致）。
+const SYNTHETIC_APP_LAYERS = [
+  '\tconst layers = (normalizeShippedProfile(name, dir, readProfileManifest(binName, dir)).dsh?.profile?.bundles ?? []).map((packageName) => {',
+  '\t\tconst packageDir = resolveBundleDir(binName, packageName, installAnchor, dir);',
+  '\t\tconst declared = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).dsh?.bundle?.patch;',
+  '\t\tif (declared === void 0) throw new Error(`' + '${binName}: profile bundle ${JSON.stringify(packageName)} declares no dsh.bundle in its package.json`' + ');',
+  '\t\tconst patchPath = join(packageDir, declared);',
+  '\t\treturn {',
+  '\t\t\tpackageName,',
+  '\t\t\tpackageDir,',
+  '\t\t\tpatchPath,',
+  '\t\t\tpatches: loadOverlayPatches(binName, patchPath)',
+  '\t\t};',
+  '\t});',
+].join('\n');
+const SYNTHETIC_APP_INSERT = 'function composeEntries(layers, warn = () => {}) {';
+
+test('applyAppBootBundleGuard: 合成源命中锚点并替换', () => {
+  const src = 'export const x = 1;\n' + SYNTHETIC_APP_LAYERS + '\n' + SYNTHETIC_APP_INSERT + '\n  return null;\n}';
+  const out = applyAppBootBundleGuard(src);
+  assert.equal(out.changed, true);
+  assert.ok(out.src.includes(PROFILE_BUNDLE_GUARD_MARKER), '应写入幂等标记');
+  assert.ok(out.src.includes('function loadProfileLayers(binName, name, dir, installAnchor)'), '应注入自愈装配');
+  assert.ok(out.src.includes('\tconst layers = loadProfileLayers(binName, name, dir, installAnchor);'), '调用点应替换');
+  assert.ok(!out.src.includes(SYNTHETIC_APP_LAYERS), '严格装配代码块应整体移除');
+  const again = applyAppBootBundleGuard(out.src);
+  assert.equal(again.changed, false, '二次应用应为幂等空操作');
+  assert.equal(again.src, out.src);
+});
+
+test('applyAppBootBundleGuard: 锚点缺失时原样返回', () => {
+  const src = 'export const x = 1;\nfunction composeEntries(layers, warn = () => {}) {\n  return null;\n}';
+  assert.deepEqual(applyAppBootBundleGuard(src), { changed: false, src });
+  assert.deepEqual(applyAppBootBundleGuard(''), { changed: false, src: '' });
+  assert.deepEqual(applyAppBootBundleGuard(null), { changed: false, src: null });
+});
+
+test('applyAppBootBundleGuard: 真实 vendored 文件（两种状态均成立）', () => {
+  const src = fs.readFileSync(appBootFile, 'utf8');
+  const out = applyAppBootBundleGuard(src);
+  if (src.includes(PROFILE_BUNDLE_GUARD_MARKER)) {
+    // 已被集成测试应用过：必须识别标记并不再改写。
+    assert.equal(out.changed, false);
+    assert.equal(out.src, src);
+  } else {
+    // 未被应用：必须命中锚点、产出合法 ESM 且二次应用幂等。
+    assert.equal(out.changed, true, 'vendored app-boot 锚点应命中（dsh 版本变更时需同步更新锚点）');
+    assert.ok(out.src.includes('function loadProfileLayers'));
+    syntaxCheck('app-boot', out.src);
+    assert.equal(applyAppBootBundleGuard(out.src).changed, false);
+  }
+});
+
+test('applyProfileBootBundleGuard: 合成源命中全部调用点并替换', () => {
+  const src = [
+    'import { writeFileSync } from "node:fs";',
+    'const NAME = "dsh";',
+    '\tconst homePatches = loadOptionalPatches(NAME, homePatchPath()) ?? [];',
+    '\t\t...loadOptionalPatches(NAME, composed.profile.patchPath) ?? [],',
+    '\t\t...loadOptionalPatches(NAME, homePatchPath()) ?? [],',
+    'export { resolveTelemetryPatch as a, prepareProfile as i, PROFILE_ROOT_FILENAME as n, runProfile as o, homePatchPath as r, INSTALL_ANCHOR as t };',
+  ].join('\n');
+  const out = applyProfileBootBundleGuard(src);
+  assert.equal(out.changed, true);
+  assert.ok(out.src.includes(PROFILE_BOOT_GUARD_MARKER), '应写入幂等标记');
+  assert.ok(out.src.includes('function loadUserPatchLayerSafe(binName, file)'), '应注入自愈加载');
+  assert.ok(out.src.includes('import { readFileSync, writeFileSync } from "node:fs";'), 'import 应扩展');
+  assert.ok(out.src.includes('\tconst homePatches = loadUserPatchLayerSafe(NAME, homePatchPath());'), 'composeProfile 调用点应替换');
+  assert.ok(out.src.includes('\t\t...loadUserPatchLayerSafe(NAME, composed.profile.patchPath),'), 'HMR profile 层调用点应替换');
+  assert.ok(out.src.includes('\t\t...loadUserPatchLayerSafe(NAME, homePatchPath()),'), 'HMR 家级层调用点应替换');
+  assert.ok(out.src.includes('export { resolveTelemetryPatch as a, prepareProfile as i, PROFILE_ROOT_FILENAME as n, runProfile as o, homePatchPath as r, INSTALL_ANCHOR as t };'), '原导出应保留');
+  assert.ok(!out.src.includes('loadOptionalPatches(NAME, homePatchPath()) ?? []'), '严格加载应移除');
+  assert.equal(applyProfileBootBundleGuard(out.src).changed, false, '二次应用应为幂等空操作');
+});
+
+test('applyProfileBootBundleGuard: 任一锚点缺失时原样返回', () => {
+  const src = 'export const x = 1;';
+  assert.deepEqual(applyProfileBootBundleGuard(src), { changed: false, src });
+  assert.deepEqual(applyProfileBootBundleGuard(null), { changed: false, src: null });
+});
+
+test('applyProfileBootBundleGuard: 真实 vendored 文件（两种状态均成立）', () => {
+  const src = fs.readFileSync(profileBootFile, 'utf8');
+  const out = applyProfileBootBundleGuard(src);
+  if (src.includes(PROFILE_BOOT_GUARD_MARKER)) {
+    assert.equal(out.changed, false);
+    assert.equal(out.src, src);
+  } else {
+    assert.equal(out.changed, true, 'vendored profile-boot 锚点应命中（dsh 版本变更时需同步更新锚点）');
+    assert.ok(out.src.includes('function loadUserPatchLayerSafe'));
+    syntaxCheck('profile-boot', out.src);
+    assert.equal(applyProfileBootBundleGuard(out.src).changed, false);
+  }
+});

--- a/dsh-desktop/scripts/test/unit-profile-bundle-heal.test.js
+++ b/dsh-desktop/scripts/test/unit-profile-bundle-heal.test.js
@@ -24,6 +24,8 @@ const {
   bundleEntryOf,
   verifyBundleDir,
   packageDirUpward,
+  scanProfileBundles,
+  recoverManifestBundles,
   writeFileAtomic,
   applyAppBootBundleGuard,
   applyProfileBootBundleGuard,
@@ -127,6 +129,44 @@ test('writeFileAtomic: 落盘内容正确且不留 .tmp', () => {
   assert.equal(fs.readFileSync(file, 'utf8'), '{"a":1}\n');
   assert.equal(fs.existsSync(file + '.tmp'), false);
   fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('scanProfileBundles: 只返回可装配的第三方 bundle，排除核心/配套/普通依赖/损坏包', () => {
+  const base = tmpFixture({
+    'node_modules/@dsh-external/tavily/package.json': JSON.stringify({ name: '@dsh-external/tavily', version: '1.2.3', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
+    'node_modules/@dsh-external/tavily/cordis.patch.yml': '[]\n',
+    'node_modules/@dsh-external/tavily/lib/index.js': 'export {};\n',
+    'node_modules/@deepseek-ai/dsh-base/package.json': JSON.stringify({ name: '@deepseek-ai/dsh-base', version: '1.0.0', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
+    'node_modules/@deepseek-ai/dsh-base/cordis.patch.yml': '[]\n',
+    'node_modules/@deepseek-ai/dsh-base/lib/index.js': 'export {};\n',
+    'node_modules/plain-lib/package.json': JSON.stringify({ name: 'plain-lib', version: '1.0.0' }),
+    // 声明了 dsh.bundle 但补丁层/入口缺失：不得恢复登记
+    'node_modules/broken-bundle/package.json': JSON.stringify({ name: 'broken-bundle', version: '1.0.0', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
+    'node_modules/bad-json/package.json': '{BAD',
+  });
+  const found = scanProfileBundles(path.join(base, 'node_modules'), new Set(['@deepseek-ai/dsh-base']));
+  assert.deepEqual(found, [{ name: '@dsh-external/tavily', version: '1.2.3' }]);
+  assert.deepEqual(scanProfileBundles(path.join(base, 'missing'), new Set()), []);
+});
+
+test('recoverManifestBundles: 追加缺失登记并补回 dependencies，保留既有顺序与内容', () => {
+  const manifest = { name: 'dsh-profile-web', private: true, dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@dsh-external/tavily'] } } };
+  const recovered = recoverManifestBundles(manifest, [
+    { name: '@dsh-external/tavily', version: '1.2.3' },
+    { name: 'other-bundle', version: '2.0.0' },
+  ]);
+  assert.deepEqual(recovered, ['other-bundle']);
+  assert.deepEqual(manifest.dsh.profile.bundles, ['@deepseek-ai/dsh-base', '@dsh-external/tavily', 'other-bundle']);
+  assert.deepEqual(manifest.dependencies, { 'other-bundle': '2.0.0' });
+
+  const m2 = { dsh: { profile: { bundles: [] } }, dependencies: { x: '' } };
+  assert.deepEqual(recoverManifestBundles(m2, [{ name: 'x', version: '3.0.0' }]), ['x']);
+  assert.deepEqual(m2.dependencies, { x: '3.0.0' });
+  assert.deepEqual(m2.dsh.profile.bundles, ['x']);
+
+  const m3 = { dsh: { profile: { bundles: ['a'] } }, dependencies: { a: '^1.0.0' } };
+  assert.deepEqual(recoverManifestBundles(m3, [{ name: 'a', version: '9.9.9' }]), []);
+  assert.deepEqual(m3.dependencies, { a: '^1.0.0' }, '既有依赖版本不得覆盖');
 });
 
 // 变换锚点合成源（必须与 profile-bundle-heal.js 内的锚点字节一致）。

--- a/dsh-desktop/scripts/test/unit-sync-cli.test.js
+++ b/dsh-desktop/scripts/test/unit-sync-cli.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+// sync-companion-plugins.js CLI 的端到端测试（node --test，全部落在隔离临时
+// 目录，绝不触碰真实 ~/.dsh）：
+//   A. 空 DSH_HOME 首次同步：19 个配套包落盘、patch 条目/禁用块/bundle 登记
+//      与共享实现一致；
+//   B. 二次同步零写入（全树 size+mtime 不变）；
+//   C. dry-run 零落盘；
+//   D. --with-patches：对临时伪造的 dsh 包应用两个运行时补丁（闪跳 + 白名单），
+//      二次运行幂等；补丁内容与 main.js 共用同一变换；
+//   E. 用户手写 disabled 条目被尊重（不重复 insert）。
+// 用法：node --test scripts/test/unit-sync-cli.test.js
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const cli = path.join(repoRoot, 'scripts', 'sync-companion-plugins.js');
+const {
+  FLASH_OLD, FLASH_NEW, SETTINGS_NAMESPACES,
+} = require('../lib/runtime-patches');
+const { COMPANION_PLUGINS } = require('../lib/companion-plugins');
+
+function tmpdir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-sync-cli-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function runCli(t, home, extraArgs = []) {
+  // 输出不经过管道（沙箱限制），只断言落盘结果。
+  const res = spawnSync(process.execPath, [cli, home, ...extraArgs], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 300000,
+    stdio: 'ignore',
+    env: { ...process.env, DSH_HOME: '' },
+  });
+  assert.strictEqual(res.status, 0, `CLI 应正常退出（signal=${res.signal}）`);
+}
+
+/** 全树 (relPath -> size:mtimeMs) 快照。 */
+function snapshotTree(root) {
+  const map = new Map();
+  const walk = (d) => {
+    let entries;
+    try { entries = fs.readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) walk(full);
+      else {
+        const st = fs.statSync(full);
+        map.set(path.relative(root, full), st.size + ':' + st.mtimeMs);
+      }
+    }
+  };
+  walk(root);
+  return map;
+}
+
+test('sync CLI: 空 DSH_HOME 首次同步落盘正确（包/条目/禁用块）', (t) => {
+  const home = tmpdir(t);
+  runCli(t, home);
+  const profileDir = path.join(home, 'profiles', 'web');
+  const nm = path.join(profileDir, 'node_modules');
+  // 全部配套包落盘
+  for (const p of COMPANION_PLUGINS) {
+    assert.ok(fs.existsSync(path.join(nm, p.name, 'package.json')), '包应落盘: ' + p.name);
+  }
+  // manifest 不凭空创建（交给 dsh 首次启动初始化）
+  assert.ok(!fs.existsSync(path.join(profileDir, 'package.json')), 'CLI 不得凭空创建 profile manifest');
+  // patch：非 bundle 插件 insert 条目；bundle 插件不写 insert
+  const patch = fs.readFileSync(path.join(profileDir, 'cordis.patch.yml'), 'utf8');
+  for (const p of COMPANION_PLUGINS) {
+    const isBundleDeclared = (() => {
+      const pkgPath = path.join(repoRoot, 'assets', 'plugins', p.name.includes('/') ? p.name.slice(p.name.indexOf('/') + 1) : p.name, 'package.json');
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      return !!(pkg && pkg.dsh && pkg.dsh.bundle && pkg.dsh.bundle.patch);
+    })();
+    if (isBundleDeclared) {
+      assert.ok(!patch.includes(`- insert:\n    - id: ${p.id}\n`), 'bundle 插件不得写 insert: ' + p.id);
+    } else {
+      assert.ok(patch.includes(`- insert:\n    - id: ${p.id}\n      name: '${p.name}'`), '非 bundle 插件应写 insert: ' + p.id);
+    }
+  }
+  // harness-pet 默认禁用块（bundle 校验通过才会写）
+  assert.ok(patch.includes('- id: harness-pet\n  disabled: true'), 'harness-pet 默认禁用块应写入');
+  // billion-context-dsh 缺 dist 构建产物 → 不注册 → 不写 compaction-basic 禁用块
+  const acpOk = fs.existsSync(path.join(repoRoot, 'assets', 'plugins', 'billion-context-dsh', 'dist', 'index.js'));
+  assert.strictEqual(patch.includes('compaction-basic'), acpOk, 'compaction-basic 禁用块只应在 ACP bundle 可装配时写入');
+});
+
+test('sync CLI: 二次同步零写入；dry-run 零落盘', (t) => {
+  const home = tmpdir(t);
+  runCli(t, home);
+  const before = snapshotTree(home);
+  runCli(t, home);
+  const after = snapshotTree(home);
+  assert.deepStrictEqual(after, before, '二次同步必须零写入（全树 size+mtime 逐文件一致）');
+  // dry-run：全新目录零落盘
+  const dryHome = path.join(tmpdir(t), 'dry-home');
+  runCli(t, dryHome, ['--dry-run']);
+  assert.ok(!fs.existsSync(dryHome), 'dry-run 不得创建任何目录');
+});
+
+test('sync CLI: --with-patches 应用闪跳与白名单补丁且幂等', (t) => {
+  const home = tmpdir(t);
+  // 伪造两个官方包的「未打补丁」状态
+  const runtimeFile = path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-client-runtime', 'lib', 'client.js');
+  const exposeFile = path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-host-apiproxy', 'lib', 'index.js');
+  fs.mkdirSync(path.dirname(runtimeFile), { recursive: true });
+  fs.mkdirSync(path.dirname(exposeFile), { recursive: true });
+  fs.writeFileSync(runtimeFile, `const x = ${JSON.stringify('prefix ' + FLASH_OLD + ' suffix')};\n`);
+  fs.writeFileSync(exposeFile, 'const WEB_SETTINGS_NAMESPACES = [\n\t"dsh-prompt"\n];\n');
+  runCli(t, home, ['--with-patches']);
+  const runtime = fs.readFileSync(runtimeFile, 'utf8');
+  assert.ok(runtime.includes(FLASH_NEW) && !runtime.includes(FLASH_OLD), '闪跳修复应落盘');
+  const expose = fs.readFileSync(exposeFile, 'utf8');
+  for (const ns of SETTINGS_NAMESPACES) {
+    assert.ok(expose.includes('"' + ns + '"'), '白名单应包含 ' + ns);
+  }
+  // 幂等：二次运行字节级不变
+  const r1 = fs.readFileSync(runtimeFile);
+  const e1 = fs.readFileSync(exposeFile);
+  runCli(t, home, ['--with-patches']);
+  assert.deepStrictEqual(fs.readFileSync(runtimeFile), r1, '闪跳补丁二次运行不得改写');
+  assert.deepStrictEqual(fs.readFileSync(exposeFile), e1, '白名单补丁二次运行不得改写');
+});
+
+test('sync CLI: 尊重用户手写 disabled 条目，不重复 insert', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(path.join(profileDir, 'cordis.patch.yml'),
+    '# 用户配置\n- id: balance\n  disabled: true\n');
+  runCli(t, home);
+  const patch = fs.readFileSync(path.join(profileDir, 'cordis.patch.yml'), 'utf8');
+  assert.strictEqual((patch.match(/id: balance/g) || []).length, 1, '用户禁用的插件不得再 insert');
+  assert.ok(patch.includes('disabled: true'), '用户禁用条目原样保留');
+  assert.ok(patch.includes('- id: file-changes'), '其它插件照常注册');
+});


### PR DESCRIPTION
## 动机

三部分工作同属「profile 装配与运行时补丁机制」的根因治理，合入同一 PR：

### 1. profile bundle 缺失/损坏导致 dsh web 启动失败的根治（前两个提交，issue #48）

- 启动防护：dsh-app-boot 的 bundle 装配改为逐层跳过（缺失 / 未声明 dsh.bundle / 补丁层损坏均不再 fail-loud 退出），profile manifest 损坏则备份 + 模板重建；dsh/lib/profile-boot-*.js 的家级与 profile 补丁层加载改为「损坏备份 + 重置 + 继续」（覆盖启动与 HMR 热重载）。
- 写盘防呆：同步侧只在「补丁层 + 入口文件」实际落盘后才登记 bundle；manifest 重置后扫描磁盘、恢复用户手动安装的 bundle 登记（dependencies + bundles，issue #48 数据恢复）。
- 健康检查：dsh web 启动前把每个 bundle 的装配状态写入 desktop.log，便于诊断。

### 2. 运行时补丁与配套插件同步机制的重复实现与漂移（第三个提交）

审查发现同一套逻辑存在三份拷贝且已发生漂移：main.js 的 12 个 apply* 各自手写「候选路径 → 读取 → 幂等判定 → 锚点校验 → 写入 → 日志」循环；scripts/sync-companion-plugins.js 再实现一份插件同步与闪跳/白名单补丁（缺「id 已存在跳过」与 bundle 迁移去重、文件同步不比对时间戳）；COMPANION_PLUGINS 清单两处维护（历史漂移：缺 better-sidebar / harness-pet）；原子写与非原子写混用、幂等约定不统一。

根治：新增 scripts/lib/ 统一引擎与单一数据源（patch-io / patch-engine / companion-plugins / runtime-patches / companion-profile），main.js、同步脚本、三个 patch 脚本与 profile-bundle-heal 全部接入，check-syntax 语法门同步纳入新模块。

### 3. 覆盖缺口补齐与质检修正（第四个提交）

- WSL / overlay 覆盖对齐：识图发送 / 识图密钥补丁增加 WSL 分支（与闪跳/白名单补丁同模式）；更新流程 WSL 分支补调 web-search baseURL / menu 视口 / 会话删除三个包级补丁（与 local 更新分支、WSL 启动分支一致）；包级补丁在 WSL 模式追加 WSL agent 直连根；插件页标签合并补丁补齐更新 overlay 与嵌套 dsh 依赖副本。候选路径构造收口为纯函数并新增单测逐项断言。
- 重复定义 / 死代码 / 接口卫生：删除 createWindow 内与模块级重复的 isAllowedWebUrl；移除无调用方的 readFailLog 钩子与无外部消费的导出。
- preload 契约补齐：dshDesktop.appVersion 在 chrome:init 返回后回填（注释声明的契约此前漏实现）；菜单/复制按钮的 IPC 调用补 .catch。
- 元数据：package.json description 修复 GBK 乱码为正确 UTF-8 文案，新增逐字回归测试。

## 兼容性保证

- 所有补丁变换字节级不变；锚点失配仍跳过且绝不损坏文件；
- 日志前缀与文案逐字保持（含集成测试断言的 web-search baseURL 补丁 等前缀）；
- 本地模式候选路径不变；WSL/overlay 仅补齐与既有同模式覆盖一致的路径；
- 同步 CLI 对齐 main.js 的既有语义（尊重用户手写 disabled 条目、bundle 迁移去重、文件同步时间戳比对零写入）；桌面端行为不变。

## 测试（真实 Electron、完全隔离）

- DSH_HOME / userData 全部落在临时目录，绝不触碰真实 ~/.dsh 与运行中的桌面端；
- 新增 scripts/test/unit-patch-engine.test.js（13 项：引擎全分支、字节级变换、候选路径构造器、真实 assets 全量同步幂等零写入、dry-run 零落盘、清单漂移防线）；
- 新增 scripts/test/unit-sync-cli.test.js（4 项：CLI 端到端，含 --with-patches）；
- 新增 scripts/test/unit-meta.test.js（2 项：package.json 文案逐字防线与关键字段完整性）；
- 新增集成场景 runtime-patches-suite（一次真实启动断言 12 个补丁家族全部落盘）；
- check-syntax 通过；15 个单测文件全绿；27 个集成场景全绿（含 8 个 boot-heal 场景）。

验证边界（实事求是）：WSL 分支与 overlay 候选经单测逐项断言 + 真实 Electron 本地启动验证；本机无 WSL 发行版，WSL 目标的 UNC 写穿为既有生产机制（与闪跳/白名单补丁同模式），本 PR 仅对齐覆盖、未新增机制。

## 变更文件

- 新增：dsh-desktop/scripts/lib/（5 个共享模块）、scripts/test/unit-patch-engine.test.js、scripts/test/unit-sync-cli.test.js、scripts/test/unit-meta.test.js、profile-bundle-heal.js、scripts/test/unit-profile-bundle-heal.test.js
- 修改：main.js、preload.js、package.json、profile-bundle-heal.js、scripts/sync-companion-plugins.js、scripts/patch-web-search-baseurl.js、scripts/patch-menu-viewport.js、scripts/patch-session-manage.js、scripts/check-syntax.js、scripts/test/integration-runner.js、electron-builder.yml、CHANGELOG.md