### PR TITLE
fix: profile bundle 装配链根治——启动前对账到「每条登记都可装配」（无效登记移除 + 隔离记录，覆盖入口缺失/重复登记等防护外形状，与主线自愈/诊断互补）

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -3,7 +3,27 @@
 DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行时与 dsh CLI，
 一键启动 Web UI。
 
-
+## [Unreleased]
+### 修复
+- **profile bundle 装配链根治性重构（「declares no dsh.bundle」一类启动失败不再依赖锚点补丁）**：`dsh.profile.bundles` 中任何一条登记不满足 dsh 装配契约（包未安装 / 未声明 `dsh.bundle.patch` / 补丁层缺失或损坏 / 入口文件缺失），官方 `dsh-app-boot` 即 fail-loud 以退出码 1 启动失败。此前唯一防线是启动前对 dsh 构建产物做字符串锚点改写（跳过 + 诊断），锚点随 dsh 版本变化失配即静默失效——用户反馈的 `profile bundle "dsh-hub" declares no dsh.bundle`（纯客户端 bundle 被登记进 profile.bundles）正是该形状，且入口缺失形状（loader 激活期 `plugin tree failed to load`）在防护覆盖范围之外。本次重构把「启动前把 manifest 对账到可装配状态」收口为唯一实现 `scripts/lib/profile-reconcile.js`（main.js 与 `sync-companion-plugins.js` 共用），运行时防护保留为纵深防御：
+  - **全量逐条校验**：每条 bundles 登记按与 dsh 装配契约一一对应的 11 种失败码校验（登记名非法 / 包未安装 / 未声明补丁层 / 补丁层越界·缺失·不可解析 / 入口越界·缺失·指向目录 / client 入口越界·缺失，补丁层用与 dsh 相同的 entry-list YAML 方言解析；client 入口校验与上游 `verifyBundleDir` 新增的 `exports["./client"]` 校验同语义、文案逐字一致，并在对账侧收口为结构化失败码）；无效且非核心的登记**从 manifest 移除**并写入隔离记录 `dsh-desktop.broken-bundles.json`（移除原因 + 时间，重装插件重新登记即恢复，恢复健康后记录自动清除）；核心 bundles（`@deepseek-ai/dsh-base` / `dsh-web-app`）校验失败绝不移除（核心缺失是安装损坏而非数据问题，保留并由启动防护兜底跳过 + 告警）；
+  - **校验实现单一化**：`profile-bundle-heal.js` 提取 `inspectBundleDir` 为唯一结构化校验实现（`verifyBundleDir` 变为兼容包装，文案与契约不变），对账与同步侧防呆共用同一判定语义；
+  - **家级补丁层启动前预检**（`healHomePatch`）：`$DSH_HOME/cordis.patch.yml` 损坏此前只由 profile-boot 锚点补丁兜底，现启动 dsh web 前用同一方言预检，损坏 → 备份 `.broken-<ts>` + 重置为最小合法文件；
+  - **既有语义逐项保留**：损坏 manifest 备份重建（.broken-<ts>）、核心补齐（issue #16）、配套登记追加、源缺失/卸载标记移除、重置后用户 bundle 恢复（issue #48）与全部日志文案不变；健康 manifest 零写入（幂等），写入全部原子化；
+  - **CLI 同步收口**：`sync-companion-plugins.js` 的 manifest 段改用同一对账实现（`initMissing=false` 保持「不凭空创建 manifest」历史契约；损坏 manifest 在核心可解析时同样备份重建，dry-run 输出计划）；
+  - **测试**：新增 `unit-profile-reconcile` 25 项单测（含两个真实 `dsh-app-boot` 复现测试——无效登记在官方 `loadProfile` 下必崩、对账后正常装配）；集成场景 `heal-missing-bundle` / `heal-manifestless-bundle` / `heal-broken-bundle-patch` / `heal-broken-home-patch` 断言更新为「移除 + 隔离记录 + 正常启动」，新增 `heal-entry-missing-bundle`（防护覆盖不到的入口缺失形状）；`check-syntax.js` 纳入新模块。
+- **全量 review 修正（装配对账判定与 dsh 官方契约逐字对齐）**：
+  - **补丁层条目级校验**：dsh 官方 `parsePatchList` 要求补丁层「顶层数组且每项为映射」，原校验只查顶层数组——`- 42` / `- "x"` / `- [1,2]` / `- null` 等畸形文件会被判健康、dsh 装配时仍 fail-loud。`inspectBundleDir`、`healHomePatch` 与 `healProfilePatch` 现共用 `isPatchListValid`（与官方逐字同构）判定；
+  - **包解析与官方同构**：`validateBundleEntry` / 核心可解析判定改用与 `resolveBundleDir` 相同的 `createRequire.resolve.paths` 探测（含 NODE_PATH 与全局 node_modules）——此前 `packageDirUpward` 探测不到 NODE_PATH/全局安装的包，会把官方实际能装配的健康登记误判 UNRESOLVABLE 而误删；
+  - **配套登记与恢复登记复检**：`addNames` 追加与 issue #48 恢复的登记此前只经 `verifyBundleDir`（不查补丁层可解析性），YAML 损坏的配套/恢复 bundle 会留下一个「仅靠运行时防护兜底」的启动窗口；现追加前/恢复后统一过 `validateBundleEntry` 复检，失败 → 不登记/移除 + 隔离记录。
+- **全量 review 第二轮修正（对账语义收口与记录生命周期）**：
+  - **入口文件必须是普通文件**：`inspectBundleDir` 的入口校验由 `existsSync` 升级为 `statSync().isFile()`——入口路径指向目录时（`main: "./lib"` 等形状）存在性检查会放过，而 dsh Loader 用 ESM `import()` 激活入口必然 `ERR_UNSUPPORTED_DIR_IMPORT`（防护覆盖不到的崩溃形状），现判 `ENTRY_MISSING` 并在启动前移除登记；
+  - **策略性移除不进隔离记录**：配套源缺失 / 插件管理「卸载」标记的登记由步骤 4/6 按「用户意图禁用」移除，不再被步骤 2 判 UNRESOLVABLE 写入隔离记录（卸载/源缺失是用户意图而非无效登记，避免记录误导；CLI 同步同步补上 `removedBundles` 与 `excludeFromRecover`，与 main.js 口径完全一致——此前 CLI 不会把已卸载配套从 manifest 移除，且重置恢复可能把用户已卸载的配套重新登记）；
+  - **隔离记录同轮清除**：`addNames` 登记成功与重置恢复成功时，同名历史隔离记录当轮即清除（此前要等下一次启动的步骤 2）；
+  - **记录写入去重**：同 code + reason 的既有隔离条目不重写（保留首次 `removedAt`，持续损坏状态不再每次启动重写记录文件）；`addNames` 校验失败不再对未改动的 manifest 做内容相同的重写；
+  - **健康检查口径统一**：`logProfileBundleHealth` 改用与对账相同的 `resolveBundleDirLike` 双锚点解析，消除「对账判定可解析、健康检查误报缺失」的口径撕裂（诊断只读）；
+  - **重复登记去重**：同一 bundle 名在 `dsh.profile.bundles` 中登记两次时，其补丁层条目会重复出现在组合 entry list 中，loader 装配期抛 `duplicate loader entry id`（fail-loud → 退出码 1），且启动防护覆盖不到（两层都能正常加载）——现对账保留首次出现、移除重复项（冗余而非无效登记，不进隔离记录），该形状此前从不清理；
+  - **测试环境封闭**：`unit-sync-cli` 的 CLI 调用 PATH 收口到 System32——CLI 的 `findDshPackageDir` 会经 PATH 探测 `dsh` 命令，环境 PATH 上的真实 dsh（如 harness 安装）会被当作预设同步目标，把 `assets/agent-presets` 写进真实安装（内容相同、mtime 被改写）；测试必须封闭，绝不触碰真实环境。
 
 ## [0.3.10] — 2026-08-17
 ### 新增

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -41,9 +41,13 @@ const {
 const { installBuiltinPresets } = require('./scripts/install-minimal-win-preset');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
-const { ensureCoreBundles, CORE_BUNDLE_NAMES } = require('./profile-manifest');
+const { CORE_BUNDLE_NAMES } = require('./profile-manifest');
 const { dedupePatchEntries, parseFailedLoaderIds, mapPackagesToPatchIds, findMissingBundleDeclarations, scanBundleContracts, removeBundlesFromProfile } = require('./profile-patch-heal');
-const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, verifyBundleDir, packageDirUpward, scanProfileBundles, recoverManifestBundles, applyAppBootBundleGuard, applyProfileBootBundleGuard, applyProfileBootHealGuard } = require('./profile-bundle-heal');
+const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, verifyBundleDir, isPatchListValid, applyAppBootBundleGuard, applyProfileBootBundleGuard, applyProfileBootHealGuard } = require('./profile-bundle-heal');
+// profile manifest 装配对账（唯一实现）：启动前把 dsh.profile.bundles 对账到
+// 「每条登记都可装配」状态（无效登记移除 + 隔离记录、核心补齐、损坏重建、
+// 重置恢复），配合 profile-bundle-heal 的运行时防护构成双层防线。
+const { reconcileProfileBundles, createEntryListYamlParser, resolveBundleDirLike } = require('./scripts/lib/profile-reconcile');
 // 统一补丁引擎与共享数据源（scripts/lib/）：main.js 的运行时补丁、同步脚本
 // 与 after-pack 共用同一实现，杜绝重复与漂移。
 const { COMPANION_PLUGINS } = require('./scripts/lib/companion-plugins');
@@ -1286,6 +1290,7 @@ async function startServer(unsafePortRetries = 4, overlays = []) {
     serverProc = null;
   }
   healProfilePatch();
+  healHomePatch();
   logProfileBundleHealth();
   if (isWslMode()) {
     // WSL 托管模式：经 wsl.exe 在 WSL 内启动 dsh web（仍 --port 0 由 WSL 内 OS
@@ -3534,24 +3539,15 @@ function profilePatchFile() {
 
 // 原子写统一收口在 scripts/lib/patch-io.js 的 writeFileAtomic（临时文件 + rename）。
 // 惰性加载 js-yaml（随内置 dsh 存在于 resources/app/node_modules，传递依赖）；
-// 缺失时静默降级为仅做结构化修复（不阻断启动）。
+// 缺失时静默降级为仅做结构化修复（不阻断启动）。方言构造与
+// scripts/lib/profile-reconcile.js 的 createEntryListYamlParser 共用同一实现。
 let dshYamlDialect = null;
 let dshYamlTried = false;
 function loadDshYamlDialect() {
   if (dshYamlTried) return dshYamlDialect;
   dshYamlTried = true;
-  try {
-    const yaml = require('js-yaml');
-    // 与 dsh 相同的 entry-list 方言：`!!js` 表达式是合法标量。
-    const jsType = new yaml.Type('tag:yaml.org,2002:js', {
-      kind: 'scalar',
-      resolve: (data) => typeof data === 'string',
-      construct: (data) => ({ __jsExpr: data }),
-    });
-    dshYamlDialect = { load: (content) => yaml.load(content, { schema: yaml.JSON_SCHEMA.extend(jsType) }) };
-  } catch {
-    dshYamlDialect = null;
-  }
+  const parse = createEntryListYamlParser();
+  dshYamlDialect = parse ? { load: (content) => parse(content) } : null;
   return dshYamlDialect;
 }
 
@@ -3625,7 +3621,8 @@ function healProfilePatch() {
     let parsed;
     let error = null;
     try { parsed = yaml.load(text); } catch (err) { error = err; }
-    if (!error && Array.isArray(parsed)) {
+    // 合法判定与 dsh-app-boot parsePatchList 同构：顶层数组且每项为映射。
+    if (!error && isPatchListValid(parsed)) {
       // issue #17 存量自愈：注册行级去重（PR #24 v2）。重复注册（旧版本
       // 插件安装写入的第二个同 id insert 条目）会让 cordis loader 抛
       // "duplicate loader entry id: X"，且该状态永远无法自愈；只删重复
@@ -3639,11 +3636,13 @@ function healProfilePatch() {
         text = dedupe.text;
       }
     }
-    if (error || !Array.isArray(parsed)) {
+    if (error || !isPatchListValid(parsed)) {
       const backup = file + '.broken-' + Date.now();
       try { fs.renameSync(file, backup); } catch { fs.copyFileSync(file, backup); }
       fs.writeFileSync(file, '# recovered by DSH Desktop: 原内容无法解析，已备份到\n# ' + backup + '\n[]\n', 'utf8');
-      log('boot', 'profile patch 自愈: 解析失败（' + String((error && error.message) || '顶层非数组') + '），已备份到 ' + backup + ' 并重置为最小文件');
+      const cause = error ? String((error && error.message) || error)
+        : (Array.isArray(parsed) ? '条目不是映射（顶层数组每项须为映射）' : '顶层非数组');
+      log('boot', 'profile patch 自愈: 解析失败（' + cause + '），已备份到 ' + backup + ' 并重置为最小文件');
     }
     // 完整自愈流程已跑完（含 yaml 解析）：记录当前内容签名，下次启动命中跳过。
     const after = patchFileSignature(file);
@@ -3655,31 +3654,59 @@ function healProfilePatch() {
     log('boot', 'profile patch 自愈失败: ' + err.message);
   }
 }
-/**
- * 在「实际将运行的 dsh 包」（内置或用户目录 overlay）中解析核心 bundles，
- * 只返回真实可解析的模板名；解析不到的名字绝不写入，避免与真正启动的
- * dsh 版本漂移后写入无效 bundle 名。
- */
-function resolvableCoreBundles() {
-  const installAnchor = path.dirname(dshPackageJson());
-  return CORE_BUNDLE_NAMES.filter((name) => {
-    try {
-      require.resolve(name + '/package.json', { paths: [installAnchor] });
-      return true;
-    } catch {
-      return false; // 该 dsh 安装中缺失，交由 dsh 初始化
+
+// ---------------------------------------------------------------------------
+// 家级补丁层预检（$DSH_HOME/cordis.patch.yml）：dsh 官方 composeProfile 对
+// 该文件 fail-loud（"failed to parse patches" → dsh web 退出码 1），此前只由
+// dsh profile-boot 的运行时防护（锚点改写）兜底。这里在启动前用与 dsh 相同
+// 的 entry-list 方言预检：损坏 → 备份 .broken-<ts> + 重置为最小合法文件
+// （与 healProfilePatch 同款语义，原文永不丢弃）。健康文件零写入（幂等，
+// 进程内签名 memo，避免重复解析）。
+// ---------------------------------------------------------------------------
+let homePatchHealMemo = null; // { file, size, mtimeMs }
+
+function healHomePatch() {
+  try {
+    const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
+    const file = path.join(home, 'cordis.patch.yml');
+    if (!fs.existsSync(file)) return;
+    const sig = patchFileSignature(file);
+    if (sig && homePatchHealMemo && homePatchHealMemo.file === file &&
+        homePatchHealMemo.size === sig.size && homePatchHealMemo.mtimeMs === sig.mtimeMs) {
+      return;
     }
-  });
+    const yaml = loadDshYamlDialect();
+    if (!yaml) return; // 无 yaml 依赖：跳过解析（运行时防护兜底）
+    let parsed = null;
+    let error = null;
+    try { parsed = yaml.load(fs.readFileSync(file, 'utf8')); } catch (err) { error = err; }
+    // 合法判定与 dsh-app-boot parsePatchList 同构：顶层数组且每项为映射
+    // （只查 Array.isArray 会放过「条目是标量/字符串/嵌套数组/null」的畸形
+    // 文件，composeProfile 仍会 fail-loud）。
+    if (!error && isPatchListValid(parsed)) {
+      homePatchHealMemo = { file, size: sig.size, mtimeMs: sig.mtimeMs };
+      return;
+    }
+    const backup = file + '.broken-' + Date.now();
+    try { fs.renameSync(file, backup); } catch { fs.copyFileSync(file, backup); }
+    fs.writeFileSync(file, '# recovered by DSH Desktop: 原内容无法解析，已备份到\n# ' + backup + '\n[]\n', 'utf8');
+    const cause = error ? String((error && error.message) || error)
+      : (Array.isArray(parsed) ? '条目不是映射（顶层数组每项须为映射）' : '顶层非数组');
+    log('boot', '家级补丁层自愈: 解析失败（' + cause + '），已备份到 ' + backup + ' 并重置为最小文件');
+    const after = patchFileSignature(file);
+    if (after) homePatchHealMemo = { file, size: after.size, mtimeMs: after.mtimeMs };
+  } catch (err) {
+    log('boot', '家级补丁层自愈失败: ' + err.message);
+  }
 }
 
 // 目录级同步（dirNeedsSync + syncDir）收口在 scripts/lib/companion-profile.js，
 // 由 syncCompanionFiles 使用；本文件不再维护副本。
 
 // ---------------------------------------------------------------------------
-// profile bundle 健康检查（只读）：dsh web 启动前把每个 bundles 条目的装配
-// 状态落到 desktop.log —— 缺失 / 未声明 dsh.bundle.patch / 补丁层缺失都会让
-// 该层被启动防护跳过，这里让诊断在壳日志里可见（dsh-web.log 的 stderr 告警
-// 保留完整细节）。不修改任何文件。
+// profile bundle 健康检查（只读）：启动对账（reconcileProfileBundles）已把
+// 无效的非核心登记从 manifest 移除，这里把对账后仍存在的异常条目（核心
+// bundle 缺失 / 损坏等，启动防护兜底跳过）落到 desktop.log。不修改任何文件。
 // ---------------------------------------------------------------------------
 function logProfileBundleHealth() {
   try {
@@ -3696,13 +3723,17 @@ function logProfileBundleHealth() {
     const installAnchor = path.dirname(dshPackageJson());
     for (const name of bundles) {
       if (typeof name !== 'string' || name === '') continue;
-      const dir = packageDirUpward(installAnchor, name) || packageDirUpward(profileDir, name);
+      // 与对账（reconcileProfileBundles）同一解析实现（createRequire.resolve.paths
+      // 双锚点，含 NODE_PATH / 全局 node_modules）：诊断口径与对账判定一致，
+      // 避免「对账判定可解析、健康检查误报缺失」的口径撕裂。
+      const dir = resolveBundleDirLike(path.join(installAnchor, 'package.json'), name)
+        || resolveBundleDirLike(path.join(profileDir, 'package.json'), name);
       if (!dir) {
-        log('boot', 'profile bundle 缺失（该层将被启动防护跳过）: ' + name + ' —— 用 dsh plugin --profile web install 可修复');
+        log('boot', 'profile bundle 缺失（对账后仍存在，启动防护兜底跳过）: ' + name + ' —— 用 dsh plugin --profile web install 可修复');
         continue;
       }
       const check = verifyBundleDir(dir);
-      if (!check.ok) log('boot', 'profile bundle 不可用（该层将被启动防护跳过）: ' + name + ' —— ' + check.reason);
+      if (!check.ok) log('boot', 'profile bundle 不可用（对账后仍存在，启动防护兜底跳过）: ' + name + ' —— ' + check.reason);
     }
   } catch (err) {
     log('boot', 'profile bundle 健康检查失败: ' + err.message);
@@ -3790,106 +3821,27 @@ function syncCompanionPlugins() {
       }
     }
 
-    const manifestFile = path.join(profileDir, 'package.json');
-    let manifest = null;
-    let manifestReset = false; // 解析失败或顶层非法触发的重置（issue #48 数据恢复标记）
-    try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch { manifestReset = true; }
-    if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
-      manifestReset = true;
-      // manifest 损坏：先备份原文件再重置（不可解析时原文是唯一现场），绝不
-      // 静默丢弃用户数据。全新 profile 没有文件，不产生备份。
-      if (fs.existsSync(manifestFile)) {
-        const backup = manifestFile + '.broken-' + Date.now();
-        try {
-          fs.copyFileSync(manifestFile, backup);
-          log('boot', 'profile manifest 损坏，原文件已备份到 ' + backup);
-        } catch (err) {
-          log('boot', 'profile manifest 备份失败: ' + err.message);
-        }
-      }
-      manifest = { name: 'dsh-profile-web', private: true };
-    }
-    if (!manifest.dsh || typeof manifest.dsh !== 'object') manifest.dsh = {};
-    if (!manifest.dsh.profile || typeof manifest.dsh.profile !== 'object') manifest.dsh.profile = {};
-    // 全新 profile（dsh 尚未初始化）时 manifest 不存在、也没有 bundles。
-    // 此时壳层不能凭空新建只含自己 bundle 的 manifest：那会顶替 dsh 的
-    // 初始化，profile 里没有提供核心服务的插件，插件树无法激活，
-    // 全新 DSH_HOME 首次启动必然失败。
-    // 处理：核心 bundles 必须在安装中实测可解析（与 dsh-app-boot 的
-    // PROFILE_TEMPLATES.web 同名）才写入；解析不到（模板未来改名）则不写
-    // manifest，交由 dsh 自行初始化，bundle 插件留待下一次启动注册。
-    let bundlesUsable = Array.isArray(manifest.dsh.profile.bundles);
-    if (!bundlesUsable) {
-      const coreBundles = resolvableCoreBundles();
-      if (coreBundles.length === CORE_BUNDLE_NAMES.length) {
-        manifest.dsh.profile.bundles = coreBundles;
-        bundlesUsable = true;
-      } else {
-        log('boot', 'dsh 出厂核心 bundles 未在安装中解析到，跳过 manifest 预写，交由 dsh 初始化');
-      }
-    } else {
-      // issue #16 存量自愈：旧版本（0.3.3/0.3.4，#13 的 bug 场景）写坏的
-      // manifest 里 bundles 只有配套 bundle、缺少核心 bundles。dsh 启动时
-      // 核心服务（webServer/subprocess/settings/llm 等）无人提供，插件树
-      // 无法激活（N entries did not activate），且该状态永远无法自愈。
-      // 这里把缺失且可解析的核心 bundles 补到列表最前（保持与模板一致的
-      // 先后顺序），其余条目（含用户自行添加的）原样保留；健康 manifest
-      // 零写入（幂等）。写入用原子写，避免与 dsh 的观察者撕裂读。
-      const healed = ensureCoreBundles(manifest.dsh.profile.bundles, resolvableCoreBundles());
-      if (healed) {
-        manifest.dsh.profile.bundles = healed.next;
-        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-        log('boot', 'profile manifest 自愈: 旧版本写坏的 bundles 缺少核心 ' + healed.added.join(', ') + '，已补齐到最前');
-      }
-    }
-    for (const name of bundleNames) {
-      if (!bundlesUsable) break;
-      if (!manifest.dsh.profile.bundles.includes(name)) {
-        manifest.dsh.profile.bundles.push(name);
-        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-        log('boot', '已把 bundle 插件加入 web profile bundles: ' + name);
-      }
-    }
-    // 存量 bundle 源缺失 → 视为用户禁用：从 bundles 移除（幂等），否则 dsh
-    // 启动仍会因 manifest 登记了不存在的包而失败。只动配套插件名，用户自行
-    // 添加的第三方 bundle 与核心 bundles 不受影响。
-    if (missingSourceNames.size > 0 && Array.isArray(manifest.dsh.profile.bundles)) {
-      const before = manifest.dsh.profile.bundles.length;
-      manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((n) => !missingSourceNames.has(n));
-      if (manifest.dsh.profile.bundles.length !== before) {
-        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-        log('boot', '配套 bundle 源缺失，已从 web profile bundles 移除（视为禁用）: ' + [...missingSourceNames].join(', '));
-      }
-    }
-    // issue #48 数据恢复：manifest 重置分支会丢掉用户手动安装的第三方 bundle
-    // 登记（dependencies + bundles 条目）。这些包仍实际落在 profile node_modules
-    // 里，扫描并校验后合并回 manifest，用户插件在自愈后照常装配，无需手工恢复
-    // 备份。只动重置分支；正常启动时既有登记零改动（幂等）。
-    if (manifestReset && bundlesUsable && Array.isArray(manifest.dsh.profile.bundles)) {
-      const recovered = recoverManifestBundles(manifest, scanProfileBundles(
-        path.join(profileDir, 'node_modules'),
-        new Set([...CORE_BUNDLE_NAMES, ...COMPANION_PLUGINS.map((p) => p.name)]),
-      ));
-      if (recovered.length > 0) {
-        writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-        log('boot', 'profile manifest 重置后已恢复用户安装的 bundle 插件: ' + recovered.join(', '));
-      } else {
-        log('boot', 'profile manifest 已重置（原文件已备份），未发现需要恢复的用户 bundle');
-      }
-      notifyManifestResetRecovered(recovered);
-    }
-    // 插件管理「卸载」标记的 bundle 配套：从 manifest bundles 移除（否则 loader
-    // 仍会装配已卸载的 bundle）。
-    if (removedIds.size > 0 && Array.isArray(manifest.dsh.profile.bundles)) {
-      const removedBundles = COMPANION_PLUGINS.filter((p) => removedIds.has(p.id)).map((p) => p.name);
-      if (removedBundles.length > 0) {
-        const before = manifest.dsh.profile.bundles.length;
-        manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((n) => !removedBundles.includes(n));
-        if (manifest.dsh.profile.bundles.length !== before) {
-          writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-          log('boot', '已卸载 bundle 插件，从 web profile bundles 移除: ' + removedBundles.join(', '));
-        }
-      }
+    // profile manifest 装配对账（收口在 scripts/lib/profile-reconcile.js 唯一
+    // 实现，main.js 与 sync-companion-plugins.js 共用）：损坏备份重建、核心
+    // 补齐、全量逐条校验（无效且非核心的登记移除并记入隔离记录
+    // dsh-desktop.broken-bundles.json）、配套登记追加、源缺失/卸载标记移除、
+    // 重置后用户 bundle 恢复（issue #48）。全部原子写，健康 manifest 零写入
+    // （幂等）。parsePatch 注入与 dsh 相同的 entry-list 方言（js-yaml 缺失时
+    // 降级为不检查补丁层可解析性，运行时防护兜底）。
+    const removedBundles = COMPANION_PLUGINS.filter((p) => removedIds.has(p.id)).map((p) => p.name);
+    const reconciled = reconcileProfileBundles(profileDir, {
+      installAnchorDir: path.dirname(dshPackageJson()),
+      coreNames: CORE_BUNDLE_NAMES,
+      addNames: bundleNames,
+      missingNames: missingSourceNames,
+      removedBundles: new Set(removedBundles),
+      excludeFromRecover: new Set([...CORE_BUNDLE_NAMES, ...COMPANION_PLUGINS.map((p) => p.name)]),
+      parsePatch: loadDshYamlDialect(),
+      log: (m) => log('boot', m),
+    });
+    if (reconciled.reset && reconciled.manifest &&
+        Array.isArray(reconciled.manifest.dsh && reconciled.manifest.dsh.profile && reconciled.manifest.dsh.profile.bundles)) {
+      notifyManifestResetRecovered(reconciled.recovered);
     }
 
     // 非 bundle 插件注册到 profile 的 patch 层（幂等）。bundle 迁移自愈

--- a/dsh-desktop/profile-bundle-heal.js
+++ b/dsh-desktop/profile-bundle-heal.js
@@ -66,30 +66,106 @@ function bundleEntryOf(pkg) {
 // ---------------------------------------------------------------------------
 
 /**
- * 校验一个已落盘的 bundle 目录：package.json 可解析、声明了 dsh.bundle.patch、
- * 补丁层与入口文件都存在；声明了 exports["./client"] 时 client bundle 入口也
- * 必须存在。任一不满足返回 { ok:false, reason } —— 同步方必须按「源缺失」处理
- * （不注册为 profile bundle），否则 dsh 启动时必然崩溃。
+ * 结构化校验失败码（inspectBundleDir 与 scripts/lib/profile-reconcile.js 的
+ * validateBundleEntry 共用；中文 reason 保持与 verifyBundleDir 既有文案逐字
+ * 一致——含上游新增的 client bundle 入口校验文案，历史调用方与单测断言不受
+ * 影响）。
  */
-function verifyBundleDir(dir) {
+const BUNDLE_CHECK_CODES = {
+  /** 登记项不是非空字符串（validateBundleEntry 前置判定）。 */
+  INVALID_NAME: 'INVALID_NAME',
+  /** 双锚点（dsh 安装 / profile node_modules）均解析不到包（validateBundleEntry）。 */
+  UNRESOLVABLE: 'UNRESOLVABLE',
+  /** package.json 不可读 / 不是合法 JSON。 */
+  PACKAGE_JSON_INVALID: 'PACKAGE_JSON_INVALID',
+  /** package.json 未声明 dsh.bundle.patch（普通库或仅客户端 bundle）。 */
+  NO_BUNDLE_DECL: 'NO_BUNDLE_DECL',
+  /** 补丁层相对路径越出包目录。 */
+  PATCH_OUTSIDE: 'PATCH_OUTSIDE',
+  /** 补丁层文件不存在。 */
+  PATCH_MISSING: 'PATCH_MISSING',
+  /** 补丁层存在但无法按 dsh entry-list 方言解析（或顶层非数组）。 */
+  PATCH_UNPARSEABLE: 'PATCH_UNPARSEABLE',
+  /** 入口文件相对路径越出包目录。 */
+  ENTRY_OUTSIDE: 'ENTRY_OUTSIDE',
+  /** 入口文件不存在。 */
+  ENTRY_MISSING: 'ENTRY_MISSING',
+  /** client bundle 入口（exports["./client"]）相对路径越出包目录。 */
+  CLIENT_ENTRY_OUTSIDE: 'CLIENT_ENTRY_OUTSIDE',
+  /** client bundle 入口（exports["./client"]）文件不存在。 */
+  CLIENT_ENTRY_MISSING: 'CLIENT_ENTRY_MISSING',
+};
+
+/**
+ * 判定一次 entry-list YAML 解析结果是否满足 dsh 的补丁层契约
+ * （dsh-app-boot parsePatchList）：顶层必须是数组，且每个条目必须是映射
+ * （非 null 对象、非数组）。与官方判定逐字同构——只检查 Array.isArray 会
+ * 放过「顶层数组但条目是标量/字符串/嵌套数组/null」的畸形文件，dsh 装配时
+ * 仍会 fail-loud（"must be a mapping"）。inspectBundleDir 与 main.js 的
+ * healHomePatch 共用本判定。
+ * @param {unknown} parsed entry-list YAML 解析结果
+ * @returns {boolean} 满足 dsh 补丁层契约时为 true
+ */
+function isPatchListValid(parsed) {
+  if (!Array.isArray(parsed)) return false;
+  return parsed.every((entry) => typeof entry === 'object' && entry !== null && !Array.isArray(entry));
+}
+
+/**
+ * 结构化校验一个已落盘的 bundle 目录（唯一实现）：package.json 可解析、
+ * 声明了 dsh.bundle.patch、补丁层存在且（提供解析器时）可解析、入口文件
+ * 存在；声明了 exports["./client"] 时 client bundle 入口也必须存在。任一
+ * 不满足返回 { ok:false, code, reason } —— 同步方必须按「源缺失」处理
+ * （不注册为 profile bundle），否则 dsh 启动时必然崩溃。verifyBundleDir
+ * 与本仓库 scripts/lib/profile-reconcile.js 的 validateBundleEntry 共用本函数，
+ * 保证各调用方的判定语义一致。
+ * @param {string} dir bundle 包目录（绝对路径）
+ * @param {(content: string) => unknown} [parsePatch] dsh entry-list 方言解析器；
+ *   提供时补丁层必须可解析且为合法 entry-list（顶层数组 + 每项为映射，与
+ *   dsh-app-boot parsePatchList 的契约一致）；null 跳过该检查（调用方无 yaml
+ *   依赖时的降级，与 healProfilePatch 的既有降级语义一致）。
+ * @returns {{ ok: boolean, code: string, reason: string, patchPath?: string }}
+ */
+function inspectBundleDir(dir, parsePatch) {
   let pkg = null;
   try {
     pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
   } catch (err) {
-    return { ok: false, reason: 'package.json 不可读或不是合法 JSON: ' + ((err && err.message) || err) };
+    return { ok: false, code: BUNDLE_CHECK_CODES.PACKAGE_JSON_INVALID, reason: 'package.json 不可读或不是合法 JSON: ' + ((err && err.message) || err) };
   }
   const patchRel = bundlePatchRel(pkg);
-  if (!patchRel) return { ok: false, reason: 'package.json 未声明 dsh.bundle.patch' };
+  if (!patchRel) return { ok: false, code: BUNDLE_CHECK_CODES.NO_BUNDLE_DECL, reason: 'package.json 未声明 dsh.bundle.patch' };
   // 路径归一化围栏：补丁层必须仍落在 bundle 目录内（防 `../../x` 越界读取）。
   const patchFile = path.resolve(dir, patchRel);
   const dirRoot = path.resolve(dir) + path.sep;
-  if (!patchFile.startsWith(dirRoot)) return { ok: false, reason: '补丁层路径越界: ' + patchRel };
-  if (!fs.existsSync(patchFile)) return { ok: false, reason: '补丁层缺失: ' + patchRel };
+  if (!patchFile.startsWith(dirRoot)) return { ok: false, code: BUNDLE_CHECK_CODES.PATCH_OUTSIDE, reason: '补丁层路径越界: ' + patchRel };
+  if (!fs.existsSync(patchFile)) return { ok: false, code: BUNDLE_CHECK_CODES.PATCH_MISSING, reason: '补丁层缺失: ' + patchRel };
+  if (typeof parsePatch === 'function') {
+    try {
+      const parsed = parsePatch(fs.readFileSync(patchFile, 'utf8'));
+      if (!Array.isArray(parsed)) {
+        return { ok: false, code: BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE, reason: '补丁层不是顶层 YAML 数组: ' + patchRel };
+      }
+      if (!parsed.every((entry) => typeof entry === 'object' && entry !== null && !Array.isArray(entry))) {
+        return { ok: false, code: BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE, reason: '补丁层条目不是映射（dsh 要求顶层数组每项为映射）: ' + patchRel };
+      }
+    } catch (err) {
+      return { ok: false, code: BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE, reason: '补丁层无法解析: ' + patchRel + '（' + ((err && err.message) || err) + '）' };
+    }
+  }
   const entry = bundleEntryOf(pkg);
   if (entry) {
     const entryFile = path.resolve(dir, entry);
-    if (!entryFile.startsWith(dirRoot)) return { ok: false, reason: '入口文件路径越界: ' + entry };
-    if (!fs.existsSync(entryFile)) return { ok: false, reason: '入口文件缺失: ' + entry };
+    if (!entryFile.startsWith(dirRoot)) return { ok: false, code: BUNDLE_CHECK_CODES.ENTRY_OUTSIDE, reason: '入口文件路径越界: ' + entry };
+    if (!fs.existsSync(entryFile)) return { ok: false, code: BUNDLE_CHECK_CODES.ENTRY_MISSING, reason: '入口文件缺失: ' + entry };
+    // 入口必须是普通文件（符号链接经 statSync 跟随解析）：dsh Loader 用 ESM
+    // import() 激活入口，指向目录的 main/exports 会在激活期抛
+    // ERR_UNSUPPORTED_DIR_IMPORT（防护覆盖不到的崩溃形状），存在性检查会放过。
+    let entryStat = null;
+    try { entryStat = fs.statSync(entryFile); } catch { /* 不可读按缺失处理 */ }
+    if (!entryStat || !entryStat.isFile()) {
+      return { ok: false, code: BUNDLE_CHECK_CODES.ENTRY_MISSING, reason: '入口文件缺失或不是普通文件: ' + entry };
+    }
   }
   // client bundle 入口（exports["./client"] 字符串声明）：client-modules 装配时
   // 按该路径读取客户端 bundle，缺失会让整个 client 模块注册 fail-loud
@@ -99,10 +175,21 @@ function verifyBundleDir(dir) {
     && typeof pkg.exports['./client'] === 'string' ? pkg.exports['./client'] : '';
   if (clientRel) {
     const clientFile = path.resolve(dir, clientRel);
-    if (!clientFile.startsWith(dirRoot)) return { ok: false, reason: 'client 入口路径越界: ' + clientRel };
-    if (!fs.existsSync(clientFile)) return { ok: false, reason: 'client 入口缺失: ' + clientRel };
+    if (!clientFile.startsWith(dirRoot)) return { ok: false, code: BUNDLE_CHECK_CODES.CLIENT_ENTRY_OUTSIDE, reason: 'client 入口路径越界: ' + clientRel };
+    if (!fs.existsSync(clientFile)) return { ok: false, code: BUNDLE_CHECK_CODES.CLIENT_ENTRY_MISSING, reason: 'client 入口缺失: ' + clientRel };
   }
-  return { ok: true, reason: '' };
+  return { ok: true, code: '', reason: '', patchPath: patchFile };
+}
+
+/**
+ * 校验一个已落盘的 bundle 目录（兼容包装）：package.json 可解析、声明了
+ * dsh.bundle.patch、补丁层与入口文件都存在；声明了 exports["./client"] 时
+ * client bundle 入口也必须存在。任一不满足返回 { ok:false, reason }。
+ * 判定语义与文案委托给 inspectBundleDir（不检查补丁层可解析性，历史契约）。
+ */
+function verifyBundleDir(dir) {
+  const check = inspectBundleDir(dir, null);
+  return { ok: check.ok, reason: check.reason };
 }
 
 /**
@@ -396,8 +483,11 @@ function applyProfileBootBundleGuard(src) {
 module.exports = {
   PROFILE_BUNDLE_GUARD_MARKER,
   PROFILE_BOOT_GUARD_MARKER,
+  BUNDLE_CHECK_CODES,
   bundlePatchRel,
   bundleEntryOf,
+  inspectBundleDir,
+  isPatchListValid,
   verifyBundleDir,
   packageDirUpward,
   scanProfileBundles,

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -32,6 +32,7 @@ const entryFiles = [
   'scripts/lib/companion-plugins.js',
   'scripts/lib/runtime-patches.js',
   'scripts/lib/companion-profile.js',
+  'scripts/lib/profile-reconcile.js',
   'scripts/lib/versions.js',
   'scripts/patch-web-search-baseurl.js',
   'scripts/patch-menu-viewport.js',

--- a/dsh-desktop/scripts/lib/profile-reconcile.js
+++ b/dsh-desktop/scripts/lib/profile-reconcile.js
@@ -1,0 +1,587 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// profile manifest 装配对账（唯一实现）。
+//
+// 背景：dsh 官方对 `dsh.profile.bundles` 采用 fail-loud 启动语义——任何一条
+// 登记不满足装配契约（包可解析、声明 dsh.bundle.patch、补丁层存在且可解析、
+// 入口文件存在），`dsh web` 即以退出码 1 启动失败。历史上有多个写入方
+// （壳层同步、dsh-hub 的 reconcileBundles、zat-dsh-engine 插件市场、用户
+// `dsh plugin` 命令、手改文件）都可能留下无效登记，且旧版本从未清理它们。
+// 过去的唯一防线是启动前对 dsh-app-boot 构建产物做字符串锚点改写（跳过 +
+// 诊断），锚点随 dsh 版本变化失配即静默失效，原始崩溃直接暴露——这也是
+// 「每次以不同方式复现」的根因。
+//
+// 本模块把「启动前把 manifest 对账到可装配状态」收口为唯一实现：
+//   · 损坏 manifest 备份后重建（.broken-<ts>，原文永不丢弃）；
+//   · 逐条校验全部 bundles 登记——无效且非核心的登记从 manifest 移除，
+//     移除事实与原因写入隔离记录文件 dsh-desktop.broken-bundles.json
+//     （dsh 完全不感知该文件；重装插件后重新登记即可恢复，健康后记录
+//     自动清除）；
+//   · 核心 bundles（@deepseek-ai/dsh-base / dsh-web-app）绝不因校验失败
+//     被移除——核心缺失是 dsh 安装损坏，不是 profile 数据问题，移除只会
+//     让插件树更糟，交由启动防护兜底跳过并告警；
+//   · 缺失核心补齐、配套 bundle 登记追加、源缺失/卸载标记移除、重置后
+//     用户 bundle 恢复（issue #48）等既有语义原样保留；
+//   · 全部写入原子化（writeFileAtomic），健康 manifest 零写入（幂等）。
+//
+// 对账执行时机：壳层每次启动（main.js syncCompanionPlugins）与
+// sync-companion-plugins.js（WSL/Linux CLI）共用本实现；dryRun 只计算
+// 不落盘。dsh-app-boot 的运行时防护（profile-bundle-heal.js 的锚点改写）
+// 保留为纵深防御，覆盖对账未跑 / 对账后仍出现的未知损坏形状。
+//
+// 本模块不依赖 Electron；js-yaml 经 parsePatch 回调注入（调用方无该依赖时
+// 传 null，仅跳过补丁层可解析性检查）。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { createRequire } = require('node:module');
+
+const {
+  BUNDLE_CHECK_CODES,
+  inspectBundleDir,
+  scanProfileBundles,
+  recoverManifestBundles,
+  writeFileAtomic,
+} = require('../../profile-bundle-heal');
+const { ensureCoreBundles, CORE_BUNDLE_NAMES } = require('../../profile-manifest');
+
+/** 无效登记隔离记录文件名（位于 profile 目录内，dsh 不读取）。 */
+const BROKEN_BUNDLES_RECORD_FILENAME = 'dsh-desktop.broken-bundles.json';
+/** 隔离记录结构版本。 */
+const BROKEN_BUNDLES_RECORD_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// 隔离记录（sidecar）读写
+// ---------------------------------------------------------------------------
+
+/**
+ * 读取无效登记隔离记录；文件缺失 / 损坏时返回 null（调用方按无记录处理，
+ * 写入侧会重建）。记录结构：
+ *   { v: 1, entries: { [packageName]: { code, reason, removedAt } } }
+ * @param {string} file 记录文件路径
+ * @returns {Object|null}
+ */
+function readBrokenBundlesRecord(file) {
+  let raw;
+  try { raw = fs.readFileSync(file, 'utf8'); } catch { return null; }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.v === BROKEN_BUNDLES_RECORD_VERSION &&
+        parsed.entries && typeof parsed.entries === 'object' && !Array.isArray(parsed.entries)) {
+      return parsed;
+    }
+  } catch { /* 结构不符按缺失处理 */ }
+  return null;
+}
+
+/**
+ * 原子写隔离记录（写入失败仅告警，不影响对账结果——记录是诊断辅助）。
+ * @param {string} file 记录文件路径
+ * @param {Object} record 记录对象
+ * @param {(msg: string) => void} [log]
+ */
+function writeBrokenBundlesRecord(file, record, log) {
+  try {
+    writeFileAtomic(file, JSON.stringify(record, null, 2) + '\n');
+  } catch (err) {
+    if (log) log('写入无效登记隔离记录失败: ' + ((err && err.message) || err));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// entry-list YAML 方言解析器（弱依赖 js-yaml）
+// ---------------------------------------------------------------------------
+
+/**
+ * 构造与 dsh-app-boot 相同的 entry-list 方言解析器（js-yaml JSON_SCHEMA +
+ * `!!js` 标量，dsh 用它解析补丁层与 patch 文件）。js-yaml 不可用（CLI 独立
+ * 环境等）时返回 null，调用方跳过补丁层可解析性检查（运行时防护兜底）。
+ * @returns {(content: string) => unknown}|null
+ */
+function createEntryListYamlParser() {
+  try {
+    // 与 main.js loadDshYamlDialect 同一构造；js-yaml 是内置 dsh 的传递依赖。
+    // eslint-disable-next-line global-require
+    const yaml = require('js-yaml');
+    const jsType = new yaml.Type('tag:yaml.org,2002:js', {
+      kind: 'scalar',
+      resolve: (data) => typeof data === 'string',
+      construct: (data) => ({ __jsExpr: data }),
+    });
+    return (content) => yaml.load(content, { schema: yaml.JSON_SCHEMA.extend(jsType) });
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 单条登记校验
+// ---------------------------------------------------------------------------
+
+/**
+ * 与 dsh-app-boot resolveBundleDir 同构的包目录解析：沿 Node 的
+ * createRequire(anchorFile).resolve.paths 搜索路径探测 package.json（含
+ * NODE_PATH 与全局 node_modules，与官方 packageDirFromAnchor 逐字同构）。
+ * 与 packageDirUpward（只走祖先 node_modules 链）的区别正是「对账判定必须
+ * 与 dsh 实际装配一致」的关键：官方能解析到的登记，对账绝不能判 UNRESOLVABLE
+ * 而误删。找不到返回 ''。
+ * @param {string} anchorFile 锚点文件（dsh 安装 / profile 的 package.json 路径）
+ * @param {string} packageName 登记名
+ * @returns {string} 包目录绝对路径；找不到返回空串
+ */
+function resolveBundleDirLike(anchorFile, packageName) {
+  let paths;
+  try {
+    paths = createRequire(anchorFile).resolve.paths(packageName) || [];
+  } catch {
+    return '';
+  }
+  for (const searchPath of paths) {
+    const candidate = path.join(searchPath, packageName);
+    try {
+      if (fs.existsSync(path.join(candidate, 'package.json'))) return candidate;
+    } catch { /* 不可读按未找到继续 */ }
+  }
+  return '';
+}
+
+/**
+ * 判定核心 bundles 是否全部可解析（决定能否安全预写 / 重建 manifest）。
+ * 与 validateBundleEntry 共用同一解析实现（resolveBundleDirLike，含 NODE_PATH
+ * / 全局 node_modules）——核心解析判定与登记校验必须一致，否则会出现
+ * 「登记校验判可解析、预写判定判不可解析」的判定撕裂。installAnchorDir 为空
+ * （CLI 未定位到 dsh 包等）时核心一律视为不可解析，绝不依据进程 cwd 的相对
+ * 探测写入。
+ * @param {string[]} coreNames 核心 bundle 名
+ * @param {string} installAnchorDir dsh 包目录（可空）
+ * @returns {string[]} 实测可解析的核心名
+ */
+function resolvableCoreNames(coreNames, installAnchorDir) {
+  if (!installAnchorDir) return [];
+  return coreNames.filter((name) => resolveBundleDirLike(path.join(installAnchorDir, 'package.json'), name) !== '');
+}
+
+/**
+ * 校验一条 profile bundle 登记（与 dsh-app-boot 的装配契约一一对应）：
+ *   INVALID_NAME      登记项不是非空字符串；
+ *   UNRESOLVABLE      双锚点（dsh 安装 / profile node_modules）都解析不到包；
+ *   其余码               委托 inspectBundleDir（package.json / 声明 / 补丁层 /
+ *                     入口文件）。
+ * 包解析用与官方 resolveBundleDir 同构的 createRequire.resolve.paths 探测
+ * （含 NODE_PATH / 全局 node_modules），保证「官方能装配的登记不会被误删」。
+ * @param {string} packageName 登记名
+ * @param {Object} opts
+ * @param {string} opts.installAnchorDir dsh 包目录（resolveBundleDir 的第一锚点）
+ * @param {string} opts.profileDir       profiles/<name> 目录（第二锚点）
+ * @param {(content: string) => unknown|{load: (content: string) => unknown}} [opts.parsePatch]
+ *   entry-list 方言解析器：接受函数或 { load(content) } 对象（main.js
+ *   loadDshYamlDialect 返回值形态）；缺省 / 其它值跳过补丁层可解析性检查
+ * @returns {{ ok: boolean, code: string, reason: string, packageDir?: string, patchPath?: string }}
+ */
+function validateBundleEntry(packageName, opts) {
+  const { installAnchorDir, profileDir, parsePatch } = opts;
+  if (typeof packageName !== 'string' || packageName === '') {
+    return { ok: false, code: BUNDLE_CHECK_CODES.INVALID_NAME, reason: '登记项不是非空字符串' };
+  }
+  // installAnchorDir 为空（CLI 未定位到 dsh 包等）时跳过第一锚点：相对路径的
+  // node_modules 探测会意外解析到进程 cwd，绝不能据此判定健康。profileDir
+  // 同理：为空时第二锚点同样跳过（绝不基于进程 cwd 的相对探测判定）。
+  const dir = (installAnchorDir && resolveBundleDirLike(path.join(installAnchorDir, 'package.json'), packageName))
+    || (profileDir && resolveBundleDirLike(path.join(profileDir, 'package.json'), packageName));
+  if (!dir) {
+    return {
+      ok: false,
+      code: BUNDLE_CHECK_CODES.UNRESOLVABLE,
+      reason: installAnchorDir
+        ? '包未安装（dsh 安装与 profile node_modules 均解析不到）'
+        : '包未安装（profile node_modules 解析不到）',
+    };
+  }
+  const check = inspectBundleDir(dir, patchParserOf(parsePatch));
+  if (!check.ok) return check;
+  return { ok: true, code: '', reason: '', packageDir: dir, patchPath: check.patchPath };
+}
+
+/**
+ * 归一化补丁层解析器入参：接受函数（createEntryListYamlParser 形态）或
+ * { load(content) } 对象（main.js loadDshYamlDialect 返回值形态）两种调用
+ * 方约定；其余值按 null 处理（跳过可解析性检查）。两种形态都得到校验，
+ * 防止调用方形态漂移导致 PATCH_UNPARSEABLE 判定被静默跳过。
+ * @param {Function|{load: Function}|null|undefined} parsePatch
+ * @returns {Function|null}
+ */
+function patchParserOf(parsePatch) {
+  if (typeof parsePatch === 'function') return parsePatch;
+  if (parsePatch && typeof parsePatch.load === 'function') return (content) => parsePatch.load(content);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// manifest 对账
+// ---------------------------------------------------------------------------
+
+/**
+ * 对账 profile manifest 到「每条登记都可装配」状态（唯一写入口）。
+ * 语义与历史 main.js syncCompanionPlugins 的 manifest 段逐项一致（日志文案
+ * 由 log 回调原样透出），并新增：全量逐条校验——无效且非核心的登记移除并
+ * 记入隔离记录；健康后清除隔离记录。健康 manifest 零写入（幂等）。
+ * @param {string} profileDir profiles/<name> 目录
+ * @param {Object} opts
+ * @param {string} opts.installAnchorDir dsh 包目录（解析第一锚点）
+ * @param {string[]} [opts.coreNames] 核心 bundle 名（默认 CORE_BUNDLE_NAMES；
+ *   校验失败绝不移除）
+ * @param {Set<string>} [opts.addNames] 应确保登记的配套包名；追加前用
+ *   validateBundleEntry 全量校验（含补丁层可解析性），校验失败的配套 bundle
+ *   不登记并记入隔离记录（调用方 verifyBundleDir 不查补丁层 YAML 可解析性，
+ *   此处收口到同一判定语义）
+ * @param {Set<string>} [opts.missingNames] 源缺失 / 校验失败的配套包名（移除登记）
+ * @param {Set<string>} [opts.removedBundles] 插件管理「卸载」标记的配套包名（移除登记）
+ * @param {Set<string>} [opts.excludeFromRecover] 重置后恢复扫描的排除名
+ *   （核心 + 配套）
+ * @param {(content: string) => unknown|{load: (content: string) => unknown}} [opts.parsePatch]
+ *   entry-list 方言解析器：函数或 { load(content) } 对象（main.js
+ *   loadDshYamlDialect 返回值形态）；缺省 / 其它值跳过补丁层可解析性检查
+ * @param {(msg: string) => void} [opts.log]
+ * @param {boolean} [opts.dryRun] 只计算不落盘（备份 / 写入 / 记录全部跳过）
+ * @param {boolean} [opts.initMissing] manifest 文件不存在时是否允许预写骨架 +
+ *   核心 bundles（默认 true，main.js 语义：核心可解析才写）；false（CLI 契约）
+ *   时完全不创建 manifest，交由 dsh 首次启动初始化
+ * @returns {{
+ *   manifest: Object,            // 对账后的 manifest（dryRun 同样返回计算结果）
+ *   changed: boolean,            // 是否有任何需要落盘的修改
+ *   reset: boolean,              // manifest 是否经历备份重建
+ *   backup: string|null,         // 重建备份路径（未重建为 null）
+ *   removed: Array<{name: string, code: string, reason: string}>, // 逐条校验移除
+ *   added: string[],             // 配套 bundle 追加
+ *   removedByPolicy: string[],   // 源缺失 / 卸载标记移除
+ *   recovered: string[],         // 重置后恢复的用户 bundle
+ *   deduped: string[],           // 重复登记的 bundle（保留首次出现）
+ *   quarantined: string[],       // 本次新记入隔离记录的名字（同 code+reason
+ *                                //   的既有条目不重写，保留首次 removedAt）
+ *   unquarantined: string[],     // 本次从隔离记录清除的名字（恢复健康，同轮生效）
+ * }}
+ */
+function reconcileProfileBundles(profileDir, opts) {
+  const {
+    installAnchorDir,
+    coreNames = CORE_BUNDLE_NAMES,
+    addNames = new Set(),
+    missingNames = new Set(),
+    removedBundles = new Set(),
+    excludeFromRecover = new Set(),
+    parsePatch = null,
+    log = () => {},
+    dryRun = false,
+    initMissing = true,
+  } = opts;
+
+  const manifestFile = path.join(profileDir, 'package.json');
+  const recordFile = path.join(profileDir, BROKEN_BUNDLES_RECORD_FILENAME);
+  // dryRun 只计算：记录修改一律作用在副本上，绝不触碰磁盘状态。
+  const record = readBrokenBundlesRecord(recordFile) || { v: BROKEN_BUNDLES_RECORD_VERSION, entries: {} };
+  const recordNext = dryRun ? JSON.parse(JSON.stringify(record)) : record;
+  let recordDirty = false;
+
+  const result = {
+    manifest: null,
+    changed: false,
+    reset: false,
+    backup: null,
+    removed: [],
+    added: [],
+    removedByPolicy: [],
+    recovered: [],
+    deduped: [],
+    quarantined: [],
+    unquarantined: [],
+  };
+
+  // --- 读取 + 损坏重建（备份原文，绝不静默丢弃用户数据） ---
+  const manifestExists = fs.existsSync(manifestFile);
+  let manifest = null;
+  let manifestReset = false;
+  if (manifestExists) {
+    try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch { manifestReset = true; }
+  }
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    manifestReset = true;
+    manifest = { name: 'dsh-profile-' + path.basename(profileDir), private: true };
+  }
+  result.reset = manifestReset;
+
+  // initMissing=false（CLI 契约）：manifest 文件不存在时绝不凭空创建（顶替
+  // dsh 的 profile 初始化有风险），交由 dsh 首次启动初始化，下次运行再对账。
+  if (!manifestExists && !initMissing) {
+    if (addNames.size > 0) log('profile manifest 尚无 bundles（可能尚未初始化），bundle 插件留待下次运行注册');
+    result.manifest = null;
+    return result;
+  }
+
+  // 核心 bundles 可解析性（决定能否安全预写 / 重建）。与登记校验同一解析
+  // 实现（resolvableCoreNames → resolveBundleDirLike）。installAnchorDir 为空
+  // 时核心一律视为不可解析（CLI 未定位到 dsh 包），绝不依据进程 cwd 的相对
+  // 探测写入。
+  const cores = resolvableCoreNames(coreNames, installAnchorDir);
+  const coresResolvable = cores.length === coreNames.length && coreNames.length > 0;
+
+  // 损坏重建：只有「核心可解析、重建后能安全启动」才备份 + 落盘骨架；核心
+  // 不可解析时保持磁盘原样（空 bundles 骨架会让插件树无法激活，比保留原文
+  // 更糟），下次运行再试。
+  if (manifestReset && manifestExists && coresResolvable) {
+    if (!dryRun) {
+      const backup = manifestFile + '.broken-' + Date.now();
+      try {
+        fs.copyFileSync(manifestFile, backup);
+        result.backup = backup;
+        log('profile manifest 损坏，原文件已备份到 ' + backup);
+      } catch (err) {
+        log('profile manifest 备份失败: ' + ((err && err.message) || err));
+      }
+    } else {
+      log('profile manifest 损坏，将备份原文件并重建（dry-run 不落盘）');
+    }
+  } else if (manifestReset && manifestExists && !coresResolvable && !initMissing) {
+    result.manifest = null;
+    return result;
+  }
+
+  if (!manifest.dsh || typeof manifest.dsh !== 'object' || Array.isArray(manifest.dsh)) manifest.dsh = {};
+  if (!manifest.dsh.profile || typeof manifest.dsh.profile !== 'object' || Array.isArray(manifest.dsh.profile)) manifest.dsh.profile = {};
+  result.manifest = manifest;
+
+  let bundles = manifest.dsh.profile.bundles;
+  let bundlesUsable = Array.isArray(bundles);
+  if (!bundlesUsable) {
+    // 全新 / 未初始化 / bundles 非数组：只有核心 bundles 在安装中实测可解析
+    // 才预写（与 dsh 初始化模板一致），预写后按「可用」继续走后续对账；
+    // 解析不到则完全不写，交由 dsh 自行初始化——避免顶替 dsh 初始化导致
+    // 首次启动失败。
+    if (coresResolvable) {
+      bundles = [...cores];
+      manifest.dsh.profile.bundles = bundles;
+      bundlesUsable = true;
+      result.changed = true;
+    } else {
+      log('dsh 出厂核心 bundles 未在安装中解析到，跳过 manifest 预写，交由 dsh 初始化');
+    }
+  }
+
+  if (bundlesUsable) {
+    // 1. 存量自愈（issue #16）：缺失的核心 bundles 补齐到最前，其余原样保留。
+    const resolvableCores = resolvableCoreNames(coreNames, installAnchorDir);
+    const healed = ensureCoreBundles(bundles, resolvableCores);
+    if (healed) {
+      bundles = healed.next;
+      manifest.dsh.profile.bundles = bundles;
+      result.changed = true;
+      log('profile manifest 自愈: 旧版本写坏的 bundles 缺少核心 ' + healed.added.join(', ') + '，已补齐到最前');
+    }
+
+    // 2. 全量逐条校验：无效且非核心的登记移除 + 隔离记录；核心异常保留
+    //    （启动防护兜底跳过，缺失核心是安装损坏而非数据问题）。
+    //    策略性移除的名字（配套源缺失 / 插件管理卸载标记）不在本步判定：
+    //    它们由步骤 4/6 按「用户意图禁用」移除，绝不写入隔离记录（隔离记录
+    //    只记录无效登记，不记录用户主动禁用——否则卸载/源缺失会在记录里
+    //    留下误导性的 UNRESOLVABLE 条目）。
+    const kept = [];
+    for (const name of bundles) {
+      if (missingNames.has(name) || removedBundles.has(name)) {
+        kept.push(name);
+        continue;
+      }
+      const check = validateBundleEntry(name, { installAnchorDir, profileDir, parsePatch });
+      if (check.ok) {
+        kept.push(name);
+        if (Object.prototype.hasOwnProperty.call(recordNext.entries, name)) {
+          delete recordNext.entries[name];
+          recordDirty = true;
+          result.unquarantined.push(name);
+        }
+        continue;
+      }
+      if (coreNames.includes(name)) {
+        kept.push(name);
+        log('核心 bundle 登记异常（保留，启动防护兜底跳过）: ' + name + ' —— ' + check.reason);
+        continue;
+      }
+      result.removed.push({ name, code: check.code, reason: check.reason });
+      recordNext.entries[name] = {
+        code: check.code,
+        reason: check.reason,
+        removedAt: new Date().toISOString(),
+      };
+      recordDirty = true;
+      result.quarantined.push(name);
+      log('已把无效的 profile bundle 登记移除: ' + name + ' —— ' + check.reason + '（重装该插件后重新登记即可恢复）');
+      result.changed = true;
+    }
+    bundles = kept;
+    manifest.dsh.profile.bundles = bundles;
+
+    // 2.5 重复登记去重：同一包名登记两次会让其补丁层条目重复出现在组合
+    //     entry list 中，loader 装配期抛 "duplicate loader entry id"（fail-loud
+    //     → dsh web 退出码 1），且启动防护覆盖不到（两层都能正常加载）。
+    //     保留首次出现、移除重复项；重复登记是冗余而非无效登记，不进隔离
+    //     记录（重装/恢复登记等写入方都可能制造该形状，历史上从不清理）。
+    {
+      const seen = new Set();
+      const deduped = [];
+      for (const name of bundles) {
+        if (seen.has(name)) {
+          result.deduped.push(name);
+          result.changed = true;
+          log('已移除重复登记的 profile bundle: ' + name + '（同一 bundle 只装配一次，重复登记会触发 loader duplicate entry id 崩溃）');
+          continue;
+        }
+        seen.add(name);
+        deduped.push(name);
+      }
+      if (deduped.length !== bundles.length) {
+        bundles = deduped;
+        manifest.dsh.profile.bundles = bundles;
+      }
+    }
+
+    // 3. 配套 bundle 登记追加。追加前用与存量登记完全相同的 validateBundleEntry
+    //    校验（含补丁层可解析性）：调用方 syncCompanionFiles 的 verifyBundleDir
+    //    不检查补丁层 YAML 可解析性，直接登记会让「补丁层损坏的配套 bundle」
+    //    暴露一个启动窗口（仅靠运行时防护兜底）；这里收口到同一判定语义，
+    //    校验失败的配套 bundle 不登记并记入隔离记录（文件保留，重装即恢复）。
+    for (const name of addNames) {
+      if (bundles.includes(name)) continue;
+      const check = validateBundleEntry(name, { installAnchorDir, profileDir, parsePatch });
+      if (!check.ok) {
+        result.removed.push({ name, code: check.code, reason: check.reason });
+        // 记录去重：同 code + reason 的既有条目不重写（保留首次 removedAt，
+        // 避免每次启动对同一持续损坏状态做无意义重写）。
+        const existing = recordNext.entries[name];
+        if (!existing || existing.code !== check.code || existing.reason !== check.reason) {
+          recordNext.entries[name] = {
+            code: check.code,
+            reason: check.reason,
+            removedAt: new Date().toISOString(),
+          };
+          recordDirty = true;
+          result.quarantined.push(name);
+        }
+        // manifest 未被改动（该名从未被登记）：不置 changed，避免对健康
+        // manifest 做内容相同的无意义重写。
+        log('配套 bundle 校验失败，不登记进 web profile bundles: ' + name + ' —— ' + check.reason + '（重装该插件后重新登记即可恢复）');
+        continue;
+      }
+      bundles.push(name);
+      result.added.push(name);
+      result.changed = true;
+      // 同名条目曾因失败被记录（历史 run）：本次登记成功 → 同轮清除记录
+      //（恢复健康后记录立即消失，不必等下一次启动的步骤 2）。
+      if (Object.prototype.hasOwnProperty.call(recordNext.entries, name)) {
+        delete recordNext.entries[name];
+        recordDirty = true;
+        result.unquarantined.push(name);
+      }
+      log('已把 bundle 插件加入 web profile bundles: ' + name);
+    }
+
+    // 4. 源缺失 / 校验失败的配套登记移除（视为用户禁用，幂等）。
+    if (missingNames.size > 0) {
+      const before = bundles.length;
+      manifest.dsh.profile.bundles = bundles.filter((n) => !missingNames.has(n));
+      if (manifest.dsh.profile.bundles.length !== before) {
+        result.removedByPolicy.push(...missingNames);
+        result.changed = true;
+        log('配套 bundle 源缺失，已从 web profile bundles 移除（视为禁用）: ' + [...missingNames].join(', '));
+      }
+      bundles = manifest.dsh.profile.bundles;
+    }
+
+    // 5. issue #48 数据恢复：manifest 重置后，用户手动安装的第三方 bundle
+    //    仍实际落在 profile node_modules，扫描校验后合并回登记。
+    if (manifestReset) {
+      const recovered = recoverManifestBundles(manifest, scanProfileBundles(
+        path.join(profileDir, 'node_modules'),
+        excludeFromRecover,
+      ));
+      if (recovered.length > 0) {
+        // 复检：scanProfileBundles 的 verifyBundleDir 不查补丁层可解析性，
+        // 恢复的登记必须过与存量登记相同的 validateBundleEntry 判定，否则
+        // 当次启动会暴露「恢复出一个坏登记」的窗口（仅靠运行时防护兜底）。
+        const kept = [];
+        const dropped = [];
+        for (const name of recovered) {
+          const check = validateBundleEntry(name, { installAnchorDir, profileDir, parsePatch });
+          if (check.ok) { kept.push(name); continue; }
+          dropped.push(name);
+          result.removed.push({ name, code: check.code, reason: check.reason });
+          const existing = recordNext.entries[name];
+          if (!existing || existing.code !== check.code || existing.reason !== check.reason) {
+            recordNext.entries[name] = {
+              code: check.code,
+              reason: check.reason,
+              removedAt: new Date().toISOString(),
+            };
+            recordDirty = true;
+            result.quarantined.push(name);
+          }
+          result.changed = true;
+          log('恢复的 bundle 复检失败，从 web profile bundles 移除: ' + name + ' —— ' + check.reason + '（重装该插件后重新登记即可恢复）');
+        }
+        if (dropped.length > 0) {
+          const dropSet = new Set(dropped);
+          bundles = bundles.filter((n) => !dropSet.has(n));
+          manifest.dsh.profile.bundles = bundles;
+        }
+        if (kept.length > 0) {
+          result.recovered = kept;
+          result.changed = true;
+          // 同名条目曾因失败被记录（历史 run）：本次恢复成功 → 同轮清除记录。
+          for (const name of kept) {
+            if (Object.prototype.hasOwnProperty.call(recordNext.entries, name)) {
+              delete recordNext.entries[name];
+              recordDirty = true;
+              result.unquarantined.push(name);
+            }
+          }
+          log('profile manifest 重置后已恢复用户安装的 bundle 插件: ' + kept.join(', '));
+        }
+      } else {
+        log('profile manifest 已重置（原文件已备份），未发现需要恢复的用户 bundle');
+      }
+    }
+
+    // 6. 插件管理「卸载」标记的配套登记移除。
+    if (removedBundles.size > 0) {
+      const before = bundles.length;
+      manifest.dsh.profile.bundles = bundles.filter((n) => !removedBundles.has(n));
+      if (manifest.dsh.profile.bundles.length !== before) {
+        result.removedByPolicy.push(...removedBundles);
+        result.changed = true;
+        log('已卸载 bundle 插件，从 web profile bundles 移除: ' + [...removedBundles].join(', '));
+      }
+      bundles = manifest.dsh.profile.bundles;
+    }
+  }
+
+  // --- 落盘（原子写；隔离记录只在有修改时写回） ---
+  if (result.changed && !dryRun) {
+    writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
+  }
+  if (recordDirty && !dryRun) {
+    // dry-run 的记录修改只反映在返回值，不落盘。
+    writeBrokenBundlesRecord(recordFile, recordNext, log);
+  }
+  return result;
+}
+
+module.exports = {
+  BROKEN_BUNDLES_RECORD_FILENAME,
+  BROKEN_BUNDLES_RECORD_VERSION,
+  createEntryListYamlParser,
+  readBrokenBundlesRecord,
+  writeBrokenBundlesRecord,
+  resolveBundleDirLike,
+  resolvableCoreNames,
+  validateBundleEntry,
+  reconcileProfileBundles,
+};

--- a/dsh-desktop/scripts/sync-companion-plugins.js
+++ b/dsh-desktop/scripts/sync-companion-plugins.js
@@ -32,8 +32,10 @@ const { spawnSync } = require('node:child_process');
 
 const { installBuiltinPresets } = require('./install-minimal-win-preset');
 const { COMPANION_PLUGINS } = require('./lib/companion-plugins');
+const { CORE_BUNDLE_NAMES } = require('../profile-manifest');
 const { writeFileAtomic } = require('./lib/patch-io');
 const { applyPatchToFiles } = require('./lib/patch-engine');
+const { reconcileProfileBundles, createEntryListYamlParser } = require('./lib/profile-reconcile');
 const {
   FLASH_PKG_REL, EXPOSE_PKG_REL, PW_REL, BASH_REL, CODE_PRESET_REL, patchTargets,
   transformFlashFix, transformExposeFix,
@@ -121,8 +123,7 @@ function findDshPackageDir(home, explicit) {
   return '';
 }
 
-function syncBuiltinPresets(home, dshPackageArg, dryRun) {
-  const dshPkgDir = findDshPackageDir(home, dshPackageArg);
+function syncBuiltinPresets(home, dshPackageArg, dryRun, dshPkgDir) {
   if (!dshPkgDir) {
     if (dshPackageArg) warn(`--dsh-package 未找到有效的 @deepseek-ai/dsh 包: ${dshPackageArg}`);
     else log('未找到 dsh 包（@deepseek-ai/dsh），跳过内置 Agent 预设同步；可用 --dsh-package <目录> 显式指定');
@@ -144,7 +145,7 @@ function syncBuiltinPresets(home, dshPackageArg, dryRun) {
 // 插件同步（与 main.js syncCompanionPlugins 共用同一实现；dry-run 时只读不改）
 // ---------------------------------------------------------------------------
 
-function syncPlugins(home, dryRun) {
+function syncPlugins(home, dryRun, dshPkgDir) {
   const profileDir = path.join(home, 'profiles', 'web');
   if (dryRun) {
     log(`dry-run: 目标 profile ${profileDir}`);
@@ -173,42 +174,28 @@ function syncPlugins(home, dryRun) {
     onVendorSynced: (name) => log(`已同步私有依赖 ${name}`),
   });
 
-  // Bundle 插件注册进 profile manifest 的 dsh.profile.bundles（dsh 启动时读取
-  // 包内 cordis.patch.yml）。本脚本不凭空创建 manifest（会顶替 dsh 的 profile
-  // 初始化导致全新 DSH_HOME 首次启动失败）：只有 manifest 已存在且已有 bundles
-  // 数组时才追加；否则交给 dsh 首次启动初始化，下次运行本脚本再注册。
-  const manifestFile = path.join(profileDir, 'package.json');
-  let manifest = {};
-  try { manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')); } catch { manifest = null; }
-  if (manifest && typeof manifest === 'object' && !Array.isArray(manifest) &&
-      manifest.dsh && manifest.dsh.profile && Array.isArray(manifest.dsh.profile.bundles)) {
-    for (const name of bundleNames) {
-      if (manifest.dsh.profile.bundles.includes(name)) continue;
-      if (dryRun) {
-        log(`dry-run: 将把 bundle 插件加入 profile bundles: ${name}`);
-        continue;
-      }
-      manifest.dsh.profile.bundles.push(name);
-      writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-      log(`已把 bundle 插件加入 web profile bundles: ${name}`);
-    }
-    // 源缺失 / 校验失败的 bundle 若仍登记在 manifest，会让 dsh 启动崩溃：
-    // 幂等移除登记（视为用户禁用），包文件保留，下次运行本脚本重试。
-    if (missingNames.size > 0) {
-      const before = manifest.dsh.profile.bundles.length;
-      manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((n) => !missingNames.has(n));
-      if (manifest.dsh.profile.bundles.length !== before) {
-        if (dryRun) {
-          log('dry-run: 将把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingNames].join(', '));
-        } else {
-          writeFileAtomic(manifestFile, JSON.stringify(manifest, null, 2) + '\n');
-          log('已把源缺失/校验失败的 bundle 移出 profile bundles: ' + [...missingNames].join(', '));
-        }
-      }
-    }
-  } else if (bundleNames.size > 0) {
-    log('profile manifest 尚无 bundles（可能尚未初始化），bundle 插件留待下次运行注册');
-  }
+  // profile manifest 装配对账（与 main.js 共用 scripts/lib/profile-reconcile.js
+  // 唯一实现）：损坏备份重建（核心可解析时）、核心补齐、全量逐条校验（无效且
+  // 非核心的登记移除并记入隔离记录 dsh-desktop.broken-bundles.json）、配套
+  // bundle 登记追加、源缺失移除。initMissing=false 保持 CLI 历史契约：manifest
+  // 文件不存在时绝不凭空创建（顶替 dsh 的 profile 初始化有风险），交由 dsh
+  // 首次启动初始化，下次运行本脚本再注册。dry-run 只计算不落盘。
+  // 与 main.js 同口径：插件管理「卸载」标记的配套 bundle 从 manifest 移除
+  //（removedBundles，避免卸载后仍被装配）；重置恢复排除核心 + 配套（由核心
+  // 补齐与配套追加步骤接管，绝不恢复用户已卸载的配套插件）。
+  const removedBundles = COMPANION_PLUGINS.filter((p) => removedIds.has(p.id)).map((p) => p.name);
+  reconcileProfileBundles(profileDir, {
+    installAnchorDir: dshPkgDir,
+    coreNames: CORE_BUNDLE_NAMES,
+    addNames: bundleNames,
+    missingNames,
+    removedBundles: new Set(removedBundles),
+    excludeFromRecover: new Set([...CORE_BUNDLE_NAMES, ...COMPANION_PLUGINS.map((p) => p.name)]),
+    parsePatch: createEntryListYamlParser(),
+    dryRun,
+    initMissing: false,
+    log: (m) => log(dryRun ? 'dry-run: ' + m : m),
+  });
 
   // 非 bundle 插件注册到 profile 补丁层（共享实现：幂等、尊重用户已有条目、
   // bundle 迁移去重、源缺失残留移除与卸载标记跳过；旧插件市场条目一并清理）。
@@ -405,8 +392,11 @@ function main() {
       fs.mkdirSync(home, { recursive: true });
     }
   }
-  syncPlugins(home, dryRun);
-  syncBuiltinPresets(home, dshPackageArg, dryRun);
+  // dsh 包目录（manifest 对账的第一解析锚点 + 内置 Agent 预设目标）；定位不到
+  // 时对账降级为只以 profile node_modules 为锚点，预设同步跳过。
+  const dshPkgDir = findDshPackageDir(home, dshPackageArg);
+  syncPlugins(home, dryRun, dshPkgDir);
+  syncBuiltinPresets(home, dshPackageArg, dryRun, dshPkgDir);
   if (withPatches) applyRuntimePatches(home, dryRun);
   console.log('[sync] 完成。');
   console.log('[sync] 提示：插件与内置 Agent 预设在 dsh web 启动时才会挂载 —— 请重启 WSL 里的 dsh web：');

--- a/dsh-desktop/scripts/test/integration-runner.js
+++ b/dsh-desktop/scripts/test/integration-runner.js
@@ -525,8 +525,10 @@ SCENARIOS['heal-dup-patch-keeps-config'] = async (t) => {
 SCENARIOS['heal-missing-bundle'] = async (t) => {
   // 用户反馈崩溃类 1：manifest 登记了未安装的 bundle（dsh plugin 安装中途
   // 失败 / 手工删除 / 迁移后缺 node_modules）→ 官方 loadProfile 抛
-  // "cannot resolve profile bundle" 并以退出码 1 启动失败。启动防护应跳过该
-  // 层并正常进入 Web UI；manifest 登记原样保留（等待用户重装，绝不破坏）。
+  // "cannot resolve profile bundle" 并以退出码 1 启动失败。启动装配对账
+  // （reconcileProfileBundles）应把该无效登记从 manifest 移除并记入隔离记录
+  // （dsh-desktop.broken-bundles.json），正常进入 Web UI；重装插件后重新登记
+  // 即可恢复，绝不破坏包文件。
   const profileDir = path.join(t.dshHome, 'profiles', 'web');
   fs.mkdirSync(profileDir, { recursive: true });
   const manifestFile = path.join(profileDir, 'package.json');
@@ -536,22 +538,26 @@ SCENARIOS['heal-missing-bundle'] = async (t) => {
     dependencies: {},
     dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/dsh-skill-manager'] } },
   }, null, 2) + '\n');
-  await t.waitFor('boot-ready', 240000, '缺失 bundle 应被跳过并正常启动');
+  await t.waitFor('boot-ready', 240000, '缺失 bundle 的登记应被对账移除并正常启动');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');
-  t.assert(t.grepLog('profile bundle 缺失'), '健康检查应记录缺失 bundle');
+  t.assert(t.grepLog('已把无效的 profile bundle 登记移除'), '应记录无效登记移除诊断');
   const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
-  t.assert(/cannot resolve profile bundle "@dsh-external\/dsh-skill-manager"/.test(webLog), 'dsh-web.log 应含 cannot resolve 诊断');
-  t.assert(/profile bundle "@dsh-external\/dsh-skill-manager" skipped/.test(webLog), 'dsh-web.log 应记录该层被跳过');
+  t.assert(!/cannot resolve profile bundle "@dsh-external\/dsh-skill-manager"/.test(webLog), 'dsh-web.log 不应再出现 cannot resolve 崩溃');
   const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
-  t.assert(after.dsh.profile.bundles.includes('@dsh-external/dsh-skill-manager'), 'manifest 登记应原样保留');
+  t.assert(!after.dsh.profile.bundles.includes('@dsh-external/dsh-skill-manager'), '无效登记应从 manifest 移除');
+  const record = JSON.parse(fs.readFileSync(path.join(profileDir, 'dsh-desktop.broken-bundles.json'), 'utf8'));
+  t.assert(record && record.entries && record.entries['@dsh-external/dsh-skill-manager'], '隔离记录应记下移除原因');
+  t.assert(record.entries['@dsh-external/dsh-skill-manager'].code === 'UNRESOLVABLE', '隔离记录应含结构化失败码');
   const q = await t.quitAndCheck();
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
 
 SCENARIOS['heal-manifestless-bundle'] = async (t) => {
   // 用户反馈崩溃类 2：bundle 包已安装但 package.json 未声明 dsh.bundle.patch
-  // （普通库 / 仅客户端 bundle）→ 官方 loadProfile 抛 "declares no
-  // dsh.bundle" 并启动失败。启动防护应跳过该层并正常进入 Web UI，登记保留。
+  // （普通库 / 仅客户端 bundle，用户反馈的 dsh-hub 即此形状）→ 官方
+  // loadProfile 抛 "declares no dsh.bundle" 并启动失败。启动装配对账应把该
+  // 无效登记从 manifest 移除并记入隔离记录，正常进入 Web UI；重装后重新登记
+  // 即可恢复，包文件不修改。
   const profileDir = path.join(t.dshHome, 'profiles', 'web');
   const pkgDir = path.join(profileDir, 'node_modules', '@dsh-external', 'dsh-gold-luxe');
   fs.mkdirSync(pkgDir, { recursive: true });
@@ -563,12 +569,14 @@ SCENARIOS['heal-manifestless-bundle'] = async (t) => {
     dependencies: {},
     dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/dsh-gold-luxe'] } },
   }, null, 2) + '\n');
-  await t.waitFor('boot-ready', 240000, '无 dsh.bundle 声明的 bundle 应被跳过并正常启动');
+  await t.waitFor('boot-ready', 240000, '无 dsh.bundle 声明的登记应被对账移除并正常启动');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');
-  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
-  t.assert(/profile bundle "@dsh-external\/dsh-gold-luxe" skipped/.test(webLog), 'dsh-web.log 应记录该层被跳过');
+  t.assert(t.grepLog('已把无效的 profile bundle 登记移除'), '应记录无效登记移除诊断');
   const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
-  t.assert(after.dsh.profile.bundles.includes('@dsh-external/dsh-gold-luxe'), 'manifest 登记应原样保留');
+  t.assert(!after.dsh.profile.bundles.includes('@dsh-external/dsh-gold-luxe'), '无效登记应从 manifest 移除');
+  const record = JSON.parse(fs.readFileSync(path.join(profileDir, 'dsh-desktop.broken-bundles.json'), 'utf8'));
+  t.assert(record && record.entries && record.entries['@dsh-external/dsh-gold-luxe'], '隔离记录应记下移除原因');
+  t.assert(record.entries['@dsh-external/dsh-gold-luxe'].code === 'NO_BUNDLE_DECL', '隔离记录应含结构化失败码');
   const q = await t.quitAndCheck();
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };
@@ -632,13 +640,16 @@ SCENARIOS['heal-broken-manifest-recovers'] = async (t) => {
 
 SCENARIOS['heal-broken-home-patch'] = async (t) => {
   // 家级补丁层 $DSH_HOME/cordis.patch.yml 损坏 → 官方 composeProfile 抛
-  // "failed to parse patches" 并启动失败。profile-boot 防护应备份 + 重置为
-  // 空列表后正常启动；损坏原文保留在 .broken- 备份里。
+  // "failed to parse patches" 并启动失败。壳层在启动 dsh web 前用与 dsh 相同
+  // 的 entry-list 方言预检（healHomePatch）：损坏 → 备份 .broken-<ts> + 重置
+  // 为最小合法文件后正常启动；损坏原文保留在备份里。运行时防护（profile-boot
+  // guard）保留为纵深防御，正常情况下 dsh-web.log 不应出现解析失败。
   fs.writeFileSync(path.join(t.dshHome, 'cordis.patch.yml'), '- id: [BAD', 'utf8');
-  await t.waitFor('boot-ready', 240000, '损坏的家级补丁层应被自愈后正常启动');
+  await t.waitFor('boot-ready', 240000, '损坏的家级补丁层应被预检自愈后正常启动');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('家级补丁层自愈'), 'desktop.log 应记录家级补丁层自愈');
   const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
-  t.assert(/cordis\.patch\.yml failed to parse/.test(webLog), 'dsh-web.log 应记录家级补丁层解析失败');
+  t.assert(!/cordis\.patch\.yml failed to parse/.test(webLog), 'dsh-web.log 不应出现解析失败（预检已修复）');
   const backups = fs.readdirSync(t.dshHome).filter((f) => f.startsWith('cordis.patch.yml.broken-'));
   t.assert(backups.length >= 1, '损坏的家级补丁层应备份为 cordis.patch.yml.broken-<ts>');
   const healed = fs.readFileSync(path.join(t.dshHome, 'cordis.patch.yml'), 'utf8');
@@ -649,8 +660,9 @@ SCENARIOS['heal-broken-home-patch'] = async (t) => {
 
 SCENARIOS['heal-broken-bundle-patch'] = async (t) => {
   // bundle 的 cordis.patch.yml 损坏 → 官方 loadOverlayPatches 抛 "failed to
-  // parse overlay" 并启动失败。启动防护应跳过该层并正常进入 Web UI；bundle
-  // 文件不修改（重装该插件即可恢复）。
+  // parse overlay" 并启动失败。启动装配对账（entry-list 方言预检）应把该无效
+  // 登记从 manifest 移除并记入隔离记录，正常进入 Web UI；bundle 文件不修改
+  // （重装该插件即可恢复）。
   const profileDir = path.join(t.dshHome, 'profiles', 'web');
   const pkgDir = path.join(profileDir, 'node_modules', '@dsh-external', 'dsh-broken');
   fs.mkdirSync(pkgDir, { recursive: true });
@@ -664,11 +676,105 @@ SCENARIOS['heal-broken-bundle-patch'] = async (t) => {
     dependencies: {},
     dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/dsh-broken'] } },
   }, null, 2) + '\n');
-  await t.waitFor('boot-ready', 240000, '损坏的 bundle 补丁层应被跳过并正常启动');
+  await t.waitFor('boot-ready', 240000, '损坏的 bundle 补丁层登记应被对账移除并正常启动');
   await t.waitFor('界面已稳定', 60000, '稳定期完成');
-  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
-  t.assert(/profile bundle "@dsh-external\/dsh-broken" skipped/.test(webLog), 'dsh-web.log 应记录该层被跳过');
+  t.assert(t.grepLog('已把无效的 profile bundle 登记移除'), '应记录无效登记移除诊断');
+  const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  t.assert(!after.dsh.profile.bundles.includes('@dsh-external/dsh-broken'), '无效登记应从 manifest 移除');
+  const record = JSON.parse(fs.readFileSync(path.join(profileDir, 'dsh-desktop.broken-bundles.json'), 'utf8'));
+  t.assert(record && record.entries && record.entries['@dsh-external/dsh-broken'], '隔离记录应记下移除原因');
+  t.assert(record.entries['@dsh-external/dsh-broken'].code === 'PATCH_UNPARSEABLE', '隔离记录应含结构化失败码');
   t.assert(fs.readFileSync(path.join(pkgDir, 'cordis.patch.yml'), 'utf8') === brokenPatch, 'bundle 文件不应被修改');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-entry-missing-bundle'] = async (t) => {
+  // 用户反馈崩溃类 3（防护覆盖不到的形状）：bundle 声明 dsh.bundle.patch 与
+  // 入口文件，但入口文件缺失（安装不完整 / 手工删除）——loadProfile 只读补丁
+  // 层不查入口，崩溃发生在 loader 激活期（plugin tree failed to load），此前
+  // 启动防护无法覆盖。启动装配对账（ENTRY_MISSING 校验）应把该登记移除并记入
+  // 隔离记录，正常进入 Web UI；包文件不修改（重装即可恢复）。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  const pkgDir = path.join(profileDir, 'node_modules', '@dsh-external', 'ghost-entry');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@dsh-external/ghost-entry', version: '1.0.0', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } } }, null, 2) + '\n');
+  fs.writeFileSync(path.join(pkgDir, 'cordis.patch.yml'), '[]\n', 'utf8');
+  const manifestFile = path.join(profileDir, 'package.json');
+  fs.writeFileSync(manifestFile, JSON.stringify({
+    name: 'dsh-profile-web',
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/ghost-entry'] } },
+  }, null, 2) + '\n');
+  await t.waitFor('boot-ready', 240000, '入口缺失的登记应被对账移除并正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('已把无效的 profile bundle 登记移除'), '应记录无效登记移除诊断');
+  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
+  t.assert(!/plugin tree failed to load/.test(webLog), 'dsh-web.log 不应出现插件树加载失败');
+  const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  t.assert(!after.dsh.profile.bundles.includes('@dsh-external/ghost-entry'), '无效登记应从 manifest 移除');
+  const record = JSON.parse(fs.readFileSync(path.join(profileDir, 'dsh-desktop.broken-bundles.json'), 'utf8'));
+  t.assert(record && record.entries && record.entries['@dsh-external/ghost-entry'], '隔离记录应记下移除原因');
+  t.assert(record.entries['@dsh-external/ghost-entry'].code === 'ENTRY_MISSING', '隔离记录应含结构化失败码');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-dup-bundle'] = async (t) => {
+  // 重复登记形状：同一 bundle 名登记两次 → 其补丁层条目重复出现在组合
+  // entry list → loader 装配期抛 "duplicate loader entry id"（fail-loud →
+  // 退出码 1），且启动防护覆盖不到（两层都能正常加载）。启动装配对账应保留
+  // 首次出现、移除重复项（冗余而非无效登记，不进隔离记录），正常进入 Web UI。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const manifestFile = path.join(profileDir, 'package.json');
+  fs.writeFileSync(manifestFile, JSON.stringify({
+    name: 'dsh-profile-web',
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'] } },
+  }, null, 2) + '\n');
+  await t.waitFor('boot-ready', 240000, '重复登记的 bundle 应被对账去重并正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('已移除重复登记的 profile bundle'), '应记录重复登记移除诊断');
+  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
+  t.assert(!/duplicate loader entry id/.test(webLog), 'dsh-web.log 不应出现 duplicate loader entry id 崩溃');
+  const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  t.assert(after.dsh.profile.bundles.filter((n) => n === '@deepseek-ai/dsh-base').length === 1, '重复登记应被去重（只保留首次出现）');
+  t.assert(after.dsh.profile.bundles.includes('@deepseek-ai/dsh-web-app'), '其余核心登记不受影响');
+  const q = await t.quitAndCheck();
+  t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
+};
+
+SCENARIOS['heal-dir-entry-bundle'] = async (t) => {
+  // 入口指向目录形状：bundle 声明 main: "./lib"（目录）——Loader 用 ESM
+  // import() 激活入口必然 ERR_UNSUPPORTED_DIR_IMPORT（激活期崩溃，防护覆盖
+  // 不到，存在性检查会放过）。对账的「入口必须是普通文件」校验应判
+  // ENTRY_MISSING 并移除登记，正常进入 Web UI；包文件不修改。
+  const profileDir = path.join(t.dshHome, 'profiles', 'web');
+  const pkgDir = path.join(profileDir, 'node_modules', '@dsh-external', 'dir-entry');
+  fs.mkdirSync(path.join(pkgDir, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@dsh-external/dir-entry', version: '1.0.0', main: 'lib', dsh: { bundle: { patch: './cordis.patch.yml' } } }, null, 2) + '\n');
+  fs.writeFileSync(path.join(pkgDir, 'cordis.patch.yml'), '[]\n', 'utf8');
+  fs.writeFileSync(path.join(pkgDir, 'lib', 'index.js'), 'export {};\n');
+  const manifestFile = path.join(profileDir, 'package.json');
+  fs.writeFileSync(manifestFile, JSON.stringify({
+    name: 'dsh-profile-web',
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@dsh-external/dir-entry'] } },
+  }, null, 2) + '\n');
+  await t.waitFor('boot-ready', 240000, '入口指向目录的登记应被对账移除并正常启动');
+  await t.waitFor('界面已稳定', 60000, '稳定期完成');
+  t.assert(t.grepLog('已把无效的 profile bundle 登记移除'), '应记录无效登记移除诊断');
+  const webLog = fs.readFileSync(path.join(t.userData, 'logs', 'dsh-web.log'), 'utf8');
+  t.assert(!/ERR_UNSUPPORTED_DIR_IMPORT|did not activate|plugin tree failed to load/.test(webLog), 'dsh-web.log 不应出现激活期崩溃');
+  const after = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  t.assert(!after.dsh.profile.bundles.includes('@dsh-external/dir-entry'), '入口指向目录的登记应从 manifest 移除');
+  const record = JSON.parse(fs.readFileSync(path.join(profileDir, 'dsh-desktop.broken-bundles.json'), 'utf8'));
+  t.assert(record && record.entries && record.entries['@dsh-external/dir-entry'], '隔离记录应记下移除原因');
+  t.assert(record.entries['@dsh-external/dir-entry'].code === 'ENTRY_MISSING', '隔离记录应含结构化失败码');
   const q = await t.quitAndCheck();
   t.assert(q.exit.code === 0 && q.cleanExit === true, '干净退出');
 };

--- a/dsh-desktop/scripts/test/unit-profile-reconcile.test.js
+++ b/dsh-desktop/scripts/test/unit-profile-reconcile.test.js
@@ -1,0 +1,999 @@
+'use strict';
+
+// scripts/lib/profile-reconcile.js 单元测试（node --test，无需 Electron）：
+//   · validateBundleEntry 全失败码与健康判定；
+//   · reconcileProfileBundles 全流程（健康零写入 / 无效登记移除 + 隔离记录 /
+//     核心异常保留 / 损坏备份重建 / 核心预写 / 配套追加 / 源缺失与卸载标记移除 /
+//     重置恢复 / dry-run 零落盘 / 恢复健康后隔离记录清除 / 记录文件容错）；
+//   · CLI 契约（initMissing=false：缺失 manifest 不凭空创建，损坏且核心不可
+//     解析时不落盘空骨架）；
+//   · 真实 dsh-app-boot 复现：无效登记在官方 loadProfile 下必崩（用户反馈的
+//     "declares no dsh.bundle" 原始错误），对账后正常装配（仓库 node_modules
+//     已安装时执行）。
+// 用法：node --test scripts/test/unit-profile-reconcile.test.js
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const {
+  BUNDLE_CHECK_CODES,
+  inspectBundleDir,
+} = require('../../profile-bundle-heal');
+const { CORE_BUNDLE_NAMES } = require('../../profile-manifest');
+const {
+  BROKEN_BUNDLES_RECORD_FILENAME,
+  createEntryListYamlParser,
+  readBrokenBundlesRecord,
+  validateBundleEntry,
+  reconcileProfileBundles,
+} = require('../../scripts/lib/profile-reconcile');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const CORES = [...CORE_BUNDLE_NAMES];
+
+function tmpdir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pbr-unit-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+/** 在 base 下构造一个健康的 bundle 包目录（声明 patch + 补丁层 + 入口）。
+ *  注意 packageDirUpward 的语义：包位于 <base>/node_modules/<name>。 */
+function writeHealthyBundle(base, name, extra = {}) {
+  const dir = path.join(base, 'node_modules', ...name.split('/'));
+  fs.mkdirSync(path.join(dir, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(Object.assign({
+    name,
+    version: '1.0.0',
+    main: 'lib/index.js',
+    dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, extra), null, 2) + '\n');
+  fs.writeFileSync(path.join(dir, 'cordis.patch.yml'), '[]\n');
+  fs.writeFileSync(path.join(dir, 'lib', 'index.js'), 'export {};\n');
+  return dir;
+}
+
+function readManifest(profileDir) {
+  return JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+}
+
+function recordFile(profileDir) {
+  return path.join(profileDir, BROKEN_BUNDLES_RECORD_FILENAME);
+}
+
+/** 解析器桩：与 dsh 方言同构（JSON_SCHEMA + !!js）；'BAD' 内容抛错。 */
+function makeParser() {
+  const yaml = require('js-yaml');
+  const jsType = new yaml.Type('tag:yaml.org,2002:js', {
+    kind: 'scalar',
+    resolve: (data) => typeof data === 'string',
+    construct: (data) => ({ __jsExpr: data }),
+  });
+  return (content) => yaml.load(content, { schema: yaml.JSON_SCHEMA.extend(jsType) });
+}
+
+// ---------------------------------------------------------------------------
+// validateBundleEntry
+// ---------------------------------------------------------------------------
+
+test('validateBundleEntry: 健康登记通过，11 种失败码逐项命中', (t) => {
+  const base = tmpdir(t);
+  writeHealthyBundle(base, 'good-bundle');
+  const ok = validateBundleEntry('good-bundle', { installAnchorDir: base, profileDir: base, parsePatch: null });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.packageDir, path.join(base, 'node_modules', 'good-bundle'));
+
+  // INVALID_NAME：非字符串 / 空串
+  assert.equal(validateBundleEntry('', { installAnchorDir: base, profileDir: base }).code, BUNDLE_CHECK_CODES.INVALID_NAME);
+  assert.equal(validateBundleEntry(42, { installAnchorDir: base, profileDir: base }).code, BUNDLE_CHECK_CODES.INVALID_NAME);
+  assert.equal(validateBundleEntry(null, { installAnchorDir: base, profileDir: base }).code, BUNDLE_CHECK_CODES.INVALID_NAME);
+
+  // UNRESOLVABLE：双锚点均解析不到
+  assert.equal(
+    validateBundleEntry('ghost-bundle', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.UNRESOLVABLE,
+  );
+
+  // NO_BUNDLE_DECL：普通库 / 仅客户端 bundle（用户反馈的 dsh-hub 形状）
+  const clientOnly = writeHealthyBundle(base, 'client-only-bundle', {
+    dsh: { client: { platform: 'web', inject: ['@deepseek-ai/dsh-client-runtime'] } },
+  });
+  fs.writeFileSync(path.join(clientOnly, 'package.json'), JSON.stringify({
+    name: 'client-only-bundle', version: '1.0.0', main: 'lib/index.js',
+    dsh: { client: { platform: 'web' } },
+  }, null, 2) + '\n');
+  assert.equal(
+    validateBundleEntry('client-only-bundle', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.NO_BUNDLE_DECL,
+  );
+
+  // PATCH_MISSING：声明了补丁层但文件缺失
+  const noPatch = path.join(base, 'node_modules', 'no-patch-file');
+  fs.mkdirSync(noPatch, { recursive: true });
+  fs.writeFileSync(path.join(noPatch, 'package.json'), JSON.stringify({
+    name: 'no-patch-file', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, null, 2) + '\n');
+  assert.equal(
+    validateBundleEntry('no-patch-file', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.PATCH_MISSING,
+  );
+
+  // PATCH_UNPARSEABLE：补丁层存在但 YAML 损坏（提供解析器时）
+  const badPatch = writeHealthyBundle(base, 'bad-patch');
+  fs.writeFileSync(path.join(badPatch, 'cordis.patch.yml'), '- id: [BAD\n', 'utf8');
+  assert.equal(
+    validateBundleEntry('bad-patch', { installAnchorDir: base, profileDir: base, parsePatch: makeParser() }).code,
+    BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE,
+  );
+  // 不提供解析器：可解析性不检查，其余通过 → 健康
+  assert.equal(validateBundleEntry('bad-patch', { installAnchorDir: base, profileDir: base, parsePatch: null }).ok, true);
+
+  // ENTRY_MISSING：声明了入口但文件缺失
+  const noEntry = path.join(base, 'node_modules', 'no-entry');
+  fs.mkdirSync(path.join(noEntry, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(noEntry, 'package.json'), JSON.stringify({
+    name: 'no-entry', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(noEntry, 'cordis.patch.yml'), '[]\n');
+  assert.equal(
+    validateBundleEntry('no-entry', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.ENTRY_MISSING,
+  );
+
+  // ENTRY_MISSING（目录形态）：入口路径存在但是目录——Loader 用 ESM import()
+  // 激活，指向目录的 main/exports 必然 ERR_UNSUPPORTED_DIR_IMPORT（存在性
+  // 检查会放过，必须校验是普通文件）
+  const dirEntry = path.join(base, 'node_modules', 'dir-entry');
+  fs.mkdirSync(path.join(dirEntry, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(dirEntry, 'package.json'), JSON.stringify({
+    name: 'dir-entry', main: 'lib', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(dirEntry, 'cordis.patch.yml'), '[]\n');
+  fs.writeFileSync(path.join(dirEntry, 'lib', 'index.js'), 'export {};\n');
+  assert.equal(
+    validateBundleEntry('dir-entry', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.ENTRY_MISSING,
+    '入口指向目录必须判 ENTRY_MISSING（ESM 无法导入目录）',
+  );
+  // 对照：入口是普通文件 → 健康
+  assert.equal(validateBundleEntry('good-bundle', { installAnchorDir: base, profileDir: base }).ok, true);
+
+  // PATCH_OUTSIDE / ENTRY_OUTSIDE：路径越界围栏
+  const escaping = path.join(base, 'node_modules', 'escaping');
+  fs.mkdirSync(escaping, { recursive: true });
+  fs.writeFileSync(path.join(escaping, 'package.json'), JSON.stringify({
+    name: 'escaping', dsh: { bundle: { patch: '../../outside.yml' } },
+  }, null, 2) + '\n');
+  assert.equal(
+    validateBundleEntry('escaping', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.PATCH_OUTSIDE,
+  );
+  fs.writeFileSync(path.join(escaping, 'package.json'), JSON.stringify({
+    name: 'escaping', main: '../../outside.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(escaping, 'cordis.patch.yml'), '[]\n');
+  assert.equal(
+    validateBundleEntry('escaping', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.ENTRY_OUTSIDE,
+  );
+
+  // CLIENT_ENTRY_MISSING / CLIENT_ENTRY_OUTSIDE：exports["./client"] 字符串声明
+  // （dshmarket 形状）——client-modules 装配按该路径读取客户端 bundle，缺失
+  // 会让整个 client 模块注册 fail-loud（MissingClientBundleError → dsh web
+  // 启动失败）。上游在 verifyBundleDir 增加该校验（3 个单测），对账侧同步
+  // 收口为结构化失败码（CLIENT_ENTRY_*），保证「每条登记都可装配」判定覆盖
+  // 该形状；健康包不受影响。
+  const clientOk = path.join(base, 'node_modules', 'client-ok');
+  fs.mkdirSync(path.join(clientOk, 'lib'), { recursive: true });
+  fs.mkdirSync(path.join(clientOk, 'client'), { recursive: true });
+  fs.writeFileSync(path.join(clientOk, 'package.json'), JSON.stringify({
+    name: 'client-ok', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+    exports: { './client': './client/client.js' },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(clientOk, 'cordis.patch.yml'), '[]\n');
+  fs.writeFileSync(path.join(clientOk, 'lib', 'index.js'), 'export {};\n');
+  fs.writeFileSync(path.join(clientOk, 'client', 'client.js'), 'export {};\n');
+  assert.equal(
+    validateBundleEntry('client-ok', { installAnchorDir: base, profileDir: base }).ok,
+    true,
+    'client 入口落盘时判定健康',
+  );
+  const clientMissing = path.join(base, 'node_modules', 'client-missing');
+  fs.mkdirSync(path.join(clientMissing, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(clientMissing, 'package.json'), JSON.stringify({
+    name: 'client-missing', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+    exports: { './client': './client/client.js' },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(clientMissing, 'cordis.patch.yml'), '[]\n');
+  fs.writeFileSync(path.join(clientMissing, 'lib', 'index.js'), 'export {};\n');
+  assert.equal(
+    validateBundleEntry('client-missing', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.CLIENT_ENTRY_MISSING,
+  );
+  const clientEsc = path.join(base, 'node_modules', 'client-esc');
+  fs.mkdirSync(path.join(clientEsc, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(clientEsc, 'package.json'), JSON.stringify({
+    name: 'client-esc', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+    exports: { './client': '../../client.js' },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(clientEsc, 'cordis.patch.yml'), '[]\n');
+  fs.writeFileSync(path.join(clientEsc, 'lib', 'index.js'), 'export {};\n');
+  assert.equal(
+    validateBundleEntry('client-esc', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.CLIENT_ENTRY_OUTSIDE,
+  );
+
+  // PACKAGE_JSON_INVALID：package.json 不可解析
+  const badJson = path.join(base, 'node_modules', 'bad-json');
+  fs.mkdirSync(badJson, { recursive: true });
+  fs.writeFileSync(path.join(badJson, 'package.json'), '{"name": BAD\n');
+  assert.equal(
+    validateBundleEntry('bad-json', { installAnchorDir: base, profileDir: base }).code,
+    BUNDLE_CHECK_CODES.PACKAGE_JSON_INVALID,
+  );
+
+  // 第一锚点为空（CLI 未定位到 dsh 包）：不得依据进程 cwd 相对探测误判健康
+  assert.equal(
+    validateBundleEntry('ghost-bundle', { installAnchorDir: '', profileDir: base }).code,
+    BUNDLE_CHECK_CODES.UNRESOLVABLE,
+  );
+});
+
+test('validateBundleEntry: parsePatch 接受 { load } 形态（main.js loadDshYamlDialect 返回值），防止形态漂移静默跳过校验', (t) => {
+  const base = tmpdir(t);
+  const bad = writeHealthyBundle(base, 'bad-patch');
+  fs.writeFileSync(path.join(bad, 'cordis.patch.yml'), '- id: [BAD\n', 'utf8');
+  // 函数形态
+  assert.equal(
+    validateBundleEntry('bad-patch', { installAnchorDir: base, profileDir: base, parsePatch: makeParser() }).code,
+    BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE,
+  );
+  // { load } 对象形态
+  const dialect = { load: (content) => makeParser()(content) };
+  assert.equal(
+    validateBundleEntry('bad-patch', { installAnchorDir: base, profileDir: base, parsePatch: dialect }).code,
+    BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE,
+  );
+  // 其它值 → 跳过可解析性检查（保守降级，不抛错）
+  assert.equal(validateBundleEntry('bad-patch', { installAnchorDir: base, profileDir: base, parsePatch: 42 }).ok, true);
+});
+
+test('validateBundleEntry: 顶层数组但条目非映射（dsh parsePatchList 契约）判 PATCH_UNPARSEABLE', (t) => {
+  const base = tmpdir(t);
+  // 四种畸形形状：标量 / 字符串 / 嵌套数组 / null —— yaml.load 得到数组，
+  // 但 dsh-app-boot parsePatchList 对每项要求是映射（"must be a mapping"）。
+  const shapes = ['- 42\n', '- "string-entry"\n', '- [1, 2]\n', '- null\n'];
+  for (const shape of shapes) {
+    const dir = writeHealthyBundle(base, 'odd-entry');
+    fs.writeFileSync(path.join(dir, 'cordis.patch.yml'), shape, 'utf8');
+    const check = validateBundleEntry('odd-entry', { installAnchorDir: base, profileDir: base, parsePatch: makeParser() });
+    assert.equal(check.code, BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE, '形状 ' + JSON.stringify(shape) + ' 应判 PATCH_UNPARSEABLE');
+  }
+  // 合法 mapping 条目不受影响
+  const ok = writeHealthyBundle(base, 'fine-entry');
+  fs.writeFileSync(path.join(ok, 'cordis.patch.yml'), '- id: x\n  config: { a: 1 }\n', 'utf8');
+  assert.equal(validateBundleEntry('fine-entry', { installAnchorDir: base, profileDir: base, parsePatch: makeParser() }).ok, true);
+  // 不提供解析器：跳过（保守降级）
+  const dir = writeHealthyBundle(base, 'odd-entry-2');
+  fs.writeFileSync(path.join(dir, 'cordis.patch.yml'), '- 42\n', 'utf8');
+  assert.equal(validateBundleEntry('odd-entry-2', { installAnchorDir: base, profileDir: base, parsePatch: null }).ok, true);
+});
+
+test('resolveBundleDirLike: 与官方双锚点语义同构（第一锚点优先，其次 profile）', (t) => {
+  const base = tmpdir(t);
+  const installDir = path.join(base, 'install');
+  const profileDir = path.join(base, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  writeHealthyBundle(installDir, 'in-install');
+  writeHealthyBundle(profileDir, 'in-profile');
+  writeHealthyBundle(installDir, 'in-both');
+  writeHealthyBundle(profileDir, 'in-both');
+  const {
+    resolveBundleDirLike,
+  } = require('../../scripts/lib/profile-reconcile');
+  // 第一锚点命中（安装优先于 profile）
+  assert.equal(
+    resolveBundleDirLike(path.join(installDir, 'node_modules', '@deepseek-ai', 'dsh', 'package.json'), 'in-both'),
+    path.join(installDir, 'node_modules', 'in-both'),
+  );
+  // 仅 profile 锚点命中（第二锚点语义）
+  assert.equal(
+    resolveBundleDirLike(path.join(profileDir, 'package.json'), 'in-profile'),
+    path.join(profileDir, 'node_modules', 'in-profile'),
+  );
+  // 双锚点组合（validateBundleEntry 语义）：第一锚点不中 → 第二锚点命中
+  const first = resolveBundleDirLike(path.join(installDir, 'node_modules', '@deepseek-ai', 'dsh', 'package.json'), 'in-profile');
+  const second = resolveBundleDirLike(path.join(profileDir, 'package.json'), 'in-profile');
+  assert.equal(first, '', '第一锚点不得命中 profile 内的包');
+  assert.ok(second, '第二锚点应命中');
+  // 都不中 → 空串
+  assert.equal(
+    resolveBundleDirLike(path.join(installDir, 'node_modules', '@deepseek-ai', 'dsh', 'package.json'), 'ghost'),
+    '',
+  );
+  assert.equal(resolveBundleDirLike(path.join(profileDir, 'package.json'), 'ghost'), '');
+  // 空锚点目录（CLI 未定位 dsh 包）→ 空串（不抛错）
+  assert.equal(resolveBundleDirLike('', 'anything'), '');
+});
+
+// ---------------------------------------------------------------------------
+// reconcileProfileBundles：健康零写入
+// ---------------------------------------------------------------------------
+
+test('reconcile: 健康 manifest 零写入（幂等）', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  for (const name of ['extra-bundle']) writeHealthyBundle(profileDir, name);
+  const before = {
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'extra-bundle'] } },
+  };
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify(before, null, 2) + '\n');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: (m) => logs.push(m),
+  });
+  assert.equal(r.changed, false);
+  assert.equal(r.removed.length, 0);
+  assert.deepEqual(logs, []);
+  assert.deepEqual(readManifest(profileDir), before, '健康 manifest 应逐字节不变');
+  assert.equal(fs.existsSync(recordFile(profileDir)), false, '不应产生隔离记录');
+});
+
+// ---------------------------------------------------------------------------
+// reconcileProfileBundles：无效登记移除 + 隔离记录
+// ---------------------------------------------------------------------------
+
+test('reconcile: 无效非核心登记移除并记入隔离记录；核心异常保留', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  // 用户反馈形状：纯客户端 bundle 被登记进 profile.bundles
+  const clientOnly = path.join(profileDir, 'node_modules', '@dsh-external', 'dsh-hub-like');
+  fs.mkdirSync(clientOnly, { recursive: true });
+  fs.writeFileSync(path.join(clientOnly, 'package.json'), JSON.stringify({
+    name: '@dsh-external/dsh-hub-like', version: '1.0.0', main: 'lib/index.js',
+    dsh: { client: { platform: 'web' } },
+  }, null, 2) + '\n');
+  // 未安装的登记（ghost-bundle）
+  // 核心之一损坏（补丁层缺失）→ 必须保留
+  const brokenCore = path.join(installDir, 'node_modules', ...CORES[0].split('/'));
+  fs.rmSync(path.join(brokenCore, 'cordis.patch.yml'));
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true, dependencies: {},
+    dsh: { profile: { bundles: [...CORES, '@dsh-external/dsh-hub-like', 'ghost-bundle'] } },
+  }, null, 2) + '\n');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: (m) => logs.push(m),
+  });
+  assert.equal(r.changed, true);
+  const removedNames = r.removed.map((x) => x.name);
+  assert.deepEqual(removedNames, ['@dsh-external/dsh-hub-like', 'ghost-bundle']);
+  for (const item of r.removed) {
+    assert.equal(typeof item.code, 'string', '失败码必须是字符串（防常量缺失静默变 undefined）');
+    assert.notEqual(item.code, '', '失败码不得为空串');
+  }
+  assert.equal(r.removed.find((x) => x.name === '@dsh-external/dsh-hub-like').code, BUNDLE_CHECK_CODES.NO_BUNDLE_DECL);
+  assert.equal(r.removed.find((x) => x.name === 'ghost-bundle').code, BUNDLE_CHECK_CODES.UNRESOLVABLE);
+  const manifest = readManifest(profileDir);
+  assert.deepEqual(manifest.dsh.profile.bundles, CORES, '核心应保留（含损坏的核心），无效登记移除');
+  assert.ok(logs.some((m) => m.includes('核心 bundle 登记异常（保留')), '核心异常应有保留告警');
+  assert.ok(logs.some((m) => m.includes('已把无效的 profile bundle 登记移除: @dsh-external/dsh-hub-like')), '移除应有诊断日志');
+  const record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && record.entries['@dsh-external/dsh-hub-like'], '隔离记录应写入');
+  assert.equal(record.entries['@dsh-external/dsh-hub-like'].code, BUNDLE_CHECK_CODES.NO_BUNDLE_DECL);
+  assert.ok(record.entries['ghost-bundle'], '未安装登记也应记录');
+});
+
+test('reconcile: 补丁层 YAML 损坏（parsePatch 提供时）移除；bundle 文件不修改', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  const broken = writeHealthyBundle(profileDir, 'broken-patch');
+  const brokenText = '- id: [BAD\n';
+  fs.writeFileSync(path.join(broken, 'cordis.patch.yml'), brokenText, 'utf8');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'broken-patch'] } },
+  }, null, 2) + '\n');
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: makeParser(),
+    log: () => {},
+  });
+  assert.equal(r.removed[0].code, BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE);
+  assert.equal(fs.readFileSync(path.join(broken, 'cordis.patch.yml'), 'utf8'), brokenText, 'bundle 文件绝不修改');
+  // 不提供解析器：跳过可解析性检查 → 该登记保留（运行时防护兜底）
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'broken-patch'] } },
+  }, null, 2) + '\n');
+  const r2 = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.equal(r2.changed, false, '无解析器时不应移除（保守降级）');
+});
+
+// ---------------------------------------------------------------------------
+// reconcileProfileBundles：损坏重建 / 核心预写
+// ---------------------------------------------------------------------------
+
+test('reconcile: 损坏 manifest 备份重建（核心可解析时），原文保留在 .broken- 备份', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  const corrupt = '{"name": "dsh-profile-web", "dsh": {"profile": {"bundles": [';
+  fs.writeFileSync(path.join(profileDir, 'package.json'), corrupt, 'utf8');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: (m) => logs.push(m),
+  });
+  assert.equal(r.reset, true);
+  assert.ok(r.backup && fs.existsSync(r.backup), '应产生 .broken- 备份');
+  assert.equal(fs.readFileSync(r.backup, 'utf8'), corrupt, '备份内容应为原文');
+  assert.deepEqual(readManifest(profileDir).dsh.profile.bundles, CORES, '重建后应含核心 bundles');
+  assert.ok(logs.some((m) => m.includes('profile manifest 损坏，原文件已备份到')));
+  assert.ok(logs.some((m) => m.includes('未发现需要恢复的用户 bundle')));
+});
+
+test('reconcile: 损坏 manifest + 核心不可解析：不落盘空骨架（保持磁盘原样）', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t); // 无任何 dsh 包
+  const corrupt = '{"name": "dsh-profile-web", BAD';
+  const file = path.join(profileDir, 'package.json');
+  fs.writeFileSync(file, corrupt, 'utf8');
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.equal(r.changed, false, '核心不可解析时不得写任何东西');
+  assert.equal(r.backup, null, '不落盘则不产生备份');
+  assert.equal(fs.readFileSync(file, 'utf8'), corrupt, '磁盘文件应原样保留');
+});
+
+test('reconcile: manifest 缺失 + initMissing=true 且核心可解析 → 预写核心', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.equal(r.changed, true);
+  assert.deepEqual(readManifest(profileDir).dsh.profile.bundles, CORES);
+});
+
+test('reconcile: CLI 契约（initMissing=false）——缺失 manifest 不创建', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    addNames: new Set(['extra-bundle']),
+    parsePatch: null,
+    initMissing: false,
+    log: (m) => logs.push(m),
+  });
+  assert.equal(r.changed, false);
+  assert.equal(fs.existsSync(path.join(profileDir, 'package.json')), false, 'CLI 不得凭空创建 manifest');
+  assert.ok(logs.some((m) => m.includes('bundle 插件留待下次运行注册')), '应提示留待下次注册');
+});
+
+// ---------------------------------------------------------------------------
+// reconcileProfileBundles：配套登记追加 / 源缺失 / 卸载标记 / 恢复
+// ---------------------------------------------------------------------------
+
+test('reconcile: 配套追加 / 源缺失移除 / 卸载标记移除各自生效', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  writeHealthyBundle(profileDir, 'companion-a');
+  writeHealthyBundle(profileDir, 'companion-b');
+  writeHealthyBundle(profileDir, 'companion-c');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'companion-a', 'companion-b'] } },
+  }, null, 2) + '\n');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    addNames: new Set(['companion-a', 'companion-c']),
+    missingNames: new Set(['companion-b']),
+    removedBundles: new Set(['companion-a']),
+    parsePatch: null,
+    log: (m) => logs.push(m),
+  });
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.added, ['companion-c']);
+  assert.deepEqual(r.removedByPolicy, ['companion-b', 'companion-a']);
+  assert.deepEqual(readManifest(profileDir).dsh.profile.bundles, [...CORES, 'companion-c']);
+  assert.ok(logs.some((m) => m === '已把 bundle 插件加入 web profile bundles: companion-c'));
+  assert.ok(logs.some((m) => m === '配套 bundle 源缺失，已从 web profile bundles 移除（视为禁用）: companion-b'));
+  assert.ok(logs.some((m) => m === '已卸载 bundle 插件，从 web profile bundles 移除: companion-a'));
+});
+
+test('reconcile: addNames 配套 bundle 校验失败（补丁层 YAML 损坏）→ 不登记 + 隔离记录', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  // 配套 bundle 文件齐全（调用方 verifyBundleDir 会通过），但补丁层 YAML 损坏
+  const bad = writeHealthyBundle(profileDir, 'companion-bad');
+  fs.writeFileSync(path.join(bad, 'cordis.patch.yml'), '- id: [BAD\n', 'utf8');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES] } },
+  }, null, 2) + '\n');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    addNames: new Set(['companion-bad']),
+    parsePatch: makeParser(),
+    log: (m) => logs.push(m),
+  });
+  assert.equal(r.changed, false, 'manifest 未被改动（该名从未被登记，不得做内容相同的无意义重写）');
+  assert.deepEqual(r.quarantined, ['companion-bad']);
+  assert.deepEqual(r.added, [], 'YAML 损坏的配套 bundle 不得登记');
+  assert.equal(r.removed[0].code, BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE);
+  assert.ok(!readManifest(profileDir).dsh.profile.bundles.includes('companion-bad'), 'manifest 不得包含该登记');
+  const record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && record.entries['companion-bad'], '隔离记录应记下拒绝原因');
+  assert.equal(record.entries['companion-bad'].code, BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE);
+  assert.ok(logs.some((m) => m.includes('配套 bundle 校验失败，不登记进 web profile bundles: companion-bad')), '应有拒绝登记诊断日志');
+  // 不提供解析器：跳过可解析性检查 → 登记成功（保守降级）
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES] } },
+  }, null, 2) + '\n');
+  const r2 = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    addNames: new Set(['companion-bad']),
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.deepEqual(r2.added, ['companion-bad'], '无解析器时保守降级登记');
+});
+
+test('reconcile: 损坏重建后恢复用户 bundle（issue #48），普通依赖不恢复', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  writeHealthyBundle(profileDir, '@dsh-external/user-bundle');
+  const plainDir = path.join(profileDir, 'node_modules', '@dsh-external', 'plain-lib');
+  fs.mkdirSync(plainDir, { recursive: true });
+  fs.writeFileSync(path.join(plainDir, 'package.json'), JSON.stringify({ name: '@dsh-external/plain-lib', version: '1.0.0' }, null, 2) + '\n');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), '{"name": "dsh-profile-web", BAD', 'utf8');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    excludeFromRecover: new Set([...CORES, 'companion-a']),
+    parsePatch: null,
+    log: (m) => logs.push(m),
+  });
+  assert.deepEqual(r.recovered, ['@dsh-external/user-bundle']);
+  const manifest = readManifest(profileDir);
+  assert.ok(manifest.dsh.profile.bundles.includes('@dsh-external/user-bundle'));
+  assert.ok(!manifest.dsh.profile.bundles.includes('@dsh-external/plain-lib'), '普通依赖不得恢复登记');
+  assert.equal(manifest.dependencies['@dsh-external/user-bundle'], '1.0.0', 'dependencies 应补回');
+  assert.ok(logs.some((m) => m.includes('已恢复用户安装的 bundle 插件')));
+});
+
+test('reconcile: 恢复的 bundle 复检失败（补丁层 YAML 损坏）→ 移除恢复登记 + 隔离记录', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  // 用户第三方 bundle 文件齐全（scanProfileBundles 的 verifyBundleDir 会通过）
+  // 但补丁层 YAML 损坏 → 复检必须拒绝恢复登记
+  const bad = writeHealthyBundle(profileDir, '@dsh-external/broken-user-bundle');
+  fs.writeFileSync(path.join(bad, 'cordis.patch.yml'), '- id: [BAD\n', 'utf8');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), '{"name": "dsh-profile-web", BAD', 'utf8');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: makeParser(),
+    log: (m) => logs.push(m),
+  });
+  assert.deepEqual(r.recovered, [], 'YAML 损坏的 bundle 不得恢复登记');
+  assert.equal(r.removed[0].code, BUNDLE_CHECK_CODES.PATCH_UNPARSEABLE);
+  const manifest = readManifest(profileDir);
+  assert.ok(!manifest.dsh.profile.bundles.includes('@dsh-external/broken-user-bundle'), 'manifest 不得包含复检失败的恢复登记');
+  const record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && record.entries['@dsh-external/broken-user-bundle'], '隔离记录应记下复检失败');
+  assert.ok(logs.some((m) => m.includes('恢复的 bundle 复检失败')), '应有复检失败诊断日志');
+  // 不提供解析器：跳过可解析性检查 → 恢复登记（保守降级）
+  fs.writeFileSync(path.join(profileDir, 'package.json'), '{"name": "dsh-profile-web", BAD', 'utf8');
+  const r2 = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.deepEqual(r2.recovered, ['@dsh-external/broken-user-bundle'], '无解析器时保守降级恢复');
+});
+
+test('reconcile: 策略性移除的名字（源缺失 / 卸载标记）不进隔离记录，由步骤 4/6 按用户意图禁用移除', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  // 已卸载配套：包目录已被插件管理删除（manifest 残留登记）→ 只能判
+  // UNRESOLVABLE，但这是用户主动卸载，绝不能写入隔离记录（记录只描述无效
+  // 登记，不描述用户意图）
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'uninstalled-bundle', 'source-missing-bundle'] } },
+  }, null, 2) + '\n');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    missingNames: new Set(['source-missing-bundle']),
+    removedBundles: new Set(['uninstalled-bundle']),
+    parsePatch: null,
+    log: (m) => logs.push(m),
+  });
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.removed, [], '策略性移除不进逐条校验移除列表');
+  assert.deepEqual(r.quarantined, [], '策略性移除不得写入隔离记录');
+  assert.deepEqual(r.removedByPolicy, ['source-missing-bundle', 'uninstalled-bundle']);
+  assert.deepEqual(readManifest(profileDir).dsh.profile.bundles, CORES);
+  assert.equal(fs.existsSync(recordFile(profileDir)), false, '不得产生隔离记录文件');
+  assert.ok(!logs.some((m) => m.includes('已把无效的 profile bundle 登记移除')), '不得出现无效登记移除诊断');
+  assert.ok(logs.some((m) => m.includes('配套 bundle 源缺失，已从 web profile bundles 移除（视为禁用）: source-missing-bundle')));
+  assert.ok(logs.some((m) => m === '已卸载 bundle 插件，从 web profile bundles 移除: uninstalled-bundle'));
+});
+
+test('reconcile: addNames 失败记录在同轮登记成功时立即清除（不必等下一次启动）', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES] } },
+  }, null, 2) + '\n');
+  // run 1：YAML 损坏 → 不登记 + 记录
+  const bad = writeHealthyBundle(profileDir, 'fixable-bundle');
+  fs.writeFileSync(path.join(bad, 'cordis.patch.yml'), '- id: [BAD\n', 'utf8');
+  reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir, coreNames: CORES,
+    addNames: new Set(['fixable-bundle']), parsePatch: makeParser(), log: () => {},
+  });
+  let record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && record.entries['fixable-bundle'], '失败应产生记录');
+  // run 2：文件修复（重装）→ 登记成功 → 同轮清除记录
+  fs.writeFileSync(path.join(bad, 'cordis.patch.yml'), '[]\n', 'utf8');
+  const r2 = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir, coreNames: CORES,
+    addNames: new Set(['fixable-bundle']), parsePatch: makeParser(), log: () => {},
+  });
+  assert.deepEqual(r2.added, ['fixable-bundle']);
+  assert.deepEqual(r2.unquarantined, ['fixable-bundle'], '登记成功应同轮解除隔离记录');
+  record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && !record.entries['fixable-bundle'], '同轮记录应已清除');
+});
+
+test('reconcile: 重复的同类失败不重写隔离记录（保留首次 removedAt，无写入放大）', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  const bad = writeHealthyBundle(profileDir, 'stuck-bundle');
+  fs.writeFileSync(path.join(bad, 'cordis.patch.yml'), '- id: [BAD\n', 'utf8');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES] } },
+  }, null, 2) + '\n');
+  reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir, coreNames: CORES,
+    addNames: new Set(['stuck-bundle']), parsePatch: makeParser(), log: () => {},
+  });
+  const first = fs.readFileSync(recordFile(profileDir), 'utf8');
+  const firstRecord = JSON.parse(first);
+  // 第二次：同 code + reason → 不得重写记录（removedAt 保持首次值）
+  reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir, coreNames: CORES,
+    addNames: new Set(['stuck-bundle']), parsePatch: makeParser(), log: () => {},
+  });
+  const second = fs.readFileSync(recordFile(profileDir), 'utf8');
+  assert.equal(second, first, '同类失败重复运行不得重写隔离记录');
+  assert.equal(JSON.parse(second).entries['stuck-bundle'].removedAt, firstRecord.entries['stuck-bundle'].removedAt);
+});
+
+test('reconcile: 重置恢复成功的 bundle 同轮清除历史隔离记录', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  // 历史场景：bundle 曾损坏被隔离记录；现文件已修复（健康），且 manifest 损坏
+  writeHealthyBundle(profileDir, '@dsh-external/fixed-user-bundle');
+  // 预置一条历史隔离记录
+  fs.writeFileSync(recordFile(profileDir), JSON.stringify({
+    v: 1,
+    entries: {
+      '@dsh-external/fixed-user-bundle': {
+        code: BUNDLE_CHECK_CODES.ENTRY_MISSING, reason: '入口文件缺失: lib/index.js',
+        removedAt: '2026-01-01T00:00:00.000Z',
+      },
+    },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), '{"name": "dsh-profile-web", BAD', 'utf8');
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    excludeFromRecover: new Set(CORES),
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.deepEqual(r.recovered, ['@dsh-external/fixed-user-bundle']);
+  assert.deepEqual(r.unquarantined, ['@dsh-external/fixed-user-bundle'], '恢复成功应同轮解除隔离记录');
+  const record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && !record.entries['@dsh-external/fixed-user-bundle'], '历史隔离记录应已清除');
+});
+
+test('reconcile: 重复登记的 bundle 去重（保留首次出现，不进隔离记录）', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  writeHealthyBundle(profileDir, 'dup-bundle');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'dup-bundle', 'dup-bundle', 'ghost-bundle'] } },
+  }, null, 2) + '\n');
+  const logs = [];
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: (m) => logs.push(m),
+  });
+  assert.deepEqual(r.deduped, ['dup-bundle']);
+  assert.deepEqual(readManifest(profileDir).dsh.profile.bundles, [...CORES, 'dup-bundle'], '重复项应移除且只保留首次出现');
+  assert.ok(logs.some((m) => m.includes('已移除重复登记的 profile bundle: dup-bundle')), '应有去重诊断日志');
+  const record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(!record || !record.entries['dup-bundle'], '重复登记是冗余而非无效登记，不得写入隔离记录');
+  assert.ok(record && record.entries['ghost-bundle'], '同轮无效登记照常隔离');
+  // 幂等：二次运行零写入
+  const afterFirst = fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8');
+  const r2 = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir, coreNames: CORES, parsePatch: null, log: () => {},
+  });
+  assert.equal(r2.changed, false);
+  assert.equal(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'), afterFirst);
+});
+
+// ---------------------------------------------------------------------------
+// reconcileProfileBundles：dry-run / 隔离记录生命周期
+// ---------------------------------------------------------------------------
+
+test('reconcile: dry-run 只计算不落盘', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  const before = {
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'ghost-bundle'] } },
+  };
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify(before, null, 2) + '\n');
+  const r = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    dryRun: true,
+    log: () => {},
+  });
+  assert.equal(r.changed, true, 'dry-run 仍应报告将发生的修改');
+  assert.deepEqual(r.removed.map((x) => x.name), ['ghost-bundle']);
+  assert.deepEqual(readManifest(profileDir), before, 'dry-run 不得落盘');
+  assert.equal(fs.existsSync(recordFile(profileDir)), false, 'dry-run 不得写隔离记录');
+});
+
+test('reconcile: 恢复健康后隔离记录清除；记录文件损坏容错', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  const installDir = tmpdir(t);
+  for (const name of CORES) writeHealthyBundle(installDir, name);
+  // 先移除一次（产生记录）
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'fixable-bundle'] } },
+  }, null, 2) + '\n');
+  reconcileProfileBundles(profileDir, { installAnchorDir: installDir, coreNames: CORES, parsePatch: null, log: () => {} });
+  let record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && record.entries['fixable-bundle'], '首次移除应产生记录');
+
+  // 模拟重装：包恢复健康 + 重新登记 → 记录清除
+  writeHealthyBundle(profileDir, 'fixable-bundle');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'fixable-bundle'] } },
+  }, null, 2) + '\n');
+  const r2 = reconcileProfileBundles(profileDir, {
+    installAnchorDir: installDir,
+    coreNames: CORES,
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.deepEqual(r2.unquarantined, ['fixable-bundle']);
+  record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && !record.entries['fixable-bundle'], '恢复健康后记录应清除');
+
+  // 记录文件损坏：按无记录处理，移除时重建
+  fs.writeFileSync(recordFile(profileDir), '{BAD JSON', 'utf8');
+  assert.equal(readBrokenBundlesRecord(recordFile(profileDir)), null, '损坏记录应视为缺失');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true,
+    dsh: { profile: { bundles: [...CORES, 'ghost-again'] } },
+  }, null, 2) + '\n');
+  reconcileProfileBundles(profileDir, { installAnchorDir: installDir, coreNames: CORES, parsePatch: null, log: () => {} });
+  record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.ok(record && record.entries['ghost-again'], '损坏记录应被重建');
+  assert.equal(record.v, 1);
+});
+
+// ---------------------------------------------------------------------------
+// 真实 dsh-app-boot 复现（仓库 node_modules 已安装时执行）
+// ---------------------------------------------------------------------------
+
+test('真实 dsh-app-boot：无 dsh.bundle 声明登记必崩（用户反馈原始错误），对账后正常装配', async (t) => {
+  const appBootIndex = path.join(repoRoot, 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js');
+  const dshAnchor = path.join(repoRoot, 'node_modules', '@deepseek-ai', 'dsh', 'package.json');
+  if (!fs.existsSync(appBootIndex) || !fs.existsSync(dshAnchor)) {
+    t.skip('仓库 node_modules 未安装（npm install），跳过真实 dsh-app-boot 验证');
+    return;
+  }
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'pbr-real-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const profileDir = path.join(home, 'profiles', 'web');
+  // 用户反馈形状：dsh-hub 是纯客户端 bundle（只声明 dsh.client），被登记进
+  // dsh.profile.bundles → 官方 loadProfile 抛 "declares no dsh.bundle"。
+  const clientOnly = path.join(profileDir, 'node_modules', '@dsh-external', 'gold-luxe');
+  fs.mkdirSync(path.join(clientOnly, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(clientOnly, 'package.json'), JSON.stringify({
+    name: '@dsh-external/gold-luxe', version: '1.0.0', main: 'lib/index.js',
+    dsh: { client: { platform: 'web', inject: ['@deepseek-ai/dsh-client-runtime'] } },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(clientOnly, 'lib', 'index.js'), 'export {};\n');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true, dependencies: {},
+    dsh: { profile: { bundles: [...CORES, '@dsh-external/gold-luxe'] } },
+  }, null, 2) + '\n');
+
+  const mod = await import(pathToFileURL(appBootIndex).href);
+  const guarded = fs.readFileSync(appBootIndex, 'utf8').includes('dsh-desktop guard: a broken profile bundle must not brick');
+  // 1. 未打防护补丁的官方 loadProfile 对无 dsh.bundle.patch 的登记 fail-loud
+  //    （同步抛错）——即用户「dsh web 启动失败（退出码 1）」的原始错误。
+  //    已打补丁（集成测试跑过、guard 已注入）时该形状被跳过而非崩溃，两种
+  //    状态都给出有意义断言。
+  if (!guarded) {
+    assert.throws(
+      () => mod.loadProfile('dsh', 'web', dshAnchor, home),
+      /declares no dsh\.bundle/,
+    );
+  } else {
+    const pre = mod.loadProfile('dsh', 'web', dshAnchor, home);
+    const layer = pre.layers.find((l) => l.packageName === '@dsh-external/gold-luxe');
+    assert.ok(layer && layer.packageDir === null && Array.isArray(layer.patches) && layer.patches.length === 0,
+      'guard 已注入时该层应被跳过（packageDir=null、无补丁）');
+  }
+  // 2. 对账后：无效登记移除，loadProfile 正常装配核心 bundles。
+  reconcileProfileBundles(profileDir, {
+    installAnchorDir: path.dirname(dshAnchor),
+    coreNames: CORES,
+    parsePatch: null,
+    log: () => {},
+  });
+  const profile = mod.loadProfile('dsh', 'web', dshAnchor, home);
+  assert.deepEqual(profile.layers.map((l) => l.packageName), CORES, '对账后应只剩核心 bundles 且全部可装配');
+  const manifest = readManifest(profileDir);
+  assert.ok(!manifest.dsh.profile.bundles.includes('@dsh-external/gold-luxe'), '无效登记应已移除');
+  const record = readBrokenBundlesRecord(recordFile(profileDir));
+  assert.equal(record.entries['@dsh-external/gold-luxe'].code, BUNDLE_CHECK_CODES.NO_BUNDLE_DECL, '隔离记录应记录移除原因');
+});
+
+test('真实 dsh-app-boot：入口文件缺失（guard 覆盖不到的崩溃形状）由对账消除', async (t) => {
+  const appBootIndex = path.join(repoRoot, 'node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js');
+  const dshAnchor = path.join(repoRoot, 'node_modules', '@deepseek-ai', 'dsh', 'package.json');
+  if (!fs.existsSync(appBootIndex) || !fs.existsSync(dshAnchor)) {
+    t.skip('仓库 node_modules 未安装（npm install），跳过真实 dsh-app-boot 验证');
+    return;
+  }
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'pbr-real2-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const profileDir = path.join(home, 'profiles', 'web');
+  // 声明 dsh.bundle.patch + main，但入口文件缺失：loadProfile 层面检查不到
+  //（它只读补丁层），崩溃发生在 loader 激活期（plugin tree failed to load）。
+  const missingEntry = path.join(profileDir, 'node_modules', '@dsh-external', 'ghost-entry');
+  fs.mkdirSync(missingEntry, { recursive: true });
+  fs.writeFileSync(path.join(missingEntry, 'package.json'), JSON.stringify({
+    name: '@dsh-external/ghost-entry', version: '1.0.0', main: 'lib/index.js',
+    dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }, null, 2) + '\n');
+  fs.writeFileSync(path.join(missingEntry, 'cordis.patch.yml'), '[]\n');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true, dependencies: {},
+    dsh: { profile: { bundles: [...CORES, '@dsh-external/ghost-entry'] } },
+  }, null, 2) + '\n');
+  const mod = await import(pathToFileURL(appBootIndex).href);
+  // loadProfile 本身不报错（该形状在防护之外）；对账能识别并移除。
+  reconcileProfileBundles(profileDir, {
+    installAnchorDir: path.dirname(dshAnchor),
+    coreNames: CORES,
+    parsePatch: null,
+    log: () => {},
+  });
+  assert.equal(readBrokenBundlesRecord(recordFile(profileDir)).entries['@dsh-external/ghost-entry'].code, BUNDLE_CHECK_CODES.ENTRY_MISSING);
+  const profile = mod.loadProfile('dsh', 'web', dshAnchor, home);
+  assert.deepEqual(profile.layers.map((l) => l.packageName), CORES);
+});
+
+test('createEntryListYamlParser: 与 dsh 方言同构（!!js 合法、损坏抛错）', () => {
+  const parse = createEntryListYamlParser();
+  assert.ok(typeof parse === 'function' || parse === null, 'js-yaml 存在时返回解析器，否则 null');
+  if (parse) {
+    assert.deepEqual(parse('[]\n'), []);
+    const withJs = parse('- id: x\n  config: !!js "({a: 1})"\n');
+    assert.equal(withJs[0].config.__jsExpr, '({a: 1})');
+    assert.throws(() => parse('- id: [BAD\n'), '损坏 YAML 应抛错');
+  }
+});

--- a/dsh-desktop/scripts/test/unit-sync-cli.test.js
+++ b/dsh-desktop/scripts/test/unit-sync-cli.test.js
@@ -33,13 +33,22 @@ function tmpdir(t) {
 
 function runCli(t, home, extraArgs = []) {
   // 输出不经过管道（沙箱限制），只断言落盘结果。
+  // PATH 收口到 System32：CLI 的 findDshPackageDir 会经 PATH 探测 `dsh` 命令，
+  // 环境 PATH 上的真实 dsh（如 harness 安装）会被当作预设同步目标，把
+  // assets/agent-presets 写进真实安装（内容相同、mtime 被改写）——测试必须
+  // 封闭，绝不触碰真实环境。System32 保证 where.exe（commandLocations 用）
+  // 可用。
   const res = spawnSync(process.execPath, [cli, home, ...extraArgs], {
     cwd: repoRoot,
     encoding: 'utf8',
     windowsHide: true,
     timeout: 300000,
     stdio: 'ignore',
-    env: { ...process.env, DSH_HOME: '' },
+    env: {
+      ...process.env,
+      DSH_HOME: '',
+      PATH: process.env.SystemRoot ? path.join(process.env.SystemRoot, 'System32') : '',
+    },
   });
   assert.strictEqual(res.status, 0, `CLI 应正常退出（signal=${res.signal}）`);
 }
@@ -143,4 +152,28 @@ test('sync CLI: 尊重用户手写 disabled 条目，不重复 insert', (t) => {
   assert.strictEqual((patch.match(/id: balance/g) || []).length, 1, '用户禁用的插件不得再 insert');
   assert.ok(patch.includes('disabled: true'), '用户禁用条目原样保留');
   assert.ok(patch.includes('- id: file-changes'), '其它插件照常注册');
+});
+
+test('sync CLI: 卸载标记（removed: true）的配套 bundle 从 manifest 移除，且不进隔离记录', (t) => {
+  const home = tmpdir(t);
+  const profileDir = path.join(home, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  // 预置 manifest：核心 + 已卸载的 balance 配套（残留登记，包目录已被删）
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web', private: true, dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@deepseek-ai/dsh-balance'] } },
+  }, null, 2) + '\n');
+  // 卸载标记（插件管理写入的形态）
+  fs.writeFileSync(path.join(profileDir, 'cordis.patch.yml'),
+    '# dsh web profile patch（由 DSH Desktop 维护）\n- id: balance\n  removed: true\n');
+  runCli(t, home);
+  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  assert.ok(!manifest.dsh.profile.bundles.includes('@deepseek-ai/dsh-balance'), '已卸载的配套 bundle 应从 manifest 移除');
+  assert.ok(manifest.dsh.profile.bundles.includes('@deepseek-ai/dsh-base'), '核心登记不得受影响');
+  assert.ok(!fs.existsSync(path.join(profileDir, 'dsh-desktop.broken-bundles.json')),
+    '卸载属用户主动意图，不得写入隔离记录');
+  // 幂等：二次运行 manifest 不再改动（已移除的登记不得被重新加回）
+  const afterFirst = fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8');
+  runCli(t, home);
+  assert.strictEqual(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'), afterFirst, '二次同步 manifest 零写入');
 });


### PR DESCRIPTION
## 动机

用户反馈 `dsh web` 启动失败（退出码 1）：`Error: dsh: profile bundle "dsh-hub" declares no dsh.bundle in its package.json`，且「此类问题已出现多次、每次形态不同」。

根因分析（基于 dsh-app-boot 实测源码）：`loadProfile` 对 `dsh.profile.bundles` 的每一条登记执行严格装配（包可解析 + 声明 `dsh.bundle.patch` + 补丁层可解析），任一不满足即以退出码 1 失败；入口缺失则在更晚的 Loader 激活期以 `plugin tree failed to load` / `N entries did not activate` 崩溃。现有防线均存在覆盖缺口：

- **锚点防护**（`profile-bundle-heal.js` 的启动前锚点改写）：锚点随 dsh 版本变化失配即**静默失效**，原始 fail-loud 崩溃直接暴露；且只读补丁层、不查入口，入口缺失形状在覆盖之外（实测确认）。
- **启动自愈**（`scanBundleContracts` / `removeBundlesFromProfile`，最新主线已合入）：只处理「缺 `dsh.bundle.patch` 声明」一种形状，且发生在 boot 失败/成功**之后**——补丁层损坏、入口缺失/指向目录、重复登记（`duplicate loader entry id`）等形状仍在覆盖之外。
- **manifest 从不被真正修复**：跳过 + 保留的登记永久残留，每次启动都依赖防护命中。

本 PR 把「启动前把 manifest 对账到『每条登记都可装配』」收口为**唯一实现**，在 dsh web 启动前修复数据本身（根治）；锚点防护与主线自愈保留为纵深防御与兜底（对账后它们保持无操作）。

## 方案

### 1. 对账唯一实现 `scripts/lib/profile-reconcile.js`（纯 Node 无 Electron 依赖；main.js 与 sync CLI 共用）

- **逐条校验（11 种结构化失败码）**，与官方装配契约一一对应：`INVALID_NAME` / `UNRESOLVABLE` / `PACKAGE_JSON_INVALID` / `NO_BUNDLE_DECL` / `PATCH_OUTSIDE` / `PATCH_MISSING` / `PATCH_UNPARSEABLE` / `ENTRY_OUTSIDE` / `ENTRY_MISSING` / `CLIENT_ENTRY_OUTSIDE` / `CLIENT_ENTRY_MISSING`；
- **包解析与官方 `resolveBundleDir` 同构**（`createRequire.resolve.paths` 双锚点探测，含 NODE_PATH / 全局 node_modules）——官方能装配的登记绝不被误删（此前只走祖先 node_modules 的实现会误删 NODE_PATH 安装的健康包）；
- **补丁层条目级校验与官方 `parsePatchList` 同构**（顶层数组且每项为映射）——`- 42` / `- null` 等畸形文件官方必抛 `must be a mapping`，只查顶层数组会放过；
- **入口必须是普通文件**（`main: "./lib"` 指向目录在激活期必抛 `ERR_UNSUPPORTED_DIR_IMPORT`，`existsSync` 会放过；符号链接跟随解析不受影响）；
- **client 入口校验**（`exports["./client"]`，dshmarket 形状）：吸收自主线 `verifyBundleDir` 新增校验，reason 文案与主线逐字一致，并在对账侧收口为结构化失败码（存量坏登记同样在启动前清除，不再等到 client-modules 装配期 `MissingClientBundleError`）；
- **重复登记去重**：同一包名登记两次会让补丁层条目重复出现在组合 entry list，loader 必抛 `duplicate loader entry id`（防护覆盖不到）；对账保留首次出现、移除重复项（冗余而非无效登记，不进隔离记录）；
- **无效且非核心的登记**：从 manifest 移除 + 写入隔离记录 `dsh-desktop.broken-bundles.json`（结构化失败码 + 中文原因 + 时间；dsh 完全不感知该文件；重装插件并重新登记即恢复装配，恢复健康后记录**自动清除**；同 code+reason 不重写、登记/恢复成功同轮清除）；原 manifest 在修改前备份（`.broken-<ts>`），损坏重建场景永不丢用户现场；
- **核心 bundles 校验失败绝不移除**（`@deepseek-ai/dsh-base` / `dsh-web-app`）：核心缺失是安装损坏而非 profile 数据问题，移除只会让插件树更糟——保留并由启动防护兜底跳过 + 告警；
- **既有语义逐项保留**：损坏 manifest 备份重建（仅核心可解析时落盘）、核心补齐（issue #16）、配套登记追加（追加前全量校验，失败不登记 + 隔离记录）、源缺失/卸载标记移除（用户主动意图，不进隔离记录）、重置后用户 bundle 恢复（issue #48，恢复后复检）；健康 manifest **零写入**（幂等）；写入全部原子化（临时文件 + rename）；`dryRun` 只计算不落盘；
- **CLI 与壳层同口径**：`initMissing=false` 保持「不凭空创建 manifest」历史契约；补 `removedBundles` / `excludeFromRecover`（此前 CLI 不移除已卸载配套、重置恢复可能复活用户卸载的插件）。

### 2. `profile-bundle-heal.js`

- 提取 `inspectBundleDir` 为**唯一**结构化校验实现（对账、同步侧防呆、恢复扫描共用同一判定语义）；
- `verifyBundleDir` 变兼容包装：返回结构与 reason 文案不变（含主线新增的 client 入口校验文案），既有调用方与单测断言不受影响；
- 新增 `BUNDLE_CHECK_CODES`（11 码）与 `isPatchListValid`（与官方 `parsePatchList` 同构的条目级判定，`healProfilePatch` / `healHomePatch` 共用）。

### 3. `main.js`

- `syncCompanionPlugins` 的 manifest 段（约 100 行）收口为一次对账调用，**既有日志文案逐字保留**（集成断言零破坏）；
- 新增 `healHomePatch()`：启动 dsh web 前用同一 entry-list 方言预检 `$DSH_HOME/cordis.patch.yml`，损坏 → 备份 `.broken-<ts>` + 重置为最小合法文件（此前只由 profile-boot 锚点兜底；签名 memo 幂等、健康零写入）；
- `loadDshYamlDialect` 委托 `createEntryListYamlParser`（消除重复实现，诊断/体检/对账共用同一方言）；
- `logProfileBundleHealth` 改用与对账相同的 `resolveBundleDirLike` 双锚点解析（消除「对账判可解析、健康检查误报缺失」的口径撕裂）；删除死代码。

### 4. 与主线既有机制的互补（本 PR 基于最新 main 之上）

- 启动成功路径的 `runBundleContractMaintenance` 与 boot 失败兜底的 `scanBundleContracts` **原样保留**：对账已在启动前处理全部失败形状，正常启动下这两条路径保持无操作；旧世代 boot / 防护锚点失配等边界由它们兜底；
- 「诊断与管理」的防砖体检（`desktop-validity`）继续用于用户主动诊断，对账后的 manifest 天然满足其检查项（含跨包 loader id 冲突项——重复登记已被启动前去重）；
- bundle 顺序重排（`desktop-ordering`）不受影响：对账只做核心前置补齐 / 去重 / 移除 / 追加，不重排既有社区 bundle 的相对顺序。

## 行为变化（有意变更，根治点）

| 场景 | 变更前 | 变更后 |
|---|---|---|
| bundles 含未安装包 | 防护跳过、登记保留；锚点失配即崩 | 启动前移除 + 隔离记录 + 日志诊断，正常启动 |
| bundles 含无 `dsh.bundle.patch` 声明的包（dsh-hub 形状） | 同上（用户反馈的崩溃即此形状） | 同上 |
| 补丁层缺失/损坏/越界/条目非法 | 防护跳过（条目非法形状防护覆盖不到） | 对账移除 + 隔离记录 |
| 入口缺失 / 指向目录 | 防护覆盖不到，Loader 激活期崩溃 | 对账移除（ENTRY_MISSING）+ 隔离记录 |
| client 入口缺失（存量登记） | 装配期 MissingClientBundleError | 对账移除（CLIENT_ENTRY_MISSING）+ 隔离记录 |
| 重复登记 | loader `duplicate loader entry id` 崩溃 | 对账去重（保留首次出现，不进隔离记录） |
| 家级 `cordis.patch.yml` 损坏 | 仅 profile-boot 锚点兜底 | 启动前预检备份 + 重置，防护保留兜底 |
| 无效登记恢复健康（重装） | 无记录概念 | 隔离记录自动清除 |

## 测试（真实 Electron + 真实 dsh web，完全隔离）

- **隔离**：全部 DSH_HOME / userData 落临时目录；CLI 测试 PATH 收口到 System32（修复测试经 PATH 发现真实 dsh、把预设写进真实安装的缺陷——内容相同但 mtime 被改写）；测试全程未触碰真实 `~/.dsh` 与运行中的桌面端（前后快照比对：`%APPDATA%` 零变化）。
- **单测**：`unit-profile-reconcile.test.js` 25 项（11 种失败码逐项命中、parsePatch 双形态归一化、reconcile 全流程、隔离记录生命周期、dry-run 零落盘、**真实 dsh-app-boot 复现 ×2**——无效登记在官方 `loadProfile` 下必崩、对账后正常装配）；`unit-profile-bundle-heal` 含主线新增 client 入口 3 项断言；全套单测 **323/323 全绿**（vendored 补丁按仓库既有约定在集成测试后还原再执行；集成应用态下 `unit-patch-engine` 的 1 项「真实 vendored 文件」断言为仓库既有的环境依赖行为——见既有测试文档，非本次改动引入）。
- **集成**（真实 Electron + 真实 dsh web 启动）：装配链 12 场景 + 补丁链路回归 4 场景 **16/16 PASS**（boot-healthy / heal-missing-bundle / heal-manifestless-bundle / heal-broken-bundle-patch / heal-entry-missing-bundle / heal-dup-bundle / heal-dir-entry-bundle / heal-broken-home-patch / heal-stale-manifest / heal-broken-manifest / heal-broken-manifest-recovers / companion-bundle-invariant / heal-dup-patch / heal-bundle-patch / heal-dup-patch-keeps-config / runtime-patches-suite）。
- `check-syntax` 打包语法门全过。

## 变更文件

- 新增：`scripts/lib/profile-reconcile.js`、`scripts/test/unit-profile-reconcile.test.js`
- 修改：`profile-bundle-heal.js`、`main.js`、`scripts/sync-companion-plugins.js`、`scripts/check-syntax.js`、`scripts/test/integration-runner.js`、`scripts/test/unit-sync-cli.test.js`、`CHANGELOG.md`
