### PR TITLE
feat(sidebar): 侧边栏项目/会话行右键菜单新增「打开项目目录」

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-session-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-session-manager/lib/client.js
@@ -220,6 +220,15 @@ window.__ModuleLoader__.load({
 				unarchiveSession: (sessionId) => unarchiveSession(ctx, String(sessionId))
 			};
 
+			// 侧边栏「打开项目目录」桥（patch-open-project-dir.js 补丁的菜单项调用）：
+			// 走宿主 preload 的 window.dshDesktop.openPath（dsh:file-open IPC →
+			// shell.openPath），零新增 IPC；未来可无缝切换为 web 端实现。
+			window.__dshDesktopOpenDir = (cwd) => {
+				if (!cwd) return;
+				if (window.dshDesktop?.openPath) window.dshDesktop.openPath(cwd);
+				else console.warn('[open-project-dir] window.dshDesktop.openPath 不可用（cwd=' + cwd + '）');
+			};
+
 			ctx.slots.inject("settings.section", () => ctx.slots.register({
 				name: "settings.section",
 				id: NS,

--- a/dsh-desktop/docs/2026-08-18-sidebar-right-click-open-project-dir.md
+++ b/dsh-desktop/docs/2026-08-18-sidebar-right-click-open-project-dir.md
@@ -1,0 +1,200 @@
+# 侧边栏右键菜单「打开项目目录」方案
+
+> 日期：2026-08-18
+> 范围：DSH Desktop（`dsh-desktop/`）侧边栏工作区树的**项目行**与**项目对话（会话）行**
+> 目标：右键项目行/对话行弹出菜单，菜单内容 = 原右侧「⋮」三小点菜单 + 新增「打开项目目录」
+
+---
+
+## 1. 需求
+
+在侧边栏（工作区树）中：
+
+- 对**项目行**（Workspace 分组头，带文件夹图标）右键，弹出菜单。
+- 对**项目对话行**（会话行，带状态点）右键，弹出菜单。
+- 弹菜单内容复用原有「⋮」按钮菜单的全部条目，在末尾追加一项 **「打开项目目录」**：用系统资源管理器打开该项目目录。
+
+## 2. 现状调研（已核实）
+
+### 2.1 三小点菜单代码位置
+
+核心文件：`node_modules/@deepseek-ai/dsh-client-ui-workspace/lib/client.js`（官方包编译产物，与 `deepseek-ai/deepseek-harness` 仓库 `packages/client/ui-workspace` 对应）。
+
+| 行组件 | 函数 | 菜单项数组 | 说明 |
+|---|---|---|---|
+| 项目行 | `ProjectRowItem`（L454） | `workspaceMenuItems`（L459） | `rename` 改名、`delete` 删除 |
+| 会话行 | `SessionNodeItem`（L693） | `sessionMenuItems`（L700） | `rename` 改名、`fork` 分叉、`archive` 归档、`delete` 删除对话（本仓库 `patch-session-manage.js` 已加） |
+
+两处菜单都用 `Menu` 组件（`@deepseek-ai/dsh-client-ui-primitives`），anchor 是 `IconEllipsisOutline16`（⋮）按钮，`portal: true`、`closeOnPointerLeave: true`，`onSelect(id)` 分发：
+
+- 项目行：`if (id === "rename") actions.rename(); else actions.delete();`
+- 会话行：`if (id === "rename") onRename(...); if (id === "fork") ...; if (id === "archive") ...; if (id === "delete") window.__dshSessionManager?.deleteSession(...)`
+
+### 2.2 行节点数据可用性
+
+- **项目行**：`row.cwd`（项目目录绝对路径）已在节点上，hover 卡片（`WorkspaceHoverContent`，L418）已显示并可一键复制。✅
+- **会话行**：`node` 节点**不含** cwd；cwd 属于其所属分组 `group.cwd`（`buildGroup` L113、`deriveGroups` L203 `cwd: g.cwd`）。会话行渲染位置（组内 children）能拿到 group 上下文。⚠️ 需要在渲染链把 `group.cwd` 传给会话行/或从 runtime workspaces 表反查。
+
+### 2.3 「打开项目目录」宿主能力 —— 已有，零新增 IPC
+
+`main.js` L2861：
+
+```js
+ipcMain.handle('dsh:file-open', async (event, { path: p } = {}) => {
+  // ... 校验 + shell.openPath(p)
+});
+```
+
+`preload.js` L83 已暴露到渲染进程：
+
+```js
+openPath: (path) => ipcRenderer.invoke('dsh:file-open', { path })
+// 即 window.dshDesktop.openPath(cwd)
+```
+
+→ **渲染侧直接 `window.dshDesktop?.openPath(cwd)` 即可打开系统资源管理器**，无需改动 Electron 壳。
+
+### 2.4 Menu 组件支持「光标处定位」
+
+`Menu` props（primitives `lib/index.js`，portal 模式）：
+
+- `getAnchorRect`：portal 模式下提供自定义 anchor 矩形（L1516 注释：用于非 trigger 锚点场景，如右键定位）。右键时返回 `{ x, y, width: 0, height: 0 }`（光标点）即可在鼠标处弹出。
+- 现有代码为 portal 模式（`portal: true`），结构具备。
+
+### 2.5 本仓库「给右侧菜单加项」的官方补丁范式 —— 已存在
+
+`scripts/patch-session-manage.js` 是完整先例：
+
+- 锚点匹配 + 插入新菜单项（`UI_MENU_ANCHOR`/`UI_MENU_INSERT`）
+- 锚点匹配 + 插入 onSelect 分发（`UI_SELECT_ANCHOR`/`UI_SELECT_INSERT`）
+- 锚点匹配 + 中英字典（`UI_ZH_ANCHOR`、`UI_EN_ANCHOR`）
+- 幂等：文件头写 `// dsh-desktop patch (xxx)` MARKER，已打则跳过；锚点不匹配只告警不损坏
+- 三处接入：`scripts/patch-deps.js`（dev 时打 node_modules）、`scripts/lib/runtime-patches.js`（main.js 启动 + after-pack 打包时打所有副本）
+
+**所以本需求不需要改源码仓库、不需要改官方包代码本身——照抄该范式新增一个补丁脚本即可。**
+
+---
+
+## 3. 实现方案
+
+采用「运行时补丁」路线（与 `patch-session-manage.js` 完全同构），新增：
+
+```
+dsh-desktop/scripts/patch-open-project-dir.js
+```
+
+对上述 4 个锚点做插入，对 `dsh-client-ui-workspace/lib/client.js` 打补丁。
+
+### 3.1 项目行（ProjectRowItem）
+
+**① 菜单项数组**（在 `workspaceMenuItems` 的 `delete` 项后插入）：
+
+```js
+{
+  id: "open-folder",
+  label: t("menu.openProjectDir"),
+  icon: jsx(IconFolderOpen16)
+}
+```
+
+**② onSelect 分发**（在现有 `if (id === "rename") ... else actions.delete();` 后追加）：
+
+```js
+if (id === "open-folder") window.__dshDesktopOpenDir?.(row.cwd);
+```
+
+**③ 右键打开同一菜单**：行 div（L469）增加：
+
+```js
+onContextMenu: (e) => {
+  e.preventDefault();
+  e.stopPropagation();
+  setMenuPos({ x: e.clientX, y: e.clientY });
+  setMenuOpen(true);
+}
+```
+
+Menu 组件加 `getAnchorRect`（仅右键路径提供）：
+
+```js
+getAnchorRect: menuPos ? () => ({ x: menuPos.x, y: menuPos.y, width: 0, height: 0 }) : undefined
+```
+
+> 说明：三小点按钮点击仍走原 anchor（按钮矩形），右键走 getAnchorRect（光标点），二者共用同一个 `menuOpen` 状态与同一 `workspaceMenuItems`，天然满足「菜单 = 原菜单 + 新项」。
+
+### 3.2 会话行（SessionNodeItem）
+
+会话行需要 cwd。两个可选取法，推荐 **A**：
+
+- **A（推荐）**：渲染链上层（组循环）已有 `group.cwd`，沿用 `patch-session-manage.js` 曾用的「上下文透传」思路，将 `cwd` 作为 prop 传给 `SessionNodeItem`。
+  - 改动点：组渲染处（本文将一起 patch）`<SessionNodeItem ... cwd={group.cwd} />`；组件签名加 `cwd` prop。
+- B：从 runtime workspaces 表按 `sessionId → workspace.path` 反查（需要注入 `workspaces` 服务，代码更多，不推荐）。
+
+会话行补丁内容同项目行三处：菜单数组加 `open-folder` 项、onSelect 加 `if (id === "open-folder") window.__dshDesktopOpenDir?.(cwd)`、行 div 加 `onContextMenu` + Menu 的 `getAnchorRect`。
+
+**边界**：会话行的 cwd 为空（未分组/流浪会话）时该项置灰或隐藏（`disabled` / 不进数组）。
+
+### 3.3 字典（zh / en）
+
+`dsh-client-ui-workspace` 的 locale 块补两个 key（对齐 `patch-session-manage.js` 的字典锚点写法）：
+
+```js
+// zh
+"menu.openProjectDir": "打开项目目录",
+// en
+"menu.openProjectDir": "Open project folder",
+```
+
+### 3.4 渲染侧桥接（新增）
+
+补丁调 `window.__dshDesktopOpenDir`，需要一个最小 `client` 插件/脚本把它挂上（对齐 `dsh-session-manager` 提供 `window.__dshSessionManager` 的模式）：
+
+```js
+// 可选：合并进 dsh-session-manager 或独立小插件 dsh-open-project-dir
+window.__dshDesktopOpenDir = (cwd) => {
+  if (!cwd) return;
+  if (window.dshDesktop?.openPath) window.dshDesktop.openPath(cwd);
+  else console.warn('[open-project-dir] window.dshDesktop.openPath 不可用');
+};
+```
+
+> 也可更简单：补丁里直接 `window.dshDesktop?.openPath?.(cwd)`（preload 已保证存在），连插件都不用，但独立窗口期/未来非 Electron 环境会丢；**统一走 `__dshDesktopOpenDir` 桥，未来可切换为 web 端「浏览器新标签打开目录」等实现，无需再改补丁锚点**。
+
+### 3.5 接入补丁生命周期（3 处，与 patch-session-manage 一致）
+
+1. `scripts/patch-deps.js`：`require('./patch-open-project-dir')` 并执行 → dev `npm start` 生效；
+2. `scripts/lib/runtime-patches.js`：启动时对 profile fallback / 内置副本 / overlay 各副本打补丁（重启保留）；
+3. `scripts/after-pack.js`：打包前对内置副本打补丁（发版产物内置）。
+
+---
+
+## 4. 改动文件清单
+
+| 文件 | 改动 | 类型 |
+|---|---|---|
+| `dsh-desktop/scripts/patch-open-project-dir.js` | 新增：锚点定义 + patchOpenProjectDir(nmRoot) | 新增 |
+| `dsh-desktop/scripts/patch-deps.js` | require + 调用 | 修改 |
+| `dsh-desktop/scripts/lib/runtime-patches.js` | 注册进补丁目标清单 | 修改 |
+| `dsh-desktop/scripts/after-pack.js` | 打包链路调用 | 修改 |
+| `node_modules/@deepseek-ai/dsh-client-ui-workspace/lib/client.js` | 补丁目标（4+ 锚点） | 运行时被打 |
+| （可选）`dsh-session-manager` 或新 client 插件 | `window.__dshDesktopOpenDir` 桥 | 新增 |
+
+---
+
+## 5. 验证清单
+
+1. **项目行右键**：光标处弹出菜单，含「改名 / 删除 / 打开项目目录」；点击「打开项目目录」→ 系统资源管理器打开该 cwd。
+2. **会话行右键**：弹出「改名 / 分叉 / 归档 / 删除对话 / 打开项目目录」，打开的是该会话所属项目目录。
+3. **⋮ 按钮不回归**：点三小点仍从按钮处弹出原菜单 + 新项。
+4. **空白会话/未分组会话**：无 cwd 时新项隐藏或置灰，不报错。
+5. **幂等**：重复跑补丁脚本，文件不再重复插入；锚点不匹配时告警且不损坏文件。
+6. **重启保留**：重启 DSH Desktop（走 runtime-patches）菜单行为仍在。
+7. **打包**：`npm run dist` 产物内已含补丁。
+
+---
+
+## 6. 备选路线（不采用）
+
+- **改官方源码仓库（deepseek-ai/deepseek-harness 上游）**：干净但需 PR/发版，本需求要尽快落地，不适合。
+- **独立 client 插件全量重挂 treeview**：重写整个工作区树，成本高、与官方槽机制冲突风险大。
+- **DOM 事件委托（监听 contextmenu + 自绘菜单）**：不改包，但菜单样式/定位/Portal 全部自建，与官方 Menu 不一致，且难维护；仅当「不能动 node_modules」时兜底。

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -60,6 +60,7 @@ const presetGuard = require('./scripts/lib/preset-guard');
 const { patchWebSearchBaseUrl } = require('./scripts/patch-web-search-baseurl');
 const { patchMenuViewport } = require('./scripts/patch-menu-viewport');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
+const { patchOpenProjectDir } = require('./scripts/patch-open-project-dir');
 const { patchSessionPersistence } = require('./scripts/patch-session-persistence');
 // 「设置 → 插件 → 诊断与管理」：诊断 / 备份与恢复 / 日志包导出 / 防砖体检 /
 // bundle 顺序检测与重排（纯函数模块，node --test 单测覆盖）。
@@ -5184,6 +5185,8 @@ function applyMenuViewportFix() {
 // dsh-client-ui-workspace（会话行菜单「删除对话」）。补丁本体在
 // scripts/patch-session-manage.js（幂等、锚点不匹配自动跳过）；覆盖三处运行
 // 副本：profile fallback、内置 app 副本、用户更新过的 agent overlay。
+// 同循环顺带重打「打开项目目录」补丁（scripts/patch-open-project-dir.js，
+// 幂等）：侧边栏项目行/会话行菜单追加「打开项目目录」并支持右键弹出。
 // ---------------------------------------------------------------------------
 function applySessionManageFix() {
   const targets = runtimeNodeModulesRoots();
@@ -5194,6 +5197,12 @@ function applySessionManageFix() {
       if (n > 0) log('boot', '对话删除补丁: 已应用到 ' + root);
     } catch (err) {
       log('boot', '对话删除补丁失败(' + root + '): ' + err.message);
+    }
+    try {
+      const n = patchOpenProjectDir(root, (m) => log('boot', m));
+      if (n > 0) log('boot', '打开项目目录补丁: 已应用到 ' + root);
+    } catch (err) {
+      log('boot', '打开项目目录补丁失败(' + root + '): ' + err.message);
     }
   }
 }

--- a/dsh-desktop/scripts/after-pack.js
+++ b/dsh-desktop/scripts/after-pack.js
@@ -35,6 +35,7 @@ const { installBuiltinPresets } = require('./install-minimal-win-preset');
 const { patchWebSearchBaseUrl } = require('./patch-web-search-baseurl');
 const { patchMenuViewport } = require('./patch-menu-viewport');
 const { patchSessionManage } = require('./patch-session-manage');
+const { patchOpenProjectDir } = require('./patch-open-project-dir');
 const { patchSessionPersistence } = require('./patch-session-persistence');
 const { patchSlotCompat } = require('./patch-slot-compat');
 
@@ -154,11 +155,14 @@ module.exports = async function afterPack(context) {
     // client-connection / client-ui-workspace）。
     const smChanged = patchSessionManage(appNm, (m) => console.log('afterPack: ' + m));
     console.log(`afterPack: session manage ${smChanged > 0 ? `patched (${smChanged} files)` : 'already up to date'}`);
+    // 侧边栏「打开项目目录」：项目行/会话行菜单追加入口 + 右键弹出。
+    const odChanged = patchOpenProjectDir(appNm, (m) => console.log('afterPack: ' + m));
+    console.log(`afterPack: open project dir ${odChanged > 0 ? 'patched' : 'already up to date'}`);
     const spChanged = patchSessionPersistence(appNm, (m) => console.log('afterPack: ' + m));
     console.log(`afterPack: session torn-tail recovery ${spChanged > 0 ? 'patched' : 'already up to date'}`);
     const skChanged = patchSlotCompat(appNm, (m) => console.log('afterPack: ' + m));
     console.log(`afterPack: keyed slot compatibility ${skChanged > 0 ? 'patched' : 'already up to date'}`);
   } else {
-    console.warn('afterPack: bundled app node_modules not found — web-search baseURL / menu viewport / session manage / session recovery / slot compatibility patches skipped');
+    console.warn('afterPack: bundled app node_modules not found — web-search baseURL / menu viewport / session manage / open project dir / session recovery / slot compatibility patches skipped');
   }
 };

--- a/dsh-desktop/scripts/patch-deps.js
+++ b/dsh-desktop/scripts/patch-deps.js
@@ -67,6 +67,17 @@ try {
   console.log('[patch-deps] session-manage 补丁跳过: ' + (err && err.message ? err.message : err));
 }
 
+// 顺带应用侧边栏「打开项目目录」补丁（项目行/会话行菜单追加「打开项目目录」，
+// 支持右键弹出同一菜单）。开发模式（npm start）直接打 dev node_modules；打包
+// 由 after-pack 与启动时运行时补丁覆盖（幂等，锚点不匹配只告警不中断）。
+try {
+  const { patchOpenProjectDir } = require('./patch-open-project-dir');
+  const n = patchOpenProjectDir(root, (m) => console.log(m));
+  if (n > 0) console.log('[patch-deps] open-project-dir 补丁已应用（dev node_modules）');
+} catch (err) {
+  console.log('[patch-deps] open-project-dir 补丁跳过: ' + (err && err.message ? err.message : err));
+}
+
 // 会话进程在 frame 收尾后、JSONL 行写完前中断时，官方读取器会把可恢复的
 // 最终半条记录误判为永久损坏。让它复用已有 torn-tail repair 流程。
 try {

--- a/dsh-desktop/scripts/patch-open-project-dir.js
+++ b/dsh-desktop/scripts/patch-open-project-dir.js
@@ -1,0 +1,194 @@
+'use strict';
+
+// 侧边栏「打开项目目录」运行时补丁（幂等、锚点不匹配时跳过且绝不损坏文件）。
+//
+// 背景：dsh 侧边栏工作区树的项目行/会话行只有「⋮」按钮菜单，没有右键菜单，
+// 也没有「打开项目目录」入口。本补丁在官方包上做外科手术式扩展：
+//
+//   @deepseek-ai/dsh-client-ui-workspace —— 项目行与会话行的菜单数组各追加
+//   「打开项目目录」项（id: "open-folder"），并在行 div 上挂 onContextMenu
+//   （preventDefault + 以光标位置弹出同一菜单，走 Menu 的 getAnchorRect），
+//    点击调用渲染侧桥 window.__dshDesktopOpenDir（由 dsh-session-manager 等
+//    内置插件提供：window.dshDesktop.openPath → 宿主 dsh:file-open IPC →
+//    shell.openPath，零新增 IPC）。
+//
+// 会话行没有 cwd 字段：组树视图由两个调用点把所属分组的 cwd 透传进
+// SessionNodeItem（组视图 group.cwd / flat 视图 list.byId 反查）；cwd 为空
+// （未分组/流浪会话）时「打开项目目录」项不显示。
+//
+// 用法：
+//   node scripts/patch-open-project-dir.js [<node_modules 根目录>]
+// 同时导出 patchOpenProjectDir(nmRoot, log) 供 main.js 启动补丁与 after-pack.js
+// 打包补丁复用（覆盖内置副本 / profile fallback / agent overlay / dev）。
+
+const fs = require('node:fs');
+const path = require('node:path');
+// 原子写与 main.js / 其它补丁脚本共用同一实现（scripts/lib/patch-io.js）。
+const { writeFileAtomic } = require('./lib/patch-io');
+
+const MARKER = 'dsh-desktop patch (open project dir)';
+
+// ---------------------------------------------------------------------------
+// 1. 项目行（ProjectRowItem）：菜单数组追加「打开项目目录」
+// ---------------------------------------------------------------------------
+const PROJ_MENU_ANCHOR = '\t\t\t\tid: "delete",\n\t\t\t\tlabel: t("delete.workspace"),\n\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconTrashOutline16, {}),\n\t\t\t\tdanger: true\n\t\t\t}];';
+const PROJ_MENU_INSERT = '\t\t\t\tid: "delete",\n\t\t\t\tlabel: t("delete.workspace"),\n\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconTrashOutline16, {}),\n\t\t\t\tdanger: true\n\t\t\t}, {\n\t\t\t\t// dsh-desktop patch (open project dir): 打开项目目录。\n\t\t\t\tid: "open-folder",\n\t\t\t\tlabel: t("menu.openProjectDir"),\n\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconFolderOpen16, {})\n\t\t\t}];';
+
+// 2. 项目行 onSelect 分发：放行 open-folder 并转发到渲染侧桥。
+const PROJ_SELECT_ANCHOR = 'if (id !== "rename" && id !== "delete") return;\n\t\t\t\t\t\t\t\tif (id === "rename") actions.rename();\n\t\t\t\t\t\t\t\telse actions.delete();';
+const PROJ_SELECT_INSERT = 'if (id !== "rename" && id !== "delete" && id !== "open-folder") return;\n\t\t\t\t\t\t\t\tif (id === "rename") actions.rename();\n\t\t\t\t\t\t\t\telse if (id === "delete") actions.delete();\n\t\t\t\t\t\t\t\telse if (id === "open-folder") window.__dshDesktopOpenDir?.(row.cwd);';
+
+// 3. 项目行 div：menuPos 状态 + 右键弹出同一菜单（仅真实工作区行挂右键，
+//    未分组 bucket 的 actions 为 undefined，不弹空菜单）。
+const PROJ_SELECT_STATE_ANCHOR = 'const [menuOpen, setMenuOpen] = (0, react.useState)(false);\n\t\t\tconst workspaceMenuItems = [{';
+const PROJ_SELECT_STATE_INSERT = 'const [menuOpen, setMenuOpen] = (0, react.useState)(false);\n\t\t\t// dsh-desktop patch (open project dir): 右键光标位置（null = 未右键，走 ⋮ 按钮锚点）。\n\t\t\tconst [menuPos, setMenuPos] = (0, react.useState)(null);\n\t\t\tconst workspaceMenuItems = [{';
+
+const PROJ_CTX_ANCHOR = '\t\t\t\tonClick: onToggle,\n\t\t\t\tdraggable: drag !== void 0,';
+const PROJ_CTX_INSERT = '\t\t\t\tonClick: onToggle,\n\t\t\t\tonContextMenu: actions === void 0 ? void 0 : (e) => {\n\t\t\t\t\te.preventDefault();\n\t\t\t\t\te.stopPropagation();\n\t\t\t\t\tsetMenuPos({ x: e.clientX, y: e.clientY });\n\t\t\t\t\tsetMenuOpen(true);\n\t\t\t\t},\n\t\t\t\tdraggable: drag !== void 0,';
+
+// 4. 项目行 Menu：portal 模式用光标矩形定位（右键时）；⋮ 按钮点击复位 menuPos。
+const PROJ_MENU_RECT_ANCHOR = '\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+const PROJ_MENU_RECT_INSERT = '\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\tgetAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, width: 0, height: 0 }),\n\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+
+const PROJ_BTN_ANCHOR = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t},';
+const PROJ_BTN_INSERT = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\tsetMenuPos(null);\n\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t},';
+
+// ---------------------------------------------------------------------------
+// 5. 会话行（SessionNodeItem）：签名加 cwd prop + menuPos 状态
+// ---------------------------------------------------------------------------
+const SESS_SIG_ANCHOR = '\t\tfunction SessionNodeItem({ node, currentId, now, onOpen, onRename, onFork, onArchive, drag, flat = false, t }) {';
+const SESS_SIG_INSERT = '\t\tfunction SessionNodeItem({ node, currentId, now, onOpen, onRename, onFork, onArchive, drag, flat = false, t, cwd }) {';
+
+const SESS_STATE_ANCHOR = 'const [menuOpen, setMenuOpen] = (0, react.useState)(false);\n\t\t\tconst sessionMenuItems = [';
+const SESS_STATE_INSERT = 'const [menuOpen, setMenuOpen] = (0, react.useState)(false);\n\t\t\t// dsh-desktop patch (open project dir): 右键光标位置（null = 未右键，走 ⋮ 按钮锚点）。\n\t\t\tconst [menuPos, setMenuPos] = (0, react.useState)(null);\n\t\t\tconst sessionMenuItems = [';
+
+// 6. 会话行菜单数组：delete 之后追加「打开项目目录」（cwd 为空时不显示）。
+const SESS_MENU_ANCHOR = '\t\t\t\t// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}\n\t\t\t];';
+const SESS_MENU_INSERT = '\t\t\t\t// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t},\n\t\t\t\t// dsh-desktop patch (open project dir): 有项目目录时追加「打开项目目录」。\n\t\t\t\t...(cwd ? [{\n\t\t\t\t\tid: "open-folder",\n\t\t\t\t\tlabel: t("menu.openProjectDir")\n\t\t\t\t}] : [])\n\t\t\t];';
+
+// 7. 会话行 onSelect 分发：open-folder → 渲染侧桥（cwd 来自新 prop）。
+const SESS_SELECT_ANCHOR = '\t\t\t\t\t\t\t\t\tif (id === "delete") window.__dshSessionManager?.deleteSession(node.id);';
+const SESS_SELECT_INSERT = '\t\t\t\t\t\t\t\t\tif (id === "delete") window.__dshSessionManager?.deleteSession(node.id);\n\t\t\t\t\t\t\t\t\tif (id === "open-folder") window.__dshDesktopOpenDir?.(cwd);';
+
+// 8. 会话行 div：右键弹出同一菜单。
+const SESS_CTX_ANCHOR = '\t\t\t\t\tonClick: () => {\n\t\t\t\t\t\tonOpen(node.id);\n\t\t\t\t\t},\n\t\t\t\t\tdraggable: drag !== void 0,';
+const SESS_CTX_INSERT = '\t\t\t\t\tonClick: () => {\n\t\t\t\t\t\tonOpen(node.id);\n\t\t\t\t\t},\n\t\t\t\t\tonContextMenu: (e) => {\n\t\t\t\t\t\te.preventDefault();\n\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\tsetMenuPos({ x: e.clientX, y: e.clientY });\n\t\t\t\t\t\tsetMenuOpen(true);\n\t\t\t\t\t},\n\t\t\t\t\tdraggable: drag !== void 0,';
+
+// 9. 会话行 Menu：portal 模式用光标矩形定位；⋮ 按钮点击复位 menuPos。
+const SESS_MENU_RECT_ANCHOR = '\t\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+const SESS_MENU_RECT_INSERT = '\t\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\t\tgetAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, width: 0, height: 0 }),\n\t\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+
+const SESS_BTN_ANCHOR = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t\t},';
+const SESS_BTN_INSERT = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\t\tsetMenuPos(null);\n\t\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t\t},';
+
+// 10. 会话行调用点透传 cwd：组树视图（group.cwd）与 flat 视图（list.byId 反查）。
+const SESS_GROUP_CALL_ANCHOR = '\t\t\t\t\t\t\t\t\t\treturn (0, react_jsx_runtime.jsx)(SessionNodeItem, {\n\t\t\t\t\t\t\t\t\t\t\tnode,';
+const SESS_GROUP_CALL_INSERT = '\t\t\t\t\t\t\t\t\t\treturn (0, react_jsx_runtime.jsx)(SessionNodeItem, {\n\t\t\t\t\t\t\t\t\t\t\tnode,\n\t\t\t\t\t\t\t\t\t\t\t// dsh-desktop patch (open project dir): 透传所属分组的项目目录。\n\t\t\t\t\t\t\t\t\t\t\tcwd: group.cwd,';
+
+const SESS_FLAT_CALL_ANCHOR = '\t\t\t\t\t\treturn (0, react_jsx_runtime.jsx)(SessionNodeItem, {\n\t\t\t\t\t\t\tnode,';
+const SESS_FLAT_CALL_INSERT = '\t\t\t\t\t\treturn (0, react_jsx_runtime.jsx)(SessionNodeItem, {\n\t\t\t\t\t\t\tnode,\n\t\t\t\t\t\t\t// dsh-desktop patch (open project dir): 从原始摘要反查项目目录。\n\t\t\t\t\t\t\tcwd: list.byId[node.id]?.cwd,';
+
+// 11. 翻译：中英字典各补一个 key。
+const UI_ZH_ANCHOR = '\t\t\t"menu.deleteSession": "删除对话",';
+const UI_ZH_INSERT = '\t\t\t"menu.deleteSession": "删除对话",\n\t\t\t"menu.openProjectDir": "打开项目目录",';
+const UI_EN_ANCHOR = '\t\t\t"menu.deleteSession": "Delete conversation",';
+const UI_EN_INSERT = '\t\t\t"menu.deleteSession": "Delete conversation",\n\t\t\t"menu.openProjectDir": "Open project folder",';
+
+// ---------------------------------------------------------------------------
+// 工具：在文件中做「锚点必须存在 + 标记幂等」的替换（与 patch-session-manage
+// 同一实现；无历史版本，upgradeRules 恒空，保留参数以对齐调用形态）。
+// ---------------------------------------------------------------------------
+function applyReplacements(file, replacements, upgradeRules, log) {
+  let src;
+  try {
+    src = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    log('open-project-dir 补丁: 读取失败 ' + file + ': ' + err.message);
+    return false;
+  }
+  if (src.includes(MARKER)) {
+    let upgraded = false;
+    for (const { anchor, insert } of upgradeRules) {
+      if (src.includes(anchor)) {
+        src = src.replace(anchor, insert);
+        upgraded = true;
+      }
+    }
+    if (upgraded) {
+      try {
+        writeFileAtomic(file, src);
+        log('open-project-dir 补丁: 已升级 ' + file);
+        return true;
+      } catch (err) {
+        log('open-project-dir 补丁: 升级写入失败 ' + file + ': ' + err.message);
+        return false;
+      }
+    }
+    log('open-project-dir 补丁: 已应用，跳过 ' + file);
+    return false;
+  }
+  for (const { anchor, insert } of replacements) {
+    if (!src.includes(anchor)) {
+      log('open-project-dir 补丁: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file + ' :: ' + anchor.slice(0, 60));
+      return false;
+    }
+    src = src.replace(anchor, insert);
+  }
+  src = '// ' + MARKER + ': 侧边栏「打开项目目录」运行时补丁\n' + src;
+  try {
+    writeFileAtomic(file, src);
+    log('open-project-dir 补丁: 已应用 ' + file);
+    return true;
+  } catch (err) {
+    log('open-project-dir 补丁: 写入失败 ' + file + ': ' + err.message);
+    return false;
+  }
+}
+
+/**
+ * 对某个 node_modules 根目录应用「打开项目目录」补丁（幂等）。
+ * @param {string} nmRoot node_modules 根目录
+ * @param {(msg: string) => void} [log]
+ * @returns {number} 实际发生修改的文件数
+ */
+function patchOpenProjectDir(nmRoot, log = () => {}) {
+  const targets = [
+    {
+      file: path.join(nmRoot, '@deepseek-ai', 'dsh-client-ui-workspace', 'lib', 'client.js'),
+      replacements: [
+        { anchor: PROJ_MENU_ANCHOR, insert: PROJ_MENU_INSERT },
+        { anchor: PROJ_SELECT_ANCHOR, insert: PROJ_SELECT_INSERT },
+        { anchor: PROJ_SELECT_STATE_ANCHOR, insert: PROJ_SELECT_STATE_INSERT },
+        { anchor: PROJ_CTX_ANCHOR, insert: PROJ_CTX_INSERT },
+        { anchor: PROJ_MENU_RECT_ANCHOR, insert: PROJ_MENU_RECT_INSERT },
+        { anchor: PROJ_BTN_ANCHOR, insert: PROJ_BTN_INSERT },
+        { anchor: SESS_SIG_ANCHOR, insert: SESS_SIG_INSERT },
+        { anchor: SESS_STATE_ANCHOR, insert: SESS_STATE_INSERT },
+        { anchor: SESS_MENU_ANCHOR, insert: SESS_MENU_INSERT },
+        { anchor: SESS_SELECT_ANCHOR, insert: SESS_SELECT_INSERT },
+        { anchor: SESS_CTX_ANCHOR, insert: SESS_CTX_INSERT },
+        { anchor: SESS_MENU_RECT_ANCHOR, insert: SESS_MENU_RECT_INSERT },
+        { anchor: SESS_BTN_ANCHOR, insert: SESS_BTN_INSERT },
+        { anchor: SESS_GROUP_CALL_ANCHOR, insert: SESS_GROUP_CALL_INSERT },
+        { anchor: SESS_FLAT_CALL_ANCHOR, insert: SESS_FLAT_CALL_INSERT },
+        { anchor: UI_ZH_ANCHOR, insert: UI_ZH_INSERT },
+        { anchor: UI_EN_ANCHOR, insert: UI_EN_INSERT },
+      ],
+      upgradeRules: [],
+    },
+  ];
+  let changed = 0;
+  for (const t of targets) {
+    if (!fs.existsSync(t.file)) continue;
+    if (applyReplacements(t.file, t.replacements, t.upgradeRules || [], log)) changed += 1;
+  }
+  return changed;
+}
+
+module.exports = { patchOpenProjectDir, MARKER };
+
+if (require.main === module) {
+  const root = process.argv[2] ? path.resolve(process.argv[2]) : path.resolve(__dirname, '..', 'node_modules');
+  const n = patchOpenProjectDir(root, (m) => console.log(m));
+  console.log(n > 0 ? `patched ${n} file(s) — restart DSH Desktop to pick it up` : 'nothing to patch (already up to date)');
+}

--- a/dsh-desktop/scripts/patch-open-project-dir.js
+++ b/dsh-desktop/scripts/patch-open-project-dir.js
@@ -47,8 +47,13 @@ const PROJ_CTX_ANCHOR = '\t\t\t\tonClick: onToggle,\n\t\t\t\tdraggable: drag !==
 const PROJ_CTX_INSERT = '\t\t\t\tonClick: onToggle,\n\t\t\t\tonContextMenu: actions === void 0 ? void 0 : (e) => {\n\t\t\t\t\te.preventDefault();\n\t\t\t\t\te.stopPropagation();\n\t\t\t\t\tsetMenuPos({ x: e.clientX, y: e.clientY });\n\t\t\t\t\tsetMenuOpen(true);\n\t\t\t\t},\n\t\t\t\tdraggable: drag !== void 0,';
 
 // 4. 项目行 Menu：portal 模式用光标矩形定位（右键时）；⋮ 按钮点击复位 menuPos。
+//    注意：Menu place() 的定位分支读取 r.left / r.bottom / r.right，矩形必须
+//    提供完整四边（缺 right/bottom 会让坐标算出 NaN，弹层落回静态位置）。
 const PROJ_MENU_RECT_ANCHOR = '\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
-const PROJ_MENU_RECT_INSERT = '\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\tgetAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, width: 0, height: 0 }),\n\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+const PROJ_MENU_RECT_INSERT = '\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\tgetAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, right: menuPos.x + 1, bottom: menuPos.y + 1, width: 0, height: 0 }),\n\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+// v1 升级：旧矩形缺 right/bottom（NaN 定位 bug，弹层固定在上方）→ 补全四边。
+const PROJ_MENU_RECT_UPGRADE_ANCHOR = 'getAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, width: 0, height: 0 }),';
+const PROJ_MENU_RECT_UPGRADE_INSERT = 'getAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, right: menuPos.x + 1, bottom: menuPos.y + 1, width: 0, height: 0 }),';
 
 const PROJ_BTN_ANCHOR = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t},';
 const PROJ_BTN_INSERT = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\tsetMenuPos(null);\n\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t},';
@@ -76,7 +81,10 @@ const SESS_CTX_INSERT = '\t\t\t\t\tonClick: () => {\n\t\t\t\t\t\tonOpen(node.id)
 
 // 9. 会话行 Menu：portal 模式用光标矩形定位；⋮ 按钮点击复位 menuPos。
 const SESS_MENU_RECT_ANCHOR = '\t\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
-const SESS_MENU_RECT_INSERT = '\t\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\t\tgetAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, width: 0, height: 0 }),\n\t\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+const SESS_MENU_RECT_INSERT = '\t\t\t\t\t\t\t\tportal: true,\n\t\t\t\t\t\t\t\tcloseOnPointerLeave: true,\n\t\t\t\t\t\t\t\tgetAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, right: menuPos.x + 1, bottom: menuPos.y + 1, width: 0, height: 0 }),\n\t\t\t\t\t\t\t\tanchor: (0, react_jsx_runtime.jsx)("button", {';
+// v1 升级：旧矩形缺 right/bottom（NaN 定位 bug，弹层固定在上方）→ 补全四边。
+const SESS_MENU_RECT_UPGRADE_ANCHOR = 'getAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, width: 0, height: 0 }),';
+const SESS_MENU_RECT_UPGRADE_INSERT = 'getAnchorRect: menuPos === null ? void 0 : () => ({ left: menuPos.x, top: menuPos.y, right: menuPos.x + 1, bottom: menuPos.y + 1, width: 0, height: 0 }),';
 
 const SESS_BTN_ANCHOR = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t\t},';
 const SESS_BTN_INSERT = 'onClick: (e) => {\n\t\t\t\t\t\t\t\t\t\te.stopPropagation();\n\t\t\t\t\t\t\t\t\t\tsetMenuPos(null);\n\t\t\t\t\t\t\t\t\t\tsetMenuOpen((v) => !v);\n\t\t\t\t\t\t\t\t\t},';
@@ -174,7 +182,12 @@ function patchOpenProjectDir(nmRoot, log = () => {}) {
         { anchor: UI_ZH_ANCHOR, insert: UI_ZH_INSERT },
         { anchor: UI_EN_ANCHOR, insert: UI_EN_INSERT },
       ],
-      upgradeRules: [],
+      // v1 → v2 升级：v1 的 getAnchorRect 矩形缺 right/bottom，Menu place()
+      // 用 r.bottom/r.right 算坐标得到 NaN，弹层固定在上方不跟随光标。
+      upgradeRules: [
+        { anchor: PROJ_MENU_RECT_UPGRADE_ANCHOR, insert: PROJ_MENU_RECT_UPGRADE_INSERT },
+        { anchor: SESS_MENU_RECT_UPGRADE_ANCHOR, insert: SESS_MENU_RECT_UPGRADE_INSERT },
+      ],
     },
   ];
   let changed = 0;


### PR DESCRIPTION
## 功能

侧边栏「项目行 / 会话行」的 ⋮ 菜单新增 **打开项目目录** 入口，并支持**右键**该项目/会话行直接弹出菜单点击打开。

- 项目行：菜单追加 `open-folder` 项（文件夹图标），点击调用 `window.__dshDesktopOpenDir(row.cwd)`
- 会话行：菜单追加 `open-folder` 项，cwd 从分组 `group.cwd` 透传（flat 视图从 `list.byId` 反查）；未分组/流浪会话（无 cwd）时自动隐藏该项
- 右键：行 div 挂 `onContextMenu`（`preventDefault` + `stopPropagation`），以光标坐标作为 `Menu` 的 `getAnchorRect`，弹出与 ⋮ 按钮同一个菜单
- 打开目录零新增 IPC：`window.dshDesktop.openPath`（preload 已有）→ `dsh:file-open` → `shell.openPath`

## 实现方式

沿用仓库既有的 **运行时补丁** 范式（与 `patch-session-manage.js` 同构），新增 `scripts/patch-open-project-dir.js`：

- 对 `@deepseek-ai/dsh-client-ui-workspace/lib/client.js` 做 17 处锚点替换，幂等（带 MARKER，已应用则跳过）
- 渲染侧桥 `window.__dshDesktopOpenDir` 挂进 `dsh-session-manager` 插件（对齐 `__dshSessionManager` 模式）
- 三处生命周期接入：`scripts/patch-deps.js`（dev）、`main.js` 启动 applySessionManageFix 循环内（运行期对所有副本）、`scripts/after-pack.js`（打包）

## 附带修复：右键菜单位置 bug

初版发现右键菜单固定在上方、不跟随光标：`Menu.place()` 定位读取 `r.left/r.bottom/r.right`，而初版 `getAnchorRect` 矩形缺少 `right/bottom`，`align=start + side=bottom` 时 `y = r.bottom + 4 = NaN`，inline `top:NaN` 被浏览器丢弃，portal 弹层落回静态位置。已补全矩形四边（`right/bottom = x+1/y+1`），菜单现在从光标右下方弹出；补丁脚本增加 upgradeRules 支持旧副本自动升级。

## 验证

- `node --check` 通过（补丁脚本 + 补丁产物）
- 三副本（仓库 node_modules / `~/.dsh/profiles` / resources/app）均已应用并验证
- 幂等：重复运行显示「已应用，跳过」