### PR TITLE
fix: 插件开关误删兄弟条目等 5 个缺陷修复（#66 #76 #75 #90 #80）

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -4142,6 +4142,14 @@ const PLUGIN_UPDATE_SOURCES = {
   'side-session': { kind: 'github', repo: 'hzhz314159/dsh-side-session' },
 };
 
+/** 解析重定向 Location：相对地址基于原 URL 解析；仅允许 https（http 跳转拒绝，
+ *  与 https.get 一致；异常收敛为 rejection，不冒泡未捕获异常——issue #80）。 */
+function resolveRedirectLocation(location, baseUrl) {
+  const next = new URL(String(location), String(baseUrl));
+  if (next.protocol !== 'https:') throw new Error('重定向目标协议不受支持: ' + next.protocol);
+  return next.toString();
+}
+
 /** GET JSON（跟随重定向，上限 5 跳防环，超时取消）。 */
 function pluginManagerHttpGetJson(url, timeoutMs = 15000, headers = {}, redirects = 0) {
   return new Promise((resolve, reject) => {
@@ -4149,7 +4157,11 @@ function pluginManagerHttpGetJson(url, timeoutMs = 15000, headers = {}, redirect
     const req = https.get(url, { headers: { 'User-Agent': 'DSH-Desktop', ...headers }, timeout: timeoutMs }, (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         res.resume();
-        return resolve(pluginManagerHttpGetJson(res.headers.location, timeoutMs, headers, redirects + 1));
+        try {
+          return resolve(pluginManagerHttpGetJson(resolveRedirectLocation(res.headers.location, url), timeoutMs, headers, redirects + 1));
+        } catch (err) {
+          return reject(err);
+        }
       }
       let data = '';
       res.on('data', (c) => { data += c; });
@@ -4170,7 +4182,11 @@ function pluginManagerHttpGetBuffer(url, timeoutMs = 60000, redirects = 0) {
     const req = https.get(url, { headers: { 'User-Agent': 'DSH-Desktop' }, timeout: timeoutMs }, (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         res.resume();
-        return resolve(pluginManagerHttpGetBuffer(res.headers.location, timeoutMs, redirects + 1));
+        try {
+          return resolve(pluginManagerHttpGetBuffer(resolveRedirectLocation(res.headers.location, url), timeoutMs, redirects + 1));
+        } catch (err) {
+          return reject(err);
+        }
       }
       if (res.statusCode !== 200) { res.resume(); return reject(new Error('HTTP ' + res.statusCode)); }
       const chunks = [];
@@ -4218,7 +4234,17 @@ async function pluginManagerFetchGithubLatest(repo) {
   try {
     const data = await pluginManagerHttpGetJson(githubReleaseApiUrl(repo), 15000, { Accept: 'application/vnd.github+json' });
     if (data && data.tag_name && Array.isArray(data.assets) && data.assets.length > 0) {
-      const a = data.assets.find((x) => x && x.name) || data.assets[0];
+      // 多资产 Release 选择策略（issue #90）：优先「平台匹配的归档」（win/x64 +
+      // .tgz/.tar.gz/.zip），其次任意归档，再次平台匹配任意文件，最后回退第一个。
+      // 此前直接取第一个资产，多资产 Release（checksum/其它平台分包）会下载错文件。
+      const isArchive = (n) => /\.(?:tgz|tar\.gz|zip)$/i.test(n);
+      const isWinAsset = (n) => /(?:win|windows)/i.test(n);
+      const a =
+        data.assets.find((x) => x && x.name && isArchive(x.name) && isWinAsset(x.name)) ||
+        data.assets.find((x) => x && x.name && isArchive(x.name)) ||
+        data.assets.find((x) => x && x.name && isWinAsset(x.name)) ||
+        data.assets.find((x) => x && x.name) ||
+        data.assets[0];
       // GitHub API digest 形如 "sha256:<hex64>"（部分老资产无此字段）
       const dm = /^(?:sha256:)?([0-9a-fA-F]{64})$/.exec(String(a.digest || ''));
       return {

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -58,11 +58,105 @@ const entryFiles = [
 // 孤立 async/await 表达式在运行时会抛 ReferenceError，必须在打包前拦截。
 const DETACHED_KEYWORD = /^[ \t]*(async|await)[ \t]*(?:\/\/[^\r\n]*)?[ \t]*\r?\n(?:[ \t]*(?:\/\/[^\r\n]*)?[ \t]*\r?\n)*[ \t]*function\b/gm;
 
+/**
+ * 把字符串/模板字面量与注释替换为等长空白（保留换行以维持行号），
+ * 只让 DETACHED_KEYWORD 扫描真实代码区（issue #75：模板字符串/块注释里的
+ * 示例文本——如 `const doc = \`\nasync\nfunction foo() {}\n\`;`——曾触发
+ * 打包门禁假阳性）。模板内 `${...}` 表达式区同样视为模板内容：与
+ * node --check 的解析边界一致，文档字符串不应拦截打包；表达式区内嵌
+ * 模板的极端形态有极小漏报可能，但事故形态（顶层 async 拆行）不受影响。
+ */
+function stripLiteralsAndComments(text) {
+  const out = text.split('');
+  const n = text.length;
+  let i = 0;
+  while (i < n) {
+    const ch = text[i];
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      const start = i;
+      i++;
+      let closed = false;
+      while (i < n) {
+        if (text[i] === '\\') { i += 2; continue; }
+        if (text[i] === quote) { i++; closed = true; break; }
+        i++;
+      }
+      if (closed) {
+        for (let j = start; j < i; j++) {
+          if (text[j] !== '\n' && text[j] !== '\r') out[j] = ' ';
+        }
+      }
+      continue;
+    }
+    if (ch === '`') {
+      const start = i;
+      i++;
+      let closed = false;
+      while (i < n) {
+        if (text[i] === '\\') { i += 2; continue; }
+        if (text[i] === '`') { i++; closed = true; break; }
+        if (text[i] === '$' && text[i + 1] === '{') {
+          // 跳过内嵌表达式区：花括号配对，引号/模板内的字符不参与配对
+          let depth = 1;
+          i += 2;
+          while (i < n && depth > 0) {
+            const c = text[i];
+            if (c === '{') depth++;
+            else if (c === '}') depth--;
+            else if (c === "'" || c === '"' || c === '`') {
+              const q = c;
+              i++;
+              while (i < n && text[i] !== q) {
+                if (text[i] === '\\') i++;
+                i++;
+              }
+            }
+            i++;
+          }
+          continue;
+        }
+        i++;
+      }
+      if (closed) {
+        for (let j = start; j < i; j++) {
+          if (text[j] !== '\n' && text[j] !== '\r') out[j] = ' ';
+        }
+      }
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < n && text[i] !== '\n') { out[i] = ' '; i++; }
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      const start = i;
+      out[start] = ' ';
+      out[start + 1] = ' ';
+      i += 2;
+      while (i < n) {
+        if (text[i] === '*' && text[i + 1] === '/') {
+          out[i] = ' ';
+          out[i + 1] = ' ';
+          i += 2;
+          break;
+        }
+        if (text[i] !== '\n' && text[i] !== '\r') out[i] = ' ';
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return out.join('');
+}
+
 function detachedHits(text) {
   const hits = [];
   let match;
+  const cleaned = stripLiteralsAndComments(text);
   DETACHED_KEYWORD.lastIndex = 0;
-  while ((match = DETACHED_KEYWORD.exec(text)) !== null) {
+  while ((match = DETACHED_KEYWORD.exec(cleaned)) !== null) {
     const upTo = text.slice(0, match.index);
     hits.push({ keyword: match[1], line: upTo.split(/\r?\n/).length });
   }

--- a/dsh-desktop/scripts/desktop-validity.js
+++ b/dsh-desktop/scripts/desktop-validity.js
@@ -185,9 +185,13 @@ function checkPluginPackage(name, dir, yaml, fs = require('node:fs'), listed = f
       }
     }
   }
-  // 声明了 main 但入口文件缺失（仅警告：bundle 不一定走 main）
+  // 声明了 main 但入口文件缺失。启动清单（listed）内的包随 patch 加载时按包名
+  // require → 走 main，缺失会导致启动失败（issue #76：缺 dist/main 实测崩）；
+  // 非清单包（普通 npm 依赖）不参与启动加载，仅警告。
   if (typeof pkg.main === 'string' && pkg.main && !fs.existsSync(path.join(dir, pkg.main))) {
-    issues.push({ level: 'warning', text: `main 入口不存在: ${pkg.main}` });
+    issues.push(listed
+      ? { level: 'error', text: `启动清单内插件 main 入口不存在: ${pkg.main}（加载该包会失败，请移除或修复）` }
+      : { level: 'warning', text: `main 入口不存在: ${pkg.main}` });
   }
   return { name, issues, ids, patchOk };
 }

--- a/dsh-desktop/scripts/plugin-manager-patch.js
+++ b/dsh-desktop/scripts/plugin-manager-patch.js
@@ -24,13 +24,16 @@ function yamlQuote(s) {
 }
 
 // 顶层用户层条目（缩进 0-2 空格）+ 全部续行（含行尾换行）。
+// id 边界用负向断言（id 字符集 [A-Za-z0-9_.-]，`\b` 对 -/. 是非法词边界，
+// 会误匹配前缀如 terminal→terminal-tab）；续行组前瞻排除同缩进兄弟
+// `- id:`（贪婪续行会把同块后续兄弟条目整块吞掉，造成误删）。
 function topLevelEntryRe(id) {
-  return new RegExp('(?:^|\\n)([ \\t]{0,2})- id:\\s*' + escRegExp(id) + '\\b[^\\n]*\\n(?:[ \\t]+[^\\n]*\\n)*', 'g');
+  return new RegExp('(?:^|\\n)([ \\t]{0,2})- id:\\s*' + escRegExp(id) + '(?![A-Za-z0-9_.-])[^\\n]*\\n(?:[ \\t]+(?![ \\t]*- id:)[^\\n]*\\n)*', 'g');
 }
 
 // insert 块内的内层条目（缩进 >= 4）+ 续行（含行尾换行）。
 function insertInnerEntryRe(id) {
-  return new RegExp('(?:^|\\n)[ \\t]+- id:\\s*' + escRegExp(id) + '\\b[^\\n]*\\n(?:[ \\t]+[^\\n]*\\n)*', 'g');
+  return new RegExp('(?:^|\\n)[ \\t]+- id:\\s*' + escRegExp(id) + '(?![A-Za-z0-9_.-])[^\\n]*\\n(?:[ \\t]+(?![ \\t]*- id:)[^\\n]*\\n)*', 'g');
 }
 
 // 本模块写入的标记注释行（整行，含行尾换行）。

--- a/dsh-desktop/scripts/test/desktop-validity.test.js
+++ b/dsh-desktop/scripts/test/desktop-validity.test.js
@@ -198,3 +198,35 @@ test('validatePlugins: 覆盖条目（disabled/config）不算注册 → 不产�
   const out3 = validatePlugins(profileDir, null, path.join(dir, 'assets'), jsonYaml, fs);
   assert.strictEqual(out3.ok, true, '定向 insert 组名不算注册');
 });
+
+// ---------- #76：main 入口缺失——清单内升 error，避免「体检通过但启动失败」 ----------
+
+test('#76 清单内（listed）main 缺失 → error；未列出 → 保持 warning', () => {
+  const dir = tmpdir();
+  write(dir, 'listed-pkg/package.json', JSON.stringify({
+    name: 'listed-pkg', main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }));
+  write(dir, 'listed-pkg/cordis.patch.yml', patchJson([{ id: 'lp' }]));
+  const listed = checkPluginPackage('listed-pkg', path.join(dir, 'listed-pkg'), jsonYaml, fs, true);
+  const err = listed.issues.find((i) => i.level === 'error' && /main 入口不存在/.test(i.text));
+  assert.ok(err, 'listed 包 main 缺失应报 error');
+  assert.match(err.text, /启动清单/);
+  const notListed = checkPluginPackage('listed-pkg', path.join(dir, 'listed-pkg'), jsonYaml, fs, false);
+  const warn = notListed.issues.find((i) => i.level === 'warning' && /main 入口不存在/.test(i.text));
+  assert.ok(warn, '未列出包 main 缺失保持 warning，不误报启动失败');
+  assert.ok(!notListed.issues.some((i) => i.level === 'error' && /main 入口不存在/.test(i.text)));
+});
+
+test('#76 validatePlugins: 清单内 main 缺失 → ok:false + contractViolations 列出', () => {
+  const dir = tmpdir();
+  const profileDir = dir;
+  write(profileDir, 'package.json', JSON.stringify({ name: 'p', dsh: { profile: { bundles: ['broken-main'] } } }));
+  write(dir, 'assets/broken-main/package.json', JSON.stringify({
+    name: 'broken-main', main: 'lib/missing.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }));
+  write(dir, 'assets/broken-main/cordis.patch.yml', patchJson([{ id: 'bm' }]));
+  const out = validatePlugins(profileDir, null, path.join(dir, 'assets'), jsonYaml, fs);
+  assert.strictEqual(out.ok, false, '清单内 main 缺失 → 体检不通过（不再假绿）');
+  assert.deepStrictEqual(out.contractViolations, ['broken-main'], '可一键移除名单包含该包');
+  assert.ok(out.summary.errors >= 1);
+});

--- a/dsh-desktop/scripts/test/plugin-manager-patch.test.js
+++ b/dsh-desktop/scripts/test/plugin-manager-patch.test.js
@@ -202,3 +202,62 @@ test('卸载→恢复→卸载 往返不堆积注释', () => {
   assert.equal(countId(t, 'balance'), 1);
   assert.equal(removedCount(t), 1);
 });
+
+// #66：insert 同块兄弟条目不得被贪婪续行组吞掉（issue #66）
+test('#66 禁用：同 insert 块的兄弟条目保留（续行组不吞兄弟）', () => {
+  const text = [
+    '- insert:',
+    '    - id: terminal',
+    '      name: terminal',
+    '    - id: file-changes',
+    '      name: file-changes',
+    '',
+  ].join('\n');
+  const out = togglePluginInPatch(text, 'terminal', false);
+  assert.ok(out.includes('    - id: file-changes'), '兄弟条目 file-changes 必须保留');
+  assert.ok(!out.includes('    - id: terminal'), '目标条目已从 insert 块移除');
+  assert.match(out, /- id: terminal\s*\n\s*name: '?terminal'?\s*\n\s*disabled: true/);
+});
+
+test('#66 禁用：目标条目在块中间时前后兄弟都保留', () => {
+  const text = [
+    '- insert:',
+    '    - id: a',
+    '      name: a',
+    '    - id: terminal',
+    '      name: terminal',
+    '    - id: c',
+    '      name: c',
+    '',
+  ].join('\n');
+  const out = togglePluginInPatch(text, 'terminal', false);
+  assert.ok(out.includes('    - id: a'), '前置兄弟 a 保留');
+  assert.ok(out.includes('    - id: c'), '后置兄弟 c 保留');
+  assert.ok(!out.includes('    - id: terminal'), '目标条目已移除');
+});
+
+test('#66 禁用：id 前缀不误删（terminal 不匹配 terminal-tab）', () => {
+  const text = [
+    '- insert:',
+    '    - id: terminal-tab',
+    '      name: terminal-tab',
+    '',
+  ].join('\n');
+  const out = togglePluginInPatch(text, 'terminal', false);
+  assert.ok(out.includes('    - id: terminal-tab'), 'terminal-tab 不得被 terminal 误删');
+  assert.match(out, /- id: terminal\s*\n/, '无现成条目时按预期追加顶层条目');
+});
+
+test('#66 卸载：同 insert 块的兄弟条目保留', () => {
+  const text = [
+    '- insert:',
+    '    - id: terminal',
+    '      name: terminal',
+    '    - id: file-changes',
+    '      name: file-changes',
+    '',
+  ].join('\n');
+  const out = setPluginRemoved(text, 'terminal', true);
+  assert.ok(out.includes('    - id: file-changes'), '卸载时兄弟条目 file-changes 必须保留');
+  assert.equal(removedCount(out), 1);
+});


### PR DESCRIPTION
针对 issue #66 / #76 / #75 / #90 / #80 的五个缺陷修复（社区审计反馈）：

## #66 插件开关/卸载误删同块兄弟条目（数据丢失）
- 根因：`topLevelEntryRe`/`insertInnerEntryRe` 的 `\b` 是非法词边界（`terminal` 命中 `terminal-tab` 前缀），续行组 `(?:[ \t]+[^\n]*\n)*` 贪婪吞掉同缩进兄弟 `- id:` 行
- 修复：id 边界改负向断言 `(?![A-Za-z0-9_.-])`；续行组加同缩进兄弟前瞻收口 `(?:[ \t]+(?![ \t]*- id:)[^\n]*\n)*`（前瞻含回溯绕过的空白处理）
- 单测 +4（兄弟保留/块中间/前缀不误删/卸载保留兄弟）

## #76 防砖体检总结论与明细矛盾（假绿）
- 根因：`main 入口不存在` 恒为 warning，errors=0 时 `ok:true` 显示「未发现问题」，但 graph-memory/billion-context-dsh 缺 dist 实测会导致启动失败
- 修复：启动清单内插件的 main 缺失升级为 error（进入「一键移除失效条目」名单并给出处置建议）；非清单普通依赖保持 warning
- 单测 +2

## #75 打包门禁 check-syntax 假阳性
- 根因：`DETACHED_KEYWORD` 纯文本启发式命中模板字符串/块注释内的 `async\nfunction` 字样即中止打包
- 修复：新增词法扫描 `stripLiteralsAndComments`（字符串/模板字面量（含 `$`{`}` 花括号配对跳转）/行注释/块注释替换为等长空白保留行号），清洗后再匹配；真实事故形态（真正孤立的 async/await + function）仍能拦截

## #90 GitHub Release 多资产选择无平台/扩展名过滤
- 根因：`assets.find(x => x && x.name) || assets[0]` 恒取第一个资产，多资产 Release 可能下到 checksum 或错误平台包
- 修复：四段选择——平台匹配归档（win/windows + .tgz/.tar.gz/.zip）→ 任意归档 → 平台匹配 → 兜底第一个

## #80 插件更新 HTTP 重定向相对地址解析失败
- 根因：3xx 时 `res.headers.location` 原样透传递归，相对地址导致 `https.get` Invalid URL、http 跳转被协议拒绝（查询失败被镜像重试掩盖）
- 修复：`resolveRedirectLocation(location, baseUrl)` 用 `new URL(location, url)` 解析（相对/绝对均正确），非 https 协议显式拒绝，异常收敛为 rejection 不冒泡

### 测试
单测新增 6 个（plugin-manager-patch 23/23、desktop-validity 13/13），全量 178/178 通过；check-syntax 30 个入口全过；`node --check` main.js 0 错；`git diff --check` 干净。