### PR TITLE
fix(dsh-hub): graph-memory 自动装配前校验入口完整性（issue #65 补充）

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-hub/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-hub/lib/index.js
@@ -1849,7 +1849,7 @@ function gmSourceStatus() {
   const pkgPath = path.join(gmSourceDir(), 'package.json')
   if (existsSync(pkgPath)) {
     const meta = readJson(pkgPath)
-    return { present: true, version: meta?.version ?? null, dir: gmSourceDir(), source: 'plugin-src' }
+    return { present: true, version: meta?.version ?? null, dir: gmSourceDir(), source: 'plugin-src', entryOk: existsSync(path.join(gmSourceDir(), 'dist', 'index.js')) }
   }
   // 随 DSH Desktop 内置分发：companion 同步器把 assets/plugins/graph-memory 复制进
   // profile node_modules 并登记 bundles，无需 plugin-src 源码目录。
@@ -1860,7 +1860,7 @@ function gmSourceStatus() {
     try { isJunction = lstatSync(bundledDir).isSymbolicLink() } catch { /* 目录不可读按非 junction 处理 */ }
     if (!isJunction) {
       const meta = readJson(bundledPkg)
-      return { present: true, version: meta?.version ?? null, dir: bundledDir, source: 'bundled' }
+      return { present: true, version: meta?.version ?? null, dir: bundledDir, source: 'bundled', entryOk: existsSync(path.join(bundledDir, 'dist', 'index.js')) }
     }
   }
   return { present: false }
@@ -1916,6 +1916,11 @@ export function mountGraphMemoryLocked() {
   const src = gmSourceStatus()
   if (!src.present) {
     return { ok: false, reason: 'missing-source', message: '未找到 graph-memory 源码（plugin-src/graph-memory 不存在）' }
+  }
+  if (src.present && !src.entryOk) {
+    // 入口缺失（dist/index.js）：装配后启动 dsh web 会 ERR_MODULE_NOT_FOUND 直接失败，
+    // 比不装配更糟（issue #65）；明确报错让用户更新应用而不是静默挂载。
+    return { ok: false, reason: 'missing-entry', message: 'graph-memory 入口缺失（dist/index.js 不存在），请更新 DSH Desktop 后重试' }
   }
   const current = gmInstalledStatus()
   if (current.installed) {


### PR DESCRIPTION
## 目标

issue #65 的补充：管理员已把 graph-memory / billion-context-dsh 的 `dist` 入库（修复干净机器同步出残缺包），本 PR 补上缺失的另一半——**dsh-hub 自动装配前的入口完整性校验**。

## 改动（1 个文件，+7/-2）

`assets/plugins/dsh-hub/lib/index.js`：

1. `gmSourceStatus()` 两个分支（plugin-src / bundled）返回值新增 `entryOk`：检查 `dist/index.js` 是否存在；
2. `mountGraphMemoryLocked()` 在 `src.present && !src.entryOk` 时**明确拒绝装配**，返回 `{ ok: false, reason: 'missing-entry', message: 'graph-memory 入口缺失（dist/index.js 不存在），请更新 DSH Desktop 后重试' }`。

## 动机

不校验时：包不完整（同步中断 / 文件损坏 / 旧版本残留 / 杀软误删）→ dsh-hub 照常装配 → 之后「重启 dsh web 服务」或下次启动报 `ERR_MODULE_NOT_FOUND` 崩溃，错误信息难懂、位置靠后。

校验后：装配前拦截，报错清晰（「请更新 DSH Desktop 后重试」），把「几秒后的服务崩溃」提前为「装配时的明确拒绝」。正常路径行为不变（入口存在时完全照旧）。