### PR TITLE
feat: add second confirmation popup before uninstall

### DIFF
--- a/dsh-desktop/scripts/build-uninstaller.ps1
+++ b/dsh-desktop/scripts/build-uninstaller.ps1
@@ -14,12 +14,14 @@ $ErrorActionPreference = 'Stop'
 $root    = Split-Path -Parent $PSScriptRoot
 $unDir   = Join-Path $root 'uninstaller'
 $outDir  = Join-Path $root 'build'
-$src     = Join-Path $unDir 'DSH_Desktop_Uninstaller.cs'
 $icon    = Join-Path $unDir 'Uninstall_DSH_Desktop_icon.ico'
 $tmpOut  = Join-Path $outDir 'Uninstall_DSH_Desktop.new.exe'
 $finalOut = Join-Path $outDir 'Uninstall_DSH_Desktop.exe'
 
-if (-not (Test-Path -LiteralPath $src)) { throw "Missing source: $src" }
+# Compile every .cs under uninstaller/ so future modules can be added without
+# editing this script again.
+$srcFiles = @(Get-ChildItem -LiteralPath $unDir -Filter '*.cs' | Sort-Object Name | ForEach-Object { $_.FullName })
+if ($srcFiles.Count -eq 0) { throw "No C# source files found under $unDir" }
 if (-not (Test-Path -LiteralPath $icon)) { throw "Missing icon: $icon" }
 
 New-Item -ItemType Directory -Force -Path $outDir | Out-Null
@@ -38,9 +40,8 @@ $args = @(
     '/target:winexe',
     "/out:$tmpOut",
     "/r:$fwDir\System.Windows.Forms.dll",
-    "/r:$fwDir\System.Drawing.dll",
-    $src
-)
+    "/r:$fwDir\System.Drawing.dll"
+) + $srcFiles
 
 Write-Host "Compiling: $csc" -ForegroundColor Cyan
 & $csc @args

--- a/dsh-desktop/uninstaller/DSH_Desktop_Uninstaller.cs
+++ b/dsh-desktop/uninstaller/DSH_Desktop_Uninstaller.cs
@@ -381,6 +381,17 @@ class DSHDesktopUninstaller
             keepPresetNames = form.KeepPresetNames;
             keepPluginNames = form.KeepPluginNames;
             useDetectedRunningDsh = form.UseDetectedRunningDsh;
+
+            // Second confirmation: show exactly what will be retained before starting.
+            string summary = RetentionSummary();
+            string message = summary == "(none)"
+                ? "确定卸载 DSH Desktop 并删除所有用户数据吗？"
+                : "确定卸载 DSH Desktop 并保留以下内容吗？\r\n\r\n" + summary;
+            if (MessageBox.Show(message, "确认卸载", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) != DialogResult.OK)
+            {
+                return false;
+            }
+
             return true;
         }
     }

--- a/dsh-desktop/uninstaller/DSH_Desktop_Uninstaller.cs
+++ b/dsh-desktop/uninstaller/DSH_Desktop_Uninstaller.cs
@@ -14,6 +14,7 @@ using Microsoft.Win32;
 
 class DSHDesktopUninstaller
 {
+#region Fields, Constants & Paths
     static bool silent = false;
     static List<string> messages = new List<string>();
     static bool keepAgentPresets = false;
@@ -71,7 +72,9 @@ class DSHDesktopUninstaller
 
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     static extern int MessageBoxW(IntPtr hWnd, string lpText, string lpCaption, uint uType);
+#endregion
 
+#region Install Detection
     static string ResolveDshInstallDir()
     {
         // Prefer a DSH Desktop uninstall entry: this works across versions,
@@ -355,8 +358,10 @@ class DSHDesktopUninstaller
         }
 
         return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dsh");
+#endregion
     }
 
+#region Entry Point & CLI Parsing
     static bool ConfirmAndSelectRetention()
     {
         if (silent) return true;
@@ -565,7 +570,9 @@ class DSHDesktopUninstaller
         }
         return result;
     }
+#endregion
 
+#region Preset/Plugin Detection
     static List<PresetInfo> DetectAgentPresets()
     {
         List<PresetInfo> result = new List<PresetInfo>();
@@ -712,7 +719,9 @@ class DSHDesktopUninstaller
         string candidate = Path.Combine(webModules, relative);
         return Directory.Exists(candidate) ? candidate : string.Empty;
     }
+#endregion
 
+#region Uninstall Pipeline
     static bool IsAdministrator()
     {
         WindowsIdentity identity = WindowsIdentity.GetCurrent();
@@ -819,6 +828,8 @@ class DSHDesktopUninstaller
         return kept.Count == 0 ? "(none)" : string.Join(", ", kept.ToArray());
     }
 
+#endregion
+#region Process & File Cleanup
     static void KillDSHProcesses()
     {
         Log("[1/9] Stopping DSH Desktop processes...");
@@ -952,7 +963,9 @@ class DSHDesktopUninstaller
             Log("  Failed to delete file: " + file + " -> " + ex.Message);
         }
     }
+#endregion
 
+#region Registry & PATH Cleanup
     static void DeleteRegistryKeys()
     {
         Log("[2/9] Cleaning registry...");
@@ -1100,7 +1113,9 @@ class DSHDesktopUninstaller
             Log("  Failed to clean PATH: " + ex.Message);
         }
     }
+#endregion
 
+#region User Data Retention & Cleanup
     static void PreserveSelectedPlugins()
     {
         if (!keepPlugins || !keepRuntime) return;
@@ -1151,7 +1166,7 @@ class DSHDesktopUninstaller
             Log("  No plugin needed copying.");
         }
     }
-static bool IsSettingsFile(string path)
+    static bool IsSettingsFile(string path)
     {
         string name = Path.GetFileName(path);
         return !string.IsNullOrEmpty(name) && name.StartsWith("settings.yaml", StringComparison.OrdinalIgnoreCase);
@@ -1314,7 +1329,9 @@ static bool IsSettingsFile(string path)
         {
         }
     }
+#endregion
 
+#region Logging & Helpers
     static void InitializeLog()
     {
         try
@@ -1358,7 +1375,9 @@ static bool IsSettingsFile(string path)
             {
             }
         }
+#endregion
     }
+#region GUI (RetentionForm)
     class RetentionForm : Form
     {
         private class PresetListItem
@@ -1396,7 +1415,7 @@ static bool IsSettingsFile(string path)
                 return Label;
             }
         }
-private class GrayableCheckBox : CheckBox
+        private class GrayableCheckBox : CheckBox
           {
               protected override void OnPaint(PaintEventArgs e)
               {
@@ -2023,3 +2042,4 @@ private class GrayableCheckBox : CheckBox
         }
     }
 }
+#endregion

--- a/dsh-desktop/uninstaller/DSH_Desktop_卸载说明.txt
+++ b/dsh-desktop/uninstaller/DSH_Desktop_卸载说明.txt
@@ -75,7 +75,8 @@ DSH Desktop 完全卸载程序 - 使用说明
     - 其他 .dsh 数据：保留预设、聊天、插件、应用设置、模型配置之外的其余 .dsh 数据
       （graph-memory/storages/super-injector/profiles 等）
     - .dsh-runtime：保留 DSH CLI 运行时
-  勾选完成后点击“卸载”继续，点击“取消”退出。
+  勾选完成后点击“卸载”，会再次弹出确认窗口，列出本次要保留的内容；
+  点击“确定”才开始卸载，点击“取消”则退出。
 
 静默参数:
   Uninstall_DSH_Desktop.exe /S

--- a/dsh-desktop/uninstaller/DshRetentionContract.cs
+++ b/dsh-desktop/uninstaller/DshRetentionContract.cs
@@ -1,0 +1,35 @@
+// DSH Desktop Uninstaller - retention extension contract.
+//
+// These types are intentionally small: they define the extension surface for
+// future retention categories without forcing the current static implementation
+// to be rewritten in one pass. New categories (e.g. "keep WSL distro data",
+// "keep updater cache") can implement IRetentionCategory and be wired into the
+// confirmation/Run pipeline later.
+
+/// <summary>Common contract for an optional item that may be kept during uninstall.</summary>
+public interface IRetentionCategory
+{
+    string DisplayName { get; }
+
+    bool IsSelected { get; set; }
+
+    string DescribeRetention();
+}
+
+/// <summary>
+/// Simple abstract base for retention categories. New categories should derive
+/// from this class and only implement DescribeRetention().
+/// </summary>
+public abstract class RetentionCategory : IRetentionCategory
+{
+    protected RetentionCategory(string displayName)
+    {
+        DisplayName = displayName;
+    }
+
+    public string DisplayName { get; protected set; }
+
+    public bool IsSelected { get; set; }
+
+    public abstract string DescribeRetention();
+}


### PR DESCRIPTION
### 功能

在卸载确认窗口点击“卸载”后，新增二次确认弹窗：

- 列出本次实际要保留的内容；
- 没有勾选任何保留项时，提示会删除所有用户数据；
- 点击“确定”才开始卸载，点击“取消”则退出；
- 静默模式 `/S` 不弹窗，行为不变。

### 代码整理

- 为单文件 C# 卸载器添加 `#region` 分组：安装检测、进程/文件清理、注册表/PATH 清理、用户数据保留、日志、GUI。
- 新增 `DshRetentionContract.cs`：提供 `IRetentionCategory` / `RetentionCategory` 作为未来保留类别的扩展接口。
- `build-uninstaller.ps1` 改为编译 `uninstaller/*.cs`，以后新增模块无需改构建脚本。
- 修复源码中两处缩进异常；无运行时行为变化。

### 改动文件

- `dsh-desktop/uninstaller/DSH_Desktop_Uninstaller.cs`
- `dsh-desktop/uninstaller/DshRetentionContract.cs`
- `dsh-desktop/uninstaller/DSH_Desktop_卸载说明.txt`
- `dsh-desktop/scripts/build-uninstaller.ps1`