### PR TITLE
fix(guard): issue #97/#98/#99/#100 防护层修复

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -27,6 +27,12 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
   - **健康检查口径统一**：`logProfileBundleHealth` 改用与对账相同的 `resolveBundleDirLike` 双锚点解析，消除「对账判定可解析、健康检查误报缺失」的口径撕裂（诊断只读）；
   - **重复登记去重**：同一 bundle 名在 `dsh.profile.bundles` 中登记两次时，其补丁层条目会重复出现在组合 entry list 中，loader 装配期抛 `duplicate loader entry id`（fail-loud → 退出码 1），且启动防护覆盖不到（两层都能正常加载）——现对账保留首次出现、移除重复项（冗余而非无效登记，不进隔离记录），该形状此前从不清理；
   - **测试环境封闭**：`unit-sync-cli` 的 CLI 调用 PATH 收口到 System32——CLI 的 `findDshPackageDir` 会经 PATH 探测 `dsh` 命令，环境 PATH 上的真实 dsh（如 harness 安装）会被当作预设同步目标，把 `assets/agent-presets` 写进真实安装（内容相同、mtime 被改写）；测试必须封闭，绝不触碰真实环境。
+- **防护层修复（issue #97/#98/#99/#100，另含 #75 补强）**：社区批量上报的「防护罩有洞」问题逐一修复——
+  - **插件 GitHub Release 多资产选择（#97）**：原实现 `isWinAsset` 用子串匹配（`darwin` 含 `win` 会误判为 Windows 资产，选中 macOS 二进制）、无架构优先级（`win-ia32` 与 `win-x64` 乱序时选错）、无归档时可能选中 `.sha256` 校验和文本。现收口为纯函数 `selectGithubAsset(assets, platform)`：词边界平台判定（`win32-x64.tgz` ✓ / `darwin-x64.tgz` ✗）、架构优先级（x64/amd64 → arm64/aarch64 → ia32/x86 → arm → 无架构兜底，稳定排序）、任何阶段排除校验和/签名/说明等非二进制文件（含无扩展名 `SHA256SUMS`/`SHA512SUMS` 与 `.sha1`；全部被排除 → 明确拒绝更新并提示），9 项单测；
+  - **语法门禁剥离器支持正则字面量（#98）**：`check-syntax.js` 的字符串/注释剥离器不识别 JS 正则字面量——含引号的正则（如 `/[&<>"']/g`）会把引号当字符串起始，与后方引号配对将中间真实代码整段涂白，门禁对「孤立 async」失明（实测 preload.js 77.2% 被涂白、19 个 function 被吞）。现新增 `findRegexClose`（跳过转义与字符类、拒绝跨行伪正则、闭 `/` 后按 flags/除法链判定）整体涂白正则字面量；补除法链识别（`a / /re/g` 第一个 `/` 按除法跳过，`return /re/` 等关键字后接正则按白名单放行）、flags 白名单含 ES2022 `d`/ES2024 `v`；并给门禁加 preload.js 失明硬断言（保留率 <23% 或 function 被吞 >5 即 FAIL 且报错注明触发项，正常基线 ~29%/吞 1 字符串内文本），24 项单测（含 mid 注入回归，防 EOF 特判假绿）；
+  - **防砖体检 manifest 读取失败假绿（#99）**：`desktop-validity.js` 的 `validatePlugins` 用 `catch {}` 静默吞掉 profile `package.json` 读取/解析失败——启动清单读不到时清单内缺陷全部降级为 warning，体检返回「未发现问题」（假绿）。现显式记录 `manifestError`、总结论判定失败（含 `dsh.profile.bundles` 字段存在但非数组的结构损坏变体；字段缺失仍视为合法空清单），设置页体检区红字提示「无法读取启动清单，体检结果不可信」，4 种情形回归测试（缺失/损坏 JSON/bundles 非数组/正常）；
+  - **补丁条目 id 负向断言漏掉行内空白（#100）**：`togglePluginInPatch` 的条目定位负向断言 `(?![A-Za-z0-9_.-])` 对行内空格放行——非标 id `- id: foo bar` 会被 `toggle('foo')` 命中误加 disabled（insert 内层更会被整条误删）。负向断言加入空格/tab（只排除行内空白，不排除 `\n`——排除换行会让所有既有条目匹配不上退化为重复新建），2 项回归测试；
+  - **行注释内引号吞代码（#75 补强）**：剥离器此前不处理 `//` 行注释，注释内的引号会被当字符串起始吞掉后续代码（漏报比误报更危险）。现行注释整体涂白到行尾（保留换行），8 场景探测全过。
 
 ## [0.3.10] — 2026-08-17
 ### 新增

--- a/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
@@ -99,6 +99,7 @@ window.__ModuleLoader__.load({
 			diagValidOk: "未发现会导致启动失败的问题 ✓",
 			diagValidSummary: "已检查 {0} 个插件包：{1} 个错误，{2} 个警告",
 			diagValidConflict: "跨包重复的 loader 条目 id「{0}」（{1}）：下次启动可能失败（duplicate loader entry id）",
+			diagValidManifestFail: "无法读取启动清单（profile/package.json），体检结果不可信：",
 			diagRemoveBtn: "一键移除失效条目",
 			diagRemoveConfirm: "确认移除 {0} 个失效条目？（备份后从启动清单移除，重启生效）",
 			diagRemoveDone: "已从启动清单移除：{0}",
@@ -959,6 +960,7 @@ window.__ModuleLoader__.load({
 				if (!validReport) return null;
 				const r = validReport;
 				if (r.loadError) return jsx("div", { style: { fontSize: 12, color: "var(--dsw-alias-state-error-primary, #ff7a85)" }, children: L.diagValidFail + r.loadError });
+				if (r.manifestError) return jsx("div", { style: { fontSize: 12, color: "var(--dsw-alias-state-error-primary, #ff7a85)", wordBreak: "break-all" }, children: "⛔ " + L.diagValidManifestFail + r.manifestError });
 				const s = r.summary || { errors: 0, warnings: 0 };
 				return jsxs("div", { style: { display: "flex", flexDirection: "column", gap: 6, fontSize: 12 }, children: [
 					r.ok

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -37,6 +37,7 @@ const {
   githubAssetDownloadUrl,
   verifyIntegrity,
   findPackageRoot,
+  selectGithubAsset,
 } = require('./scripts/plugin-manager-update');
 const { installBuiltinPresets } = require('./scripts/install-minimal-win-preset');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
@@ -4425,18 +4426,14 @@ async function pluginManagerFetchGithubLatest(repo) {
   try {
     const data = await pluginManagerHttpGetJson(githubReleaseApiUrl(repo), 15000, { Accept: 'application/vnd.github+json' });
     if (data && data.tag_name && Array.isArray(data.assets) && data.assets.length > 0) {
-      // 多资产 Release 选择策略（issue #90）：优先「平台匹配的归档」
-      // （win/windows + .tgz/.tar.gz/.zip）→ 任意归档 → 平台匹配任意文件 →
-      // 兜底第一个。此前直接取第一个资产，多资产 Release（checksum / 其它
-      // 平台分包）会下载错文件。
-      const isArchive = (n) => /\.(?:tgz|tar\.gz|zip)$/i.test(n);
-      const isWinAsset = (n) => /(?:win|windows)/i.test(n);
-      const a =
-        data.assets.find((x) => x && x.name && isArchive(x.name) && isWinAsset(x.name)) ||
-        data.assets.find((x) => x && x.name && isArchive(x.name)) ||
-        data.assets.find((x) => x && x.name && isWinAsset(x.name)) ||
-        data.assets.find((x) => x && x.name) ||
-        data.assets[0];
+      // 多资产 Release 选择策略（issue #90/#97）：纯函数 selectGithubAsset——
+      // 词边界平台判定（darwin 不再含 "win" 误判）、架构优先级（x64 优先）、
+      // 任何阶段排除 .sha256/.sig/.asc 等非二进制文件。无可用资产返回 null。
+      const a = selectGithubAsset(data.assets, process.platform);
+      if (!a) {
+        log('plugin-manager', 'Release ' + data.tag_name + ' 无可下载资产（仅校验和/签名等非二进制文件）');
+        return null;
+      }
       // GitHub API digest 形如 "sha256:<hex64>"（部分老资产无此字段）
       const dm = /^(?:sha256:)?([0-9a-fA-F]{64})$/.exec(String(a.digest || ''));
       return {

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -63,8 +63,70 @@ const entryFiles = [
 // 孤立 async/await 表达式在运行时会抛 ReferenceError，必须在打包前拦截。
 const DETACHED_KEYWORD = /^[ \t]*(async|await)[ \t]*(?:\/\/[^\r\n]*)?[ \t]*\r?\n(?:[ \t]*(?:\/\/[^\r\n]*)?[ \t]*\r?\n)*[ \t]*function\b/gm;
 
-// 扫描前剔除字符串字面量（单/双引号）、模板字面量与块注释，避免其中的
-// "async\nfunction" 合法文本被误判为「孤立 async」并终止打包（issue #75）。
+// 正则字面量的 flags 白名单（dgimsuv，含 ES2022 d / ES2024 v）。闭 / 之后
+// 只允许这些字母，否则像 `a / b / c` 这样的除法链会被误认成正则。
+const REGEX_FLAG_CHARS = new Set('dgimsuv');
+
+// 除法链识别（issue #98 补强）：正则起始 / 之前若紧跟表达式操作数
+// （标识符 / 数字 / ) / ]），它更可能是除法运算符而非正则字面量——
+// `a / /re/g` 的第一个 / 若不识别为除法，会在真正则的起始 / 处伪闭合、
+// 把真正则内的引号放给字符串分支，整段涂白导致门禁失明。
+// 但 `return /re/`、`typeof /re/` 等语句前导关键字后接正则属于合法 JS，
+// 必须按关键字白名单放行（否则 return 后的正则内引号会重新致盲）。
+const EXPR_END_KEYWORDS = new Set([
+  'return', 'typeof', 'instanceof', 'in', 'delete', 'void', 'new',
+  'throw', 'yield', 'await', 'case', 'else', 'do', 'of',
+]);
+function prevTokenIsOperand(text, i) {
+  let j = i - 1;
+  while (j >= 0 && (text[j] === ' ' || text[j] === '\t')) j -= 1;
+  if (j < 0) return false;
+  const c = text[j];
+  if (/[A-Za-z0-9_)\]]/.test(c)) {
+    // 字母/下划线开头：取完整标识符，命中关键字白名单 → 正则前导（非除法）
+    if (/[A-Za-z_]/.test(c)) {
+      let k = j;
+      while (k >= 0 && /[A-Za-z0-9_$]/.test(text[k])) k -= 1;
+      if (EXPR_END_KEYWORDS.has(text.slice(k + 1, j + 1))) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * 在 text[start]（必须是 '/'）处试探「正则字面量」的闭 / 下标。
+ * 规则：跳过转义（\/ 等）；字符类 [...] 内的 / 与引号不结束正则；
+ * 传统正则字面量不跨行；闭 / 之后允许 flags 字母（gimsuy）与空白，
+ * 但空白后若跟普通字母/数字则按除法链（a / b / c）处理，返回 -1。
+ * 找不到返回 -1。
+ */
+function findRegexClose(text, start) {
+  let j = start + 1;
+  let inClass = false;
+  for (; j < text.length; j += 1) {
+    const c = text[j];
+    if (c === '\\') { j += 1; continue; }
+    if (c === '\n' || c === '\r') return -1;
+    if (c === '[') { inClass = true; continue; }
+    if (c === ']') { inClass = false; continue; }
+    if (c === '/' && !inClass) break;
+  }
+  if (j >= text.length) return -1;
+  let k = j + 1;
+  while (k < text.length && REGEX_FLAG_CHARS.has(text[k])) k += 1;
+  while (k < text.length && (text[k] === ' ' || text[k] === '\t')) k += 1;
+  const nxt = text[k];
+  // 闭 / 后（跳过 flags 与空白）必须是分隔符/行尾/点号（.test 调用）——
+  // 普通字母或数字说明是除法链（a / b / c）的下一操作数。
+  if (nxt !== undefined && /[A-Za-z0-9_]/.test(nxt)) return -1;
+  return j;
+}
+
+// 扫描前剔除字符串字面量（单/双引号）、模板字面量、块注释与正则字面量，
+// 避免其中的 "async\nfunction" 合法文本被误判为「孤立 async」并终止打包
+// （issue #75；issue #98：正则字面量内的引号若当字符串起始，会把中间
+// 真实代码整段涂白，门禁失明——preload.js 实测曾 77.2% 被涂白）。
 // 用等长空白替换以保持行号与列号不变，使报错定位仍准确。
 function stripStringsAndBlockComments(text) {
   const out = [];
@@ -79,6 +141,28 @@ function stripStringsAndBlockComments(text) {
       out.push(repl(text.slice(i, end + 2)));
       i = end + 2;
       continue;
+    }
+    // 行注释：跳到行尾（保留换行）。行注释内的引号/反引号若被当作字符串
+    // 起始，会把后续真实代码整段剔除，导致「孤立 async」漏报并放行走私
+    // （issue #75 补强：漏报比误报更危险）。
+    if (c === '/' && text[i + 1] === '/') {
+      const nl = text.indexOf('\n', i + 2);
+      if (nl === -1) { out.push(repl(text.slice(i))); break; }
+      out.push(repl(text.slice(i, nl)));
+      i = nl;
+      continue;
+    }
+    // 正则字面量（issue #98）：整体涂白，防止其中的引号被当成字符串起始。
+    // 除法运算符（a / b）的 / 不是正则起始，跳过；关键字后接正则（return /re/）放行。
+    if (c === '/' && text[i + 1] !== '/' && text[i + 1] !== '*') {
+      if (!prevTokenIsOperand(text, i)) {
+        const close = findRegexClose(text, i);
+        if (close >= 0) {
+          out.push(repl(text.slice(i, close + 1)));
+          i = close + 1;
+          continue;
+        }
+      }
     }
     // 字符串 / 模板字面量（含插值片段）。处理转义；模板插值 ${} 内的内容在
     // 绝大多数场景也是文档/示例文本，统一剔除即可规避误报。
@@ -133,6 +217,28 @@ for (const file of entryFiles) {
     continue;
   }
   const text = fs.readFileSync(filePath, 'utf8');
+  const scanned = stripStringsAndBlockComments(text);
+  // issue #98 失明防护：preload.js 含正则字面量（如 /[&<>"']/g）。若剥离器
+  // 失明复发（正则内引号当字符串起始，吞掉后续代码），非空格字符保留率会
+  // 断崖下跌、真实 function 声明被成批吞掉（曾实测 77.2% 涂白 / 19 个被吞）。
+  // 硬性断言防回归——失明 = 放行走私。正常基线：保留率 ~29%（字符串/注释/
+  // 正则天然占 70%），function 仅字符串字面量内的文本被涂（0 个真实声明）。
+  // 阈值 23% 相对基线留 6pp 余量（失明基线 22.8%，fn 吞没断言是主哨兵）。
+  if (file === 'preload.js') {
+    const ns0 = (text.match(/[^\s]/g) || []).length;
+    const ns1 = (scanned.match(/[^\s]/g) || []).length;
+    const ratio = ns0 > 0 ? ns1 / ns0 : 1;
+    const fn0 = (text.match(/function\b/g) || []).length;
+    const fn1 = (scanned.match(/function\b/g) || []).length;
+    if (ratio < 0.23 || fn0 - fn1 > 5) {
+      failed++;
+      const why = ratio < 0.23
+        ? `剥离保留率 ${(ratio * 100).toFixed(1)}%（阈值 23%）`
+        : `function 被吞 ${fn0 - fn1} 个（阈值 5）`;
+      console.error(`[check-syntax] FAIL preload.js（${why}，疑似剥离器失明）`);
+      continue;
+    }
+  }
   const hits = detachedHits(text);
   if (hits.length > 0) {
     failed++;

--- a/dsh-desktop/scripts/desktop-validity.js
+++ b/dsh-desktop/scripts/desktop-validity.js
@@ -203,18 +203,30 @@ function checkPluginPackage(name, dir, yaml, fs = require('node:fs'), listed = f
  * @param {string|null} assetsDir
  * @param {object} yaml js-yaml 方言加载器
  * @param {object} fs
- * @returns {object} { ok, checked, conflicts, contractViolations, summary:{errors, warnings} }
+ * @returns {object} { ok, manifestError, checked, conflicts, contractViolations, summary:{errors, warnings} }
+ *   manifestError = profile package.json 读取/解析失败信息（此时 ok 必为 false，体检不可信）
  *   contractViolations = 在启动清单内但缺 dsh.bundle.patch 声明的包名（可一键移除）
  */
 function validatePlugins(profileDir, coreDirDshAt, assetsDir, yaml, fs = require('node:fs')) {
   let listedSet = new Set();
+  let manifestError = null;
   try {
     const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
-    const bundles = manifest && manifest.dsh && manifest.dsh.profile && Array.isArray(manifest.dsh.profile.bundles)
-      ? manifest.dsh.profile.bundles
-      : [];
-    listedSet = new Set(bundles.filter((n) => typeof n === 'string'));
-  } catch { /* 无 manifest 时 listedSet 为空 */ }
+    const profileMeta = manifest && manifest.dsh && manifest.dsh.profile ? manifest.dsh.profile : null;
+    // issue #99 补强：bundles 字段存在但非数组 = 结构损坏，与 manifest 读取失败
+    // 同级的假绿变体（静默置空会让清单内缺陷全部降级 warning）；字段缺失则
+    // 视为合法空清单，避免新装 profile 误报。
+    if (profileMeta && !Array.isArray(profileMeta.bundles)) {
+      manifestError = 'dsh.profile.bundles 不是数组（实际类型: ' + (typeof profileMeta.bundles) + '）';
+    } else {
+      const bundles = profileMeta ? profileMeta.bundles : [];
+      listedSet = new Set(bundles.filter((n) => typeof n === 'string'));
+    }
+  } catch (err) {
+    // issue #99：manifest 缺失/损坏时不能静默 —— listedSet 为空会让清单内缺陷
+    // 全部降级为 warning，体检假绿。显式记录并让总结论判定为失败。
+    manifestError = String((err && err.message) || err);
+  }
   const checked = collectPluginCandidates(profileDir, coreDirDshAt, assetsDir, fs).map((c) => {
     const result = checkPluginPackage(c.name, c.dir, yaml, fs, listedSet.has(c.name));
     return {
@@ -261,7 +273,14 @@ function validatePlugins(profileDir, coreDirDshAt, assetsDir, yaml, fs = require
   const contractViolations = checked
     .filter((c) => c.listed && c.issues.some((i) => i.level === 'error' && /启动清单/.test(i.text)))
     .map((c) => c.name);
-  return { ok: errors === 0, checked, conflicts, contractViolations, summary: { errors, warnings } };
+  return {
+    ok: errors === 0 && !manifestError,
+    manifestError,
+    checked,
+    conflicts,
+    contractViolations,
+    summary: { errors, warnings },
+  };
 }
 
 module.exports = {

--- a/dsh-desktop/scripts/plugin-manager-patch.js
+++ b/dsh-desktop/scripts/plugin-manager-patch.js
@@ -26,16 +26,19 @@ function yamlQuote(s) {
 // 顶层用户层条目（缩进 0-2 空格）+ 完整子树（含行尾换行）。
 // 子树用非贪婪 [\s\S]*? 匹配，并用「下一同级 - id: / - insert: / 注释 / 文件尾」
 // 前瞻收口，避免贪婪续行组把同一 insert 块内后续兄弟条目一并吞掉（issue #66）。
-// id 边界用负向断言 (?![A-Za-z0-9_.-])，因为 \b 在连字符/点后不是合法 YAML 词边界
-// （terminal\b 会误中 terminal-tab）。
+// id 边界用负向断言 (?![A-Za-z0-9_.\t -])，因为 \b 在连字符/点后不是合法 YAML 词边界
+// （terminal\b 会误中 terminal-tab）；行内空白（空格/tab）一并计入不允许的下一个
+// 字符，避免含空格的非标 id（`- id: foo bar`）被 foo 命中误改（issue #100）。
+// 注意只排除行内空白、不能排除 \n：条目行尾换行必须放行，否则既有条目全部
+// 匹配不上（退化为重复新建条目）。
 function topLevelEntryRe(id) {
-  return new RegExp('(?:^|\\n)([ \\t]{0,2})- id:\\s*' + escRegExp(id) + '(?![A-Za-z0-9_.-])[^\\n]*\\n([\\s\\S]*?)(?=(?:\\n[ \\t]{0,2}- id:)|(?:\\n[ \\t]{0,2}- insert:)|(?:\\n#)|\\s*$)', 'g');
+  return new RegExp('(?:^|\\n)([ \\t]{0,2})- id:\\s*' + escRegExp(id) + '(?![A-Za-z0-9_.\\t -])[^\\n]*\\n([\\s\\S]*?)(?=(?:\\n[ \\t]{0,2}- id:)|(?:\\n[ \\t]{0,2}- insert:)|(?:\\n#)|\\s*$)', 'g');
 }
 
 // insert 块内的内层条目（缩进 >= 4）+ 完整子树（含行尾换行）。
 // 同 topLevelEntryRe：非贪婪子树 + 下一同级/上级条目或文件尾前瞻收口。
 function insertInnerEntryRe(id) {
-  return new RegExp('(?:^|\\n)[ \\t]+- id:\\s*' + escRegExp(id) + '(?![A-Za-z0-9_.-])[^\\n]*\\n([\\s\\S]*?)(?=(?:\\n[ \\t]+- id:)|(?:\\n[ \\t]{0,2}- id:)|(?:\\n[ \\t]{0,2}- insert:)|\\s*$)', 'g');
+  return new RegExp('(?:^|\\n)[ \\t]+- id:\\s*' + escRegExp(id) + '(?![A-Za-z0-9_.\\t -])[^\\n]*\\n([\\s\\S]*?)(?=(?:\\n[ \\t]+- id:)|(?:\\n[ \\t]{0,2}- id:)|(?:\\n[ \\t]{0,2}- insert:)|\\s*$)', 'g');
 }
 
 // 本模块写入的标记注释行（整行，含行尾换行）。

--- a/dsh-desktop/scripts/plugin-manager-update.js
+++ b/dsh-desktop/scripts/plugin-manager-update.js
@@ -40,6 +40,71 @@ function ghProxyUrl(url) {
   return GH_PROXY_PREFIXES[0] + url;
 }
 
+// ---------------------------------------------------------------------------
+// GitHub Release 多资产选择（issue #90 遗留边界，issue #97 根治）：
+// 原实现 isWinAsset 用子串匹配（darwin 含 "win" 误判为 Windows）、无架构
+// 优先级、无归档时可能选中 .sha256 校验和文本。这里改为纯函数 + 词边界
+// 平台判定 + 架构优先级 + 任何阶段排除非二进制文件。
+// ---------------------------------------------------------------------------
+
+/** 任何阶段都不得选中的「非二进制」文件（校验和/签名/说明等，下载了无法安装）。 */
+const NON_BINARY_RE = /\.(?:sha256|sha512|sha1|sig|asc|txt|md|json|yaml|yml|toml|ini|nfo|log)$|(?:^|[.\-_])sha(?:256|512|1)?sums?$/i;
+
+/** process.platform 值 → 资产命名中的平台关键词（词边界匹配）。 */
+const PLATFORM_HINTS = {
+  win32: ['win', 'windows'],
+  darwin: ['darwin', 'macos', 'osx'],
+  linux: ['linux'],
+};
+
+/** 架构优先级（越小越优先）：x64/amd64 > arm64/aarch64 > ia32/x86 > arm。 */
+const ARCH_ORDER = ['x64', 'amd64', 'arm64', 'aarch64', 'ia32', 'x86', 'arm'];
+
+/**
+ * 从 GitHub Release 资产中挑选「当前平台可用的安装包」：
+ *   1) 剔除 .sha256/.sig/.asc/说明文档等非二进制文件（任何阶段不选中）；
+ *   2) 平台词边界匹配（win/windows | darwin/macos/osx | linux）优先；
+ *   3) 平台池内归档（.tgz/.tar.gz/.zip）优先，无归档时回退平台池任意文件；
+ *   4) 架构优先级排序（x64 优先，ia32/arm64 次之）。
+ * 纯函数，便于单测。返回资产对象；无可下载资产返回 null。
+ * @param {Array} assets GitHub API 资产数组（含 name 字段的对象）
+ * @param {string} platform process.platform 值（win32/darwin/linux）
+ */
+function selectGithubAsset(assets, platform) {
+  const list = (assets || []).filter((x) => x && typeof x.name === 'string');
+  const candidates = list.filter((x) => !NON_BINARY_RE.test(x.name));
+  if (!candidates.length) return null;
+
+  const hints = PLATFORM_HINTS[platform] || [];
+  // 词边界平台匹配：win/windows（win 后可带数字：win32/win64/win-arm64），
+  // 前后必须是分隔符/行首行尾——darwin 含 "win" 子串但前无边界，不误配。
+  const platRe = hints.length
+    ? new RegExp('(?:^|[.\\-_])(' + hints.map((h) => (h === 'win' ? 'win\\d*' : h)).join('|') + ')(?:[.\\-_]|$)', 'i')
+    : null;
+  const platPool = platRe ? candidates.filter((x) => platRe.test(x.name)) : [];
+  const pool = platPool.length ? platPool : candidates;
+
+  const archives = pool.filter((x) => /\.(?:tgz|tar\.gz|zip)$/i.test(x.name));
+  const finalPool = archives.length ? archives : pool;
+
+  const archPatterns = ARCH_ORDER.map((a) => new RegExp('(?:^|[.\\-_])' + a + '(?:[.\\-_]|$)', 'i'));
+  const archScore = (name) => {
+    for (let i = 0; i < archPatterns.length; i += 1) {
+      if (archPatterns[i].test(name)) return i;
+    }
+    return archPatterns.length; // 无架构信息 → 排最后但可用
+  };
+  // 排序：平台命中优先（darwin-x64 与 win32-x64 同架构时仍必须选 win32），
+  // 再按架构优先级。稳定排序保证同分保持资产原始顺序。
+  const platHit = (name) => (platRe ? (platRe.test(name) ? 0 : 1) : 0);
+  return finalPool.slice().sort((a, b) => {
+    const pa = platHit(a.name);
+    const pb = platHit(b.name);
+    if (pa !== pb) return pa - pb;
+    return archScore(a.name) - archScore(b.name);
+  })[0] || null;
+}
+
 /** 校验 sha512 base64 integrity（npm dist.integrity 格式: sha512-<base64>）。 */
 function verifyIntegrity(buffer, integrity) {
   if (!integrity || typeof integrity !== 'string') return false;
@@ -91,4 +156,6 @@ module.exports = {
   GH_PROXY_PREFIXES,
   verifyIntegrity,
   findPackageRoot,
+  selectGithubAsset,
+  NON_BINARY_RE,
 };

--- a/dsh-desktop/scripts/test/check-syntax.test.js
+++ b/dsh-desktop/scripts/test/check-syntax.test.js
@@ -1,0 +1,180 @@
+'use strict';
+// 单元测试：scripts/check-syntax.js 的剥离器与孤立 async/function 扫描。
+// 背景：issue #75（字符串/注释内合法文本误报）→ 修复引入 issue #98 失明
+// （正则字面量内引号当字符串起始，把中间真实代码涂白 → 真实缺陷漏报）。
+// 本测试用 vm 加载 check-syntax.js 的 core 函数（切割到门禁执行段之前），
+// 覆盖：#75 原始场景、行注释引号补强、#98 正则字面量各形态、mid 注入回归、
+// 真实 preload.js 保留率（防失明复发）。
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const CS_PATH = path.join(__dirname, '..', 'check-syntax.js');
+const csSrc = fs.readFileSync(CS_PATH, 'utf8');
+const cut = csSrc.indexOf('const missing = entryFiles.filter');
+assert.ok(cut > 0, 'check-syntax.js 结构异常：找不到门禁执行段起点');
+const coreSrc = csSrc.slice(0, cut);
+const ctx = { require, console, process, __dirname: path.dirname(CS_PATH), __filename: CS_PATH };
+vm.createContext(ctx);
+vm.runInContext(coreSrc, ctx);
+const detachedHits = vm.runInContext('detachedHits', ctx);
+const stripStringsAndBlockComments = vm.runInContext('stripStringsAndBlockComments', ctx);
+const findRegexClose = vm.runInContext('findRegexClose', ctx);
+
+test('check-syntax 可加载：core 函数就绪', () => {
+  assert.equal(typeof detachedHits, 'function');
+  assert.equal(typeof stripStringsAndBlockComments, 'function');
+  assert.equal(typeof findRegexClose, 'function');
+});
+
+// ---------- #75 原始目标（防误报） ----------
+
+test('#75 字符串内的 async\\nfunction 不命中', () => {
+  const s = 'const s = "async\\nfunction";\nconsole.log(s);';
+  assert.equal(detachedHits(s).length, 0);
+});
+
+test('#75 模板字面量内的 async\\nfunction 不命中', () => {
+  const s = 'const t = `async\\nfunction`;\nconsole.log(t);';
+  assert.equal(detachedHits(s).length, 0);
+});
+
+test('#75 块注释内的 async\\nfunction 不命中', () => {
+  const s = '/* async\\nfunction */\nconst x = 1;';
+  assert.equal(detachedHits(s).length, 0);
+});
+
+// ---------- #75 补强：行注释 ----------
+
+test('行注释内的引号不吞后续代码（真实孤立仍命中）', () => {
+  const s = '// comment with "quote"\nasync\nfunction real() {}\n';
+  assert.ok(detachedHits(s).length >= 1, '行注释引号后真实孤立 async 必须命中');
+});
+
+test('行注释内的 async\\nfunction 不命中', () => {
+  const s = '// async\n// function\nconst x = 1;';
+  assert.equal(detachedHits(s).length, 0);
+});
+
+// ---------- #98 失明回归：正则字面量 ----------
+
+test('#98 正则内引号不吞代码：/["\' ]/g 后真实孤立命中', () => {
+  const s = ['const re = /["\' ]/g;', 'async', 'function probe() {}', 'module.exports = probe;'].join('\n');
+  assert.ok(detachedHits(s).length >= 1, '正则含引号后真实孤立 async 必须命中（0 = 门禁失明）');
+});
+
+test('#98 preload.js 同款正则 /[&<>"\' ]/g 后真实孤立命中', () => {
+  const s = ['const re = /[&<>"\' ]/g;', 'async', 'function f() {}', 'module.exports = f;'].join('\n');
+  assert.ok(detachedHits(s).length >= 1);
+});
+
+test('#98 无 flags 正则含引号后真实孤立命中', () => {
+  const s = ['const re = /"foo"/;', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1);
+});
+
+test('#98 转义斜杠正则（/\\//）后真实孤立命中', () => {
+  const s = ['const re = /\\//.test(x);', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1);
+});
+
+test('#98 字符类含斜杠正则（/[\\/"]/）后真实孤立命中', () => {
+  const s = ['const re = /[\\/"]/;', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1);
+});
+
+test('#98 除法链不误吞：a / b / c 后真实孤立命中', () => {
+  const s = ['const x = a / b / c;', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1, '除法链（第一个 / 可能被误判正则）不得吞掉后续孤立 async');
+});
+
+test('#98 单除法不误判为正则：a / b; 后真实孤立命中', () => {
+  const s = ['const x = a / b;', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1);
+});
+
+test('#98 正则不能跨行：跨行 / 按普通字符处理（不整段涂白）', () => {
+  const s = 'const re = /"a\nb"/;\nasync\nfunction f() {}\n';
+  assert.ok(detachedHits(s).length >= 1, '跨行伪正则不得吞掉后续孤立 async');
+});
+
+// ---------- #98 注入位置回归 ----------
+
+test('#98 mid 位置注入必须命中（防 EOF 特判假绿）', () => {
+  const mid = ['const re = /["\' ]/g;', 'async', 'function midFn() {}', 'const z = "tail";'].join('\n');
+  assert.ok(detachedHits(mid).length >= 1, 'mid 注入漏报 = 回归测试在 EOF 断言会假绿');
+});
+
+test('#98 EOF 位置注入同样命中', () => {
+  const eof = ['const re = /["\' ]/g;', 'line1', 'const z = "tail";', 'async', 'function eofFn() {}'].join('\n');
+  assert.ok(detachedHits(eof).length >= 1);
+});
+
+// ---------- 行号保持 ----------
+
+test('命中行号正确（等长空白替换保持行列）', () => {
+  const s = 'line1\nasync\n\nfunction f() {}\n';
+  const hits = detachedHits(s);
+  assert.ok(hits.length >= 1);
+  assert.equal(hits[0].line, 2, 'async 在第 2 行');
+});
+
+// ---------- findRegexClose 单元 ----------
+
+test('findRegexClose：字符类内斜杠不结束、转义跳过、除法拒绝', () => {
+  assert.equal(findRegexClose('/["\' ]/g', 0), 6, '闭 / 在 index 6');
+  assert.equal(findRegexClose('/[\\/"]/', 0), 6, '字符类内转义斜杠不算闭');
+  assert.equal(findRegexClose('/a\\/b/g', 0), 5, '转义斜杠跳过，闭 / 在 index 5');
+  assert.equal(findRegexClose('a / b / c', 2), -1, '除法链的闭 / 后是字母 c，拒绝');
+  assert.equal(findRegexClose('a / b;', 2), -1, '单除法无闭 /');
+  assert.equal(findRegexClose('/x/', 0), 2, '简单正则');
+  assert.equal(findRegexClose('/x/gi', 0), 2, '多 flags 不影响闭位置');
+  assert.equal(findRegexClose('/x/ .test', 0), 2, '闭 / 后点号调用放行');
+  assert.equal(findRegexClose('/x/g;', 0), 2, '闭 / 后分号放行');
+});
+
+// ---------- 真实 preload.js 保留率（失明硬指标） ----------
+
+test('#98 真实 preload.js 剥离后保留率与 function 存活（失明复发即失败）', () => {
+  const pre = fs.readFileSync(path.join(__dirname, '..', '..', 'preload.js'), 'utf8');
+  const scanned = stripStringsAndBlockComments(pre);
+  const ns0 = (pre.match(/[^\s]/g) || []).length;
+  const ns1 = (scanned.match(/[^\s]/g) || []).length;
+  const pct = (ns1 / ns0) * 100;
+  // 正常基线 ~29%（preload.js 字符串/注释/正则天然占 ~70%）；失明复发时 ~23% 且 function 成批被吞
+  assert.ok(pct > 25, `preload.js 保留率 ${pct.toFixed(1)}% ≤ 25%（失明复发，应 >25%）`);
+  const fn0 = (pre.match(/function\b/g) || []).length;
+  const fn1 = (scanned.match(/function\b/g) || []).length;
+  // 只允许字符串字面量内的 function 文本被涂（preload.js 有 1 处 'function' 字符串）；
+  // 失明复发时 18 个真实声明会被成批吞掉（曾吞 19 个）。
+  assert.ok(fn0 - fn1 <= 5, `function 被吞 ${fn0 - fn1} 个（应 ≤5，真实声明必须存活）`);
+});
+
+// ---------- 终审补强：除法链+正则相邻（A1）、ES2022/2024 flags（B1） ----------
+
+test('A1 除法紧跟正则不吞代码：a / /["\' ]/g.test(x) 后真实孤立命中', () => {
+  const s = ['const n = a / /["\' ]/g.test(x);', 'async', 'function f() {}', 'module.exports = f;'].join('\n');
+  assert.ok(detachedHits(s).length >= 1, '除法 / 在真正则起始处伪闭合会把正则内引号放给字符串分支 → 失明');
+});
+
+test('A1 关键字后接正则放行：return /["\' ]/g 后真实孤立命中', () => {
+  const s = ['function pick() {', '  return /["\' ]/g;', '}', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1, 'return 后接正则（合法 JS）不得被当除法跳过 → 正则内引号致盲');
+});
+
+test('A1 关键字感知不误伤常规除法：yield a / b; 后真实孤立命中', () => {
+  const s = ['function* g() {', '  yield a / b;', '}', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1, 'yield 后是表达式除法 a / b，第一个 / 应按除法跳过');
+});
+
+test('B1 ES2022 d flag 正则含引号后真实孤立命中', () => {
+  const s = ['const re = /["\' ]/d;', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1, 'd flag 不在 flags 白名单会拒绝整个正则 → 引号致盲');
+});
+
+test('B1 ES2024 v flag 正则含引号后真实孤立命中', () => {
+  const s = ['const re = /["\' ]/v;', 'async', 'function f() {}'].join('\n');
+  assert.ok(detachedHits(s).length >= 1);
+});

--- a/dsh-desktop/scripts/test/desktop-validity.test.js
+++ b/dsh-desktop/scripts/test/desktop-validity.test.js
@@ -222,3 +222,50 @@ test('validatePlugins: 覆盖条目（disabled/config）不算注册 → 不产�
   const out3 = validatePlugins(profileDir, null, path.join(dir, 'assets'), jsonYaml, fs);
   assert.strictEqual(out3.ok, true, '定向 insert 组名不算注册');
 });
+
+test('issue #99: profile package.json 缺失/损坏 → manifestError 显式 + ok:false（不再假绿）', () => {
+  const dir = tmpdir();
+  const profileDir = dir;
+  const assetsDir = path.join(dir, 'assets');
+  write(assetsDir, 'good-pkg/package.json', JSON.stringify({ name: 'good-pkg', dsh: { bundle: { patch: './cordis.patch.yml' } } }));
+  write(assetsDir, 'good-pkg/cordis.patch.yml', patchJson([{ id: 'good' }]));
+  // 情况一：package.json 不存在（ENOENT）
+  let out = validatePlugins(profileDir, null, assetsDir, jsonYaml, fs);
+  assert.strictEqual(out.ok, false, 'manifest 缺失必须判失败');
+  assert.ok(out.manifestError, 'manifestError 应有信息（ENOENT）');
+  assert.match(out.manifestError, /ENOENT/);
+  // 情况二：package.json 是损坏 JSON（JSON.parse 抛错）
+  write(profileDir, 'package.json', '{oops not json');
+  out = validatePlugins(profileDir, null, assetsDir, jsonYaml, fs);
+  assert.strictEqual(out.ok, false, 'manifest 损坏必须判失败');
+  assert.ok(out.manifestError, 'manifestError 应有信息（解析错误）');
+  assert.match(out.manifestError, /(JSON|Unexpected|oops)/i);
+  // checked 仍照常执行（清单之外的内置配套照查），但 listed 标志全部为 false
+  assert.ok(Array.isArray(out.checked) && out.checked.some((c) => c.name === 'good-pkg'), 'checked 不被 manifest 失败阻断');
+  assert.ok(out.checked.every((c) => c.listed === false), 'manifest 失败时所有 listed 为 false');
+  // 情况三：manifest 正常可读 → 无 manifestError 且 listed 生效
+  write(profileDir, 'package.json', JSON.stringify({ name: 'p', dsh: { profile: { bundles: ['good-pkg'] } } }));
+  out = validatePlugins(profileDir, null, assetsDir, jsonYaml, fs);
+  assert.strictEqual(out.manifestError, null, 'manifest 正常时无 manifestError');
+  assert.strictEqual(out.ok, true, 'manifest 正常且无缺陷 → ok:true');
+  assert.ok(out.checked.find((c) => c.name === 'good-pkg').listed, '清单可读后 listed 生效');
+});
+
+test('issue #99 补强 B4: dsh.profile.bundles 存在但非数组 → manifestError + ok:false（假绿变体）', () => {
+  const dir = tmpdir();
+  const profileDir = dir;
+  const assetsDir = path.join(dir, 'assets');
+  write(assetsDir, 'good-pkg/package.json', JSON.stringify({ name: 'good-pkg', dsh: { bundle: { patch: './cordis.patch.yml' } } }));
+  write(assetsDir, 'good-pkg/cordis.patch.yml', patchJson([{ id: 'good' }]));
+  // 情况一：bundles 字段非数组（结构损坏的合法 JSON）——静默置空会假绿，必须显式报错
+  write(profileDir, 'package.json', JSON.stringify({ name: 'p', dsh: { profile: { bundles: 'oops' } } }));
+  let out = validatePlugins(profileDir, null, assetsDir, jsonYaml, fs);
+  assert.strictEqual(out.ok, false, 'bundles 非数组必须判失败（#99 假绿变体）');
+  assert.ok(out.manifestError, 'manifestError 应有信息');
+  assert.match(out.manifestError, /bundles 不是数组/);
+  // 情况二：字段缺失 → 合法空清单，不误报
+  write(profileDir, 'package.json', JSON.stringify({ name: 'p' }));
+  out = validatePlugins(profileDir, null, assetsDir, jsonYaml, fs);
+  assert.strictEqual(out.manifestError, null, 'bundles 字段缺失 = 合法空清单，不误报');
+  assert.strictEqual(out.ok, true);
+});

--- a/dsh-desktop/scripts/test/plugin-manager-patch.test.js
+++ b/dsh-desktop/scripts/test/plugin-manager-patch.test.js
@@ -228,3 +228,33 @@ test('issue #66: 关闭 terminal 不误改前缀匹配的 terminal-tab（\b 缺�
   const out = togglePluginInPatch(src, 'terminal', false);
   assert.equal(countId(out, 'terminal-tab'), 1, 'terminal-tab 必须原样保留');
 });
+
+test('issue #100: 顶层含空格的非标 id（foo bar）不被 foo 命中误改', () => {
+  const src = [
+    '- id: foo bar',
+    '  name: Foo Bar',
+    '  config: {}',
+    '',
+  ].join('\n');
+  const out = togglePluginInPatch(src, 'foo', false);
+  // foo bar 条目块必须原样保留（文件开头即该条目，未被插入 disabled）
+  assert.ok(out.startsWith('- id: foo bar\n  name: Foo Bar\n  config: {}\n'), 'foo bar 条目原样保留');
+  // foo 自己的新顶层 disabled 条目正常追加
+  assert.ok(out.includes('- id: foo'), 'foo 条目正常登记');
+});
+
+test('issue #100: insert 内层含空格的非标 id（foo bar）不被 foo 命中误删', () => {
+  const src = [
+    '- insert:',
+    '    - id: foo',
+    '      name: foo',
+    '    - id: foo bar',
+    '      name: fb',
+    '',
+  ].join('\n');
+  const out = togglePluginInPatch(src, 'foo', false);
+  assert.ok(!out.includes('    - id: foo\n'), 'foo 内层条目被移出（正常）');
+  assert.ok(out.includes('    - id: foo bar\n'), 'foo bar 内层条目必须保留');
+  // 顶层登记点恰一个（注意 countId 的 \b 会把 foo bar 误计，这里用行级精确断言）
+  assert.equal((out.match(/^- id: foo\s*$/m) || []).length, 1, 'foo 顶层 disabled 条目保留');
+});

--- a/dsh-desktop/scripts/test/plugin-manager-update.test.js
+++ b/dsh-desktop/scripts/test/plugin-manager-update.test.js
@@ -13,7 +13,10 @@ const {
   ghProxyUrl,
   verifyIntegrity,
   findPackageRoot,
+  selectGithubAsset,
 } = require('../plugin-manager-update');
+
+const asset = (name) => ({ name });
 
 test('版本比较：数值分段（0.12.2 > 0.2.1）', () => {
   assert.ok(compareVersions('0.12.2', '0.2.1') > 0);
@@ -102,4 +105,64 @@ test('解压定位：唯一子目录递归深入 / 多层嵌套', () => {
     assert.equal(findPackageRoot(nested), path.join(nested, 'a', 'b'));
     fs.rmSync(nested, { recursive: true, force: true });
   } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+});
+
+// ============ issue #97：GitHub Release 多资产选择 ============
+
+test('资产选择：#97 多资产 darwin 在前时选 win32-x64（darwin 不再误判 win）', () => {
+  const r = selectGithubAsset([asset('dsh-darwin-arm64.tgz'), asset('dsh-win32-x64.tgz')], 'win32');
+  assert.equal(r.name, 'dsh-win32-x64.tgz');
+});
+
+test('资产选择：#97 乱序 win-ia32/win-x64 时选 x64（架构优先级）', () => {
+  const r = selectGithubAsset([asset('dsh-win-ia32.tgz'), asset('dsh-win-x64.tgz')], 'win32');
+  assert.equal(r.name, 'dsh-win-x64.tgz');
+});
+
+test('资产选择：#97 仅 .sha256 校验和时返回 null（任何阶段不选非二进制）', () => {
+  const r = selectGithubAsset([asset('dsh-darwin-arm64.tgz.sha256'), asset('dsh-win32-x64.tgz.sha256')], 'win32');
+  assert.equal(r, null);
+});
+
+test('资产选择：B2 无扩展名 SHA256SUMS/SHA512SUMS 与 .sha1 校验和不选', () => {
+  assert.equal(selectGithubAsset([asset('SHA256SUMS')], 'win32'), null, '无点号校验和文件（真实发行常见命名）不得被选中');
+  assert.equal(selectGithubAsset([asset('dsh-SHA512SUMS')], 'win32'), null, 'SHA512SUMS 同样剔除');
+  assert.equal(selectGithubAsset([asset('dsh-win32-x64.tgz'), asset('SHA256SUMS')], 'win32').name, 'dsh-win32-x64.tgz', '校验和文件混入时被剔除、正常资产仍可选');
+  assert.equal(selectGithubAsset([asset('dsh-SHA256SUMS.txt')], 'win32'), null, '.txt 后缀校验和仍被剔除');
+  assert.equal(selectGithubAsset([asset('dsh-win32-x64.exe.sha1')], 'win32'), null, '.sha1 扩展名被剔除');
+});
+
+test('资产选择：#97 控制组 win32-x64 + linux-x64 选 win32-x64', () => {
+  const r = selectGithubAsset([asset('dsh-win32-x64.tgz'), asset('dsh-linux-x64.tgz')], 'win32');
+  assert.equal(r.name, 'dsh-win32-x64.tgz');
+});
+
+test('资产选择：词边界——darwin 不匹配 win，win32/windows 匹配', () => {
+  const mixed = selectGithubAsset([asset('dsh-darwin-x64.tgz'), asset('dsh-win32-x64.tgz')], 'win32');
+  assert.equal(mixed.name, 'dsh-win32-x64.tgz', '混合资产时 darwin 不误配 win，仍选 win32');
+  assert.equal(selectGithubAsset([asset('dsh-win32-x64.tgz')], 'win32').name, 'dsh-win32-x64.tgz');
+  assert.equal(selectGithubAsset([asset('dsh-windows-arm64.zip')], 'win32').name, 'dsh-windows-arm64.zip', 'windows 全称匹配');
+  // 仅 darwin 资产（无本平台包）：回退选中（保持旧行为，digest 校验兜底）
+  assert.equal(selectGithubAsset([asset('dsh-darwin-x64.tgz')], 'win32').name, 'dsh-darwin-x64.tgz');
+});
+
+test('资产选择：平台池为空时回退任意归档；无归档时回退平台文件', () => {
+  const r1 = selectGithubAsset([asset('dsh-linux-x64.tgz')], 'win32');
+  assert.equal(r1.name, 'dsh-linux-x64.tgz', '仅 linux 资产时回退（保持旧行为）');
+  const r2 = selectGithubAsset([asset('dsh-win32-x64.exe'), asset('dsh-win32-x64.exe.sha256')], 'win32');
+  assert.equal(r2.name, 'dsh-win32-x64.exe', '无归档时选平台文件而非校验和');
+});
+
+test('资产选择：架构优先级 arm64 优于无架构；amd64 等价 x64；大小写不敏感', () => {
+  assert.equal(selectGithubAsset([asset('dsh-win.zip'), asset('dsh-win-arm64.zip')], 'win32').name, 'dsh-win-arm64.zip');
+  assert.equal(selectGithubAsset([asset('dsh-WIN32-X64.TGZ')], 'win32').name, 'dsh-WIN32-X64.TGZ');
+  const r = selectGithubAsset([asset('x.zip'), asset('x-amd64.zip')], 'win32');
+  assert.equal(r.name, 'x-amd64.zip', 'amd64 与 x64 同级优先于无架构');
+});
+
+test('资产选择：非法输入不抛错', () => {
+  assert.equal(selectGithubAsset(null, 'win32'), null);
+  assert.equal(selectGithubAsset([], 'win32'), null);
+  assert.equal(selectGithubAsset([null, { name: 'dsh-win32-x64.tgz' }], 'win32').name, 'dsh-win32-x64.tgz');
+  assert.equal(selectGithubAsset([{ name: 'dsh-win32-x64.tgz' }], undefined).name, 'dsh-win32-x64.tgz', '未知平台回退全部候选');
 });


### PR DESCRIPTION
## 修复内容

针对 #97 / #98 / #99（#100 已于此前单独修复，本次一并提交回归测试）——均为「防护罩有洞」类缺陷，不涉及运行中功能故障，已逐项复验属实后修复；独立审查后按 A/B 级报告再补强 5 处（见下）。

### #97 GitHub Release 多资产选择缺陷
原实现 `isWinAsset` 用子串匹配（`darwin-arm64.tgz` 含 `win` 误判为 Windows 资产）、无架构优先级、无归档时可能选中 `.sha256` 校验和文本。
- 收口为纯函数 `selectGithubAsset(assets, platform)`：词边界平台判定（`win32-x64.tgz` 命中 / `darwin-x64.tgz` 不命中）、架构优先级（x64/amd64 → arm64/aarch64 → ia32/x86 → arm → 无架构兜底，稳定排序保序）、任何阶段排除校验和/签名/说明等非二进制文件
- 全部资产被剔除 → 明确拒绝更新并记日志，不再下载错误文件
- 审查补强：排除范围覆盖无扩展名 `SHA256SUMS`/`SHA512SUMS` 与 `.sha1` 后缀

### #98 check-syntax 剥离器对正则字面量失明
含引号的正则（如 `/[&<>"']/g`）把引号当字符串起始，与后方引号配对把中间真实代码整段涂白——门禁漏报（实测 preload.js 77.2% 被涂白、19 个 function 被吞）。
- 新增 `findRegexClose`：跳过转义、字符类 `[...]` 内不闭合、拒绝跨行伪正则、闭 `/` 后按 flags 白名单与除法链（`a / b / c`）判定
- 门禁新增 preload.js 失明硬断言：保留率 <23% 或 function 被吞 >5 直接 FAIL（正常基线 ~29%、吞 0 个真实声明；报错注明触发项，便于自查）
- 审查补强：除法链+正则相邻（`a / /["']/g.test(x)` 第一个 `/` 伪闭合致失明）——按前置操作数判定跳过除法 ` / `，`return /re/` 等语句前导关键字后接正则按白名单放行；flags 白名单含 ES2022 `d` / ES2024 `v`

### #99 防砖体检 profile manifest 读取失败假绿
`validatePlugins` 的 `catch {}` 静默吞掉 `package.json` 读取/解析失败 → 启动清单为空 → 清单内缺陷全部降级 warning → 体检返回「未发现问题」。
- 显式记录 `manifestError` 字段，总结论 `ok: false`
- 设置页体检区红字提示「无法读取启动清单（profile/package.json），体检结果不可信」
- 审查补强：`dsh.profile.bundles` 字段存在但非数组（结构损坏合法 JSON）同样记 `manifestError`；字段缺失仍视为合法空清单（新装 profile 不误报）

### #100 补丁条目 id 负向断言漏掉行内空白（回归测试一并提交）
`- id: foo bar` 会被 `toggle('foo')` 命中误加 disabled（insert 内层更会被整条误删）。负向断言排除行内空格/tab（不排除换行），2 项回归测试。

## 测试
- 单测 **348/348** 全绿（新增：资产选择 9 项 + check-syntax 24 项 + #99 回归 2 项 + #100 回归 2 项，共 37 项）
- `check-syntax` 打包门禁全部入口通过（含 preload.js 失明断言）
- `git diff --check` 无空白错误
- 三次审查：自审（逻辑/边界/回归）→ 独立审查员逐文件审查（A/B/C/D 四级报告）→ 终审对照复核（A1 采用关键字感知方案修复、B1-B4 全部落实，C 级已知边界记录在案）