### PR TITLE
fix(ci): 诊断余额链路验证持续红——拆步骤 + 诊断 artifact + 放宽超时

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,14 @@ jobs:
         run: node scripts/check-syntax.js
       - name: 全量单测（unit-* / desktop-*，node --test 自动发现）
         run: npm test
-      - name: 余额链路验证（逻辑级 + 真实 Electron 渲染层，#106）
-        run: |
-          node scripts/test/verify-balance-dock.cjs
-          node scripts/test/verify-balance-renderer.cjs
+      - name: 余额链路验证（逻辑级 dock）
+        run: node scripts/test/verify-balance-dock.cjs
+      - name: 余额链路验证（真实 Electron 渲染层，#106）
+        run: node scripts/test/verify-balance-renderer.cjs
+      - name: 上传余额验证诊断（仅失败时）
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: balance-verify-diag
+          path: dsh-desktop/.ci-diag
+          if-no-files-found: ignore

--- a/dsh-desktop/scripts/test/renderer-balance-harness/main.js
+++ b/dsh-desktop/scripts/test/renderer-balance-harness/main.js
@@ -43,7 +43,7 @@ app.whenReady().then(() => {
   });
   win.loadFile(path.join(__dirname, 'page.html'));
   // 看门狗：任何卡死都在 30s 内以失败退出
-  setTimeout(() => finish(1, 'TIMEOUT: 渲染层测试 30s 未完成'), 30000);
+  setTimeout(() => finish(1, 'TIMEOUT: 渲染层测试 60s 未完成'), 60000);
 });
 
 app.on('window-all-closed', () => {});

--- a/dsh-desktop/scripts/test/verify-balance-renderer.cjs
+++ b/dsh-desktop/scripts/test/verify-balance-renderer.cjs
@@ -44,10 +44,25 @@ delete childEnv.ELECTRON_RUN_AS_NODE;
 // 隐藏窗口渲染层测试用软件渲染即可，跨环境更稳。--no-sandbox 同理利于无沙箱的 CI。
 const r = spawnSync(electron, ['--disable-gpu', '--no-sandbox', harnessDir], {
   env: childEnv,
-  stdio: 'inherit',
+  encoding: 'utf8',
   windowsHide: true,
-  timeout: 60000,
+  timeout: 120000,
 });
+
+// CI 诊断落盘：无论成败都把 Electron 全量输出与结果 JSON 写进 .ci-diag，
+// 失败时由 workflow 上传 artifact，避免日志域不可达时无从定位。
+const diagDir = path.join(__dirname, '..', '..', '.ci-diag');
+try {
+  fs.mkdirSync(diagDir, { recursive: true });
+  fs.writeFileSync(path.join(diagDir, 'balance-renderer.log'),
+    '=== stdout ===\n' + (r.stdout || '') + '\n=== stderr ===\n' + (r.stderr || '') +
+    '\n=== status: ' + r.status + (r.error ? ' error: ' + r.error.message : '') + ' ===\n');
+  if (fs.existsSync(resultFile)) {
+    fs.copyFileSync(resultFile, path.join(diagDir, 'balance-renderer-result.json'));
+  }
+} catch {}
+if (r.stdout) process.stdout.write(r.stdout);
+if (r.stderr) process.stderr.write(r.stderr);
 
 if (r.error) {
   console.error('[verify-balance-renderer] 启动失败: ' + r.error.message);


### PR DESCRIPTION
## 背景

「余额链路验证」步骤自引入（c43b5fb）起在 CI 上**持续红**（0f56841 / 7277e8e / feebd5a / bc8f87f 连续红），阻塞 main 与所有 PR（如 #107）。而本地 Windows（Node 22 与 24 双版本验证）dock 与 renderer 全部通过（16/16 断言），判定为 **runner 环境特有**失败。日志存储域（results-receiver.actions.githubusercontent.com）本地网络不可达，无日志无法定位。

## 变更内容（纯诊断增强，不改断言语义）

- [x] ci.yml：余额验证拆为两个独立 step（逻辑级 dock / 真实 Electron 渲染层），失败时可定位是哪一段
- [x] verify-balance-renderer.cjs：诊断落盘——无论成败把 Electron 全量 stdout/stderr 与结果 JSON 写入 dsh-desktop/.ci-diag/；失败时由 workflow 上传 artifact（balance-verify-diag）
- [x] 放宽超时余量：harness 看门狗 30s→60s，外层 spawnSync 超时 60s→120s（runner 冷启动较慢，排除超时假阳性）

## 测试与验证

- [x] node --check 两脚本通过
- [x] 本地实跑：dock 全绿；renderer 16/16 通过且 .ci-diag 落盘正常（log 1863B + result.json）

## 影响面

- [ ] 破坏性变更（无：仅 CI 基础设施与测试诊断）

## 预期

本 PR 自身 CI 即用新 workflow 运行：若余额步骤再红，可直接从拆分后的步骤名定位失败段，并从 artifact 下载 Electron 完整输出确诊。