### PR TITLE
fix(quest-ui+session): synapse 适配双 UI 通用 + 损坏会话日志容错不击穿启动

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-quest-ui/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-quest-ui/lib/client.js
@@ -95,6 +95,21 @@
 				".qdu-switch[aria-checked=true] .qdu-knob{transform:translateX(18px)}"
 			].join("");
 
+			// dsh-synapse 会话地图适配（双 UI 通用，不锁 body[data-dsh-quest-ui]
+			// 作用域——默认 UI 与 Quest UI 都生效）：切换按钮与顶部 Session log
+			// （wSkVaW_headerUtilities，y≈48）同一水平面；地图 overlay 下移避开
+			// Electron 自绘标题栏（0-36px），否则 iframe 内 topbar 被挡上半截。
+			// 颜色用字面量（默认 UI 下 --qdu-* 令牌不存在），与 ROW_CSS 同为
+			// 无作用域常量，随 ensureCss 一并注入。
+			const SYNAPSE_CSS = [
+				".dsh-synapse-switch{top:48px!important;border:1px solid rgba(15,17,21,.10)!important;background:#ffffff!important;box-shadow:0 1px 3px rgba(16,24,40,.06)!important;border-radius:999px!important}",
+				".dsh-synapse-switch button{font-weight:500!important;color:#61666b!important;border-radius:999px!important;transition:background-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1)!important}",
+				".dsh-synapse-switch button:hover{background:rgba(38,49,72,.06)!important;color:#0f1115!important}",
+				".dsh-synapse-switch button.active{background:#4176e6!important;color:#fff!important}",
+				".dsh-synapse-overlay{animation:qdu-synapse-fade-in .18s cubic-bezier(.4,0,.2,1);top:36px!important}",
+				"@keyframes qdu-synapse-fade-in{from{opacity:0}to{opacity:1}}"
+			].join("");
+
 			// 主题 CSS（Quest 风格 reskin）：每条规则都必须以 body[data-dsh-quest-ui]
 			// 开头（验收静态扫描）；设计令牌全部映射宿主 --dsw-alias-* token，
 			// 深浅色自动兼容。选择器基于实机探测的宿主结构（语义后缀子串匹配
@@ -233,16 +248,7 @@
 				// 上下文用量面板（JObwrW_panel）：轻度美化降噪（内容为宿主用量数据）
 				'body[data-dsh-quest-ui] .JObwrW_panel{line-height:1.6}',
 				'body[data-dsh-quest-ui] .JObwrW_figures{color:var(--qdu-label-2)}',
-				// —— dsh-synapse 会话地图适配（内置后集成）：切换按钮 Quest 化，
-				//    与顶部 Session log（wSkVaW_headerUtilities，y≈48）同一水平面；
-				//    地图 overlay 下移避开 Electron 自绘标题栏（0-36px），
-				//    否则 iframe 内 topbar 会被标题栏挡住上半截 ——
-				'body[data-dsh-quest-ui] .dsh-synapse-switch{top:48px!important;border:1px solid color-mix(in srgb,var(--qdu-label-1) 10%,transparent)!important;background:var(--qdu-bg-card)!important;box-shadow:0 1px 3px rgba(16,24,40,.06)!important;border-radius:999px!important}',
-				'body[data-dsh-quest-ui] .dsh-synapse-switch button{font-weight:500!important;color:var(--qdu-label-2)!important;border-radius:999px!important;transition:background-color .15s var(--qdu-ease),color .15s var(--qdu-ease)!important}',
-				'body[data-dsh-quest-ui] .dsh-synapse-switch button:hover{background:var(--qdu-hover)!important;color:var(--qdu-label-1)!important}',
-				'body[data-dsh-quest-ui] .dsh-synapse-switch button.active{background:var(--qdu-accent)!important;color:#fff!important}',
-				'body[data-dsh-quest-ui] .dsh-synapse-overlay{animation:qdu-fade-in .18s var(--qdu-ease);top:36px!important}',
-				'@keyframes qdu-fade-in{from{opacity:0}to{opacity:1}}',
+				// —— dsh-synapse 适配已上移为双 UI 通用的 SYNAPSE_CSS（v0.6.0）——
 			
 				// —— 空态建议卡：圆点前缀（::before 14px 描边圆）+ 40px 行高 +
 				//    hover 浅底；官方欢迎页有建议条目时才命中，无条目安静无效 ——
@@ -258,7 +264,7 @@
 				const tag = document.createElement("style");
 				tag.dataset.plugin = "@deepseek-ai/dsh-quest-ui";
 				tag.dataset.pluginCss = tagId;
-				tag.textContent = ROW_CSS + CSS;
+				tag.textContent = ROW_CSS + SYNAPSE_CSS + CSS;
 				document.head.appendChild(tag);
 			}
 
@@ -375,15 +381,36 @@
 				if (synapseFrameHooked !== frame) {
 					if (synapseFrameHooked && synapseFrameHooked.removeEventListener) {
 						synapseFrameHooked.removeEventListener("load", synapseFrameReload);
-				}
+					}
 					synapseFrameHooked = frame;
 					frame.addEventListener("load", synapseFrameReload);
 				}
+			}
+			// 双 UI 通用（v0.6.0）：synapse 宿主元素由其 client.js 在模块加载时创建，
+			// 与本插件加载顺序不确定——启动期有界探测（最多 12 次×800ms）找到
+			// iframe 后接管（注入 + load 重挂），找不到即安静放弃，不常驻轮询
+			// （P1：模式关闭态除一次性探测外零开销）。
+			var synapseBootTimer = null;
+			function bootstrapSynapseTheme() {
+				if (typeof document === "undefined") return;
+				var tries = 0;
+				var probe = function () {
+					synapseBootTimer = null;
+					try {
+						if (document.querySelector(".dsh-synapse-overlay iframe")) {
+							ensureSynapseTheme();
+							return;
+						}
+					} catch (e) { /* P8 */ }
+					if (++tries < 12) synapseBootTimer = setTimeout(probe, 800);
+				};
+				probe();
 			}
 			function synapseFrameReload() {
 				try { injectSynapseStyle(synapseFrameHooked && synapseFrameHooked.contentDocument); } catch (e) { /* P8 */ }
 			}
 			function teardownSynapseTheme() {
+				if (synapseBootTimer !== null) { clearTimeout(synapseBootTimer); synapseBootTimer = null; }
 				if (synapseFrameHooked && synapseFrameHooked.removeEventListener) {
 					synapseFrameHooked.removeEventListener("load", synapseFrameReload);
 				}
@@ -427,7 +454,8 @@
 					if (this._timer) { clearTimeout(this._timer); this._timer = null; }
 					if (this._observer) { this._observer.disconnect(); this._observer = null; }
 					this._removeAllOwnedNodes(); // 摘掉全部 qdu-* 自有节点
-					teardownSynapseTheme();   // 摘 synapse 主题注入与 load 监听
+					// 注：synapse 主题注入为双 UI 通用能力（v0.6.0），模式关闭不拆；
+					// 仅在插件卸载时由 teardown effect 清理。
 					this._fp = "";
 				},
 				_removeAllOwnedNodes: function () {
@@ -483,7 +511,11 @@
 				}, QuestModeRow), "dsh-quest-ui: quest mode row");
 
 				// 插件卸载时彻底拆除增强器（清理回调语义）。
-				ctx.effect(() => () => questEnhancers.setOn(false), "dsh-quest-ui: teardown enhancers");
+				// 插件卸载时彻底清理增强器与 synapse 注入（模式开关不由此路径负责）。
+				ctx.effect(() => () => { questEnhancers.setOn(false); teardownSynapseTheme(); }, "dsh-quest-ui: teardown enhancers");
+
+				// synapse 适配双 UI 通用：无论模式开关状态，启动即接管画布。
+				try { bootstrapSynapseTheme(); } catch (e) { console.warn("[dsh-quest-ui] synapse bootstrap failed: " + ((e && e.message) || e)); }
 			}
 
 			function apply(ctx) {

--- a/dsh-desktop/assets/plugins/dsh-quest-ui/package.json
+++ b/dsh-desktop/assets/plugins/dsh-quest-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-ai/dsh-quest-ui",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "private": true,
   "description": "DSH Desktop 配套插件：Quest 模式界面（通用设置一键切换，默认关闭）",
   "type": "module",

--- a/dsh-desktop/scripts/lib/runtime-patches.js
+++ b/dsh-desktop/scripts/lib/runtime-patches.js
@@ -246,6 +246,47 @@ function transformPersistenceTornTail(src, file) {
 }
 
 // ---------------------------------------------------------------------------
+// 单个损坏的会话日志不得击穿整个启动扫描：listArtifacts 读首行遇到损坏 zstd
+// 时跳过该会话并告警，而不是让整个 plugin tree 初始化崩溃（2026-08 事故：
+// 卷影恢复带回零填充头部的会话日志，导致应用整体无法启动）。
+const PERSISTENCE_CORRUPT_MARKER = 'dsh-desktop-corrupt-guard-v1';
+const PERSISTENCE_CORRUPT_OLD =
+  'const first = this.compression === "zstd" ? await this.readFirstZstdLine(path, signal) : await this.readFirstLine(path, signal);';
+const PERSISTENCE_CORRUPT_NEW = [
+  'let first;',
+  '\t\t\t\ttry {',
+  '\t\t\t\t\t// ' + PERSISTENCE_CORRUPT_MARKER + ': 损坏会话日志告警跳过，不得击穿启动扫描。',
+  '\t\t\t\t\tfirst = this.compression === "zstd" ? await this.readFirstZstdLine(path, signal) : await this.readFirstLine(path, signal);',
+  '\t\t\t\t} catch (corruptError) {',
+  '\t\t\t\t\tsignal?.throwIfAborted();',
+  '\t\t\t\t\tconsole.warn(`[dsh-session-persistence] skipping corrupt session log: ${path} (${corruptError?.message ?? corruptError})`);',
+  '\t\t\t\t\tcontinue;',
+  '\t\t\t\t}',
+].join('\n');
+
+function transformPersistenceCorruptGuard(src, file) {
+  if (src.includes(PERSISTENCE_CORRUPT_MARKER)) return { status: 'already' };
+  if (!src.includes(PERSISTENCE_CORRUPT_OLD)) {
+    return {
+      status: 'anchor-missing',
+      detail: '未找到损坏会话容错锚点（版本可能已变更），跳过 ' + file,
+    };
+  }
+  return { status: 'changed', src: src.replace(PERSISTENCE_CORRUPT_OLD, PERSISTENCE_CORRUPT_NEW) };
+}
+
+/** 会话持久化全部容错变换：尾部擕裂恢复 + 损坏会话跳过，依次应用。 */
+function transformPersistenceAll(src, file) {
+  const torn = transformPersistenceTornTail(src, file);
+  const afterTorn = torn.status === 'changed' ? torn.src : src;
+  const guard = transformPersistenceCorruptGuard(afterTorn, file);
+  if (guard.status === 'changed') return { status: 'changed', src: guard.src };
+  if (torn.status === 'changed') return { status: 'changed', src: afterTorn };
+  if (torn.status === 'already' && guard.status === 'already') return { status: 'already' };
+  return guard.status === 'anchor-missing' ? guard : torn;
+}
+
+// ---------------------------------------------------------------------------
 /**
  * Preserve the rc.6 keyed-slot registration contract for third-party client
  * plugins: an explicit key wins, and a legacy `id` is promoted to `key`.
@@ -453,6 +494,9 @@ module.exports = {
   PERSISTENCE_PKG_REL,
   PERSISTENCE_TORN_MARKER,
   transformPersistenceTornTail,
+  PERSISTENCE_CORRUPT_MARKER,
+  transformPersistenceCorruptGuard,
+  transformPersistenceAll,
   SLOT_KEY_COMPAT_PKG_REL,
   SLOT_UNKEYED_COMPAT_PKG_REL,
   SLOT_COMPAT_PKG_RELS,

--- a/dsh-desktop/scripts/patch-session-persistence.js
+++ b/dsh-desktop/scripts/patch-session-persistence.js
@@ -1,30 +1,35 @@
 'use strict';
 
-// Make the JSONL persistence reader tolerate the recoverable crash state where
-// the final zstd frame is structurally complete but its plaintext ends halfway
-// through one JSONL record.  The actual transform lives in runtime-patches.js
-// so the desktop boot path, WSL sync, postinstall, and afterPack share it.
+// Make the JSONL persistence reader tolerate recoverable crash states:
+// 1) the final zstd frame is structurally complete but its plaintext ends
+//    halfway through one JSONL record (torn tail);
+// 2) a whole session log is corrupt (bad frame magic / zero-padded head) —
+//    it must be skipped with a warning instead of crashing the entire
+//    plugin-tree init (2026-08 incident: shadow-copy restored logs with
+//    zero-padded heads bricked app startup).
+// The actual transforms live in runtime-patches.js so the desktop boot path,
+// WSL sync, postinstall, and afterPack share them.
 
 const fs = require('node:fs');
 const path = require('node:path');
 const { applyPatchToFiles } = require('./lib/patch-engine');
 const {
   PERSISTENCE_PKG_REL,
-  transformPersistenceTornTail,
+  transformPersistenceAll,
 } = require('./lib/runtime-patches');
 
 function patchSessionPersistence(nmRoot, log = () => {}) {
   const file = path.join(nmRoot, '@deepseek-ai', PERSISTENCE_PKG_REL);
   if (!fs.existsSync(file)) return 0;
   return applyPatchToFiles({
-    prefix: '会话历史尾部恢复补丁',
+    prefix: '会话持久化容错补丁',
     files: [file],
     log,
-    transform: transformPersistenceTornTail,
+    transform: transformPersistenceAll,
     alreadyLog: (target) => '已应用，跳过 ' + target,
-    doneLog: (target) => '已恢复 zstd 尾部容错 ' + target,
+    doneLog: (target) => '已应用 zstd 尾部/损坏会话容错 ' + target,
     anchorLog: log,
-    failLog: (target, error) => '会话历史尾部恢复补丁失败(' + target + '): ' + error.message,
+    failLog: (target, error) => '会话持久化容错补丁失败(' + target + '): ' + error.message,
   });
 }
 
@@ -33,5 +38,5 @@ module.exports = { patchSessionPersistence };
 if (require.main === module) {
   const root = path.resolve(process.argv[2] || path.join(__dirname, '..', 'node_modules'));
   const changed = patchSessionPersistence(root, (message) => console.log(message));
-  console.log(`会话历史尾部恢复补丁: ${changed > 0 ? '已应用' : '无变化'}`);
+  console.log(`会话持久化容错补丁: ${changed > 0 ? '已应用' : '无变化'}`);
 }

--- a/dsh-desktop/scripts/sync-companion-plugins.js
+++ b/dsh-desktop/scripts/sync-companion-plugins.js
@@ -43,7 +43,7 @@ const {
   transformShellDescriptionOptional, transformCodeModeCompat,
   transformAttachmentMimeTrust, ATTACH_LOCAL_REL,
   transformLegacySlotKey, transformSlotUnkeyedCompat,
-  PERSISTENCE_PKG_REL, transformPersistenceTornTail,
+  PERSISTENCE_PKG_REL, transformPersistenceAll,
 } = require('./lib/runtime-patches');
 const {
   ACP_DISABLE_BLOCK, PET_DISABLE_BLOCK,
@@ -378,19 +378,20 @@ function applyRuntimePatches(home, dryRun) {
     dryRunChangedLog: (file) => 'dry-run: 将信任图片解码字节 ' + file,
   });
 
-  // 最终完整 zstd frame 内的半条 JSONL 走已有崩溃恢复流程。
+  // 会话持久化容错：尾部擕裂的半条 JSONL 走崩溃恢复流程；整个日志损坏
+  // （坏帧头/零填充头）的会话告警跳过，不得击穿启动扫描。
   applyPatchToFiles({
-    prefix: '会话历史尾部恢复补丁',
+    prefix: '会话持久化容错补丁',
     files: patchTargets(home, PERSISTENCE_PKG_REL),
     log: (m) => log(m),
     anchorLog: (m) => warn(m),
-    transform: transformPersistenceTornTail,
+    transform: transformPersistenceAll,
     alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已恢复 zstd 尾部容错 ' + file,
+    doneLog: (file) => '已应用 zstd 尾部/损坏会话容错 ' + file,
     donePrefix: false,
-    failLog: (file, err) => '会话历史尾部恢复补丁失败(' + file + '): ' + err.message,
+    failLog: (file, err) => '会话持久化容错补丁失败(' + file + '): ' + err.message,
     dryRun,
-    dryRunChangedLog: (file) => 'dry-run: 将恢复 zstd 尾部容错 ' + file,
+    dryRunChangedLog: (file) => 'dry-run: 将应用 zstd 尾部/损坏会话容错 ' + file,
   });
 }
 


### PR DESCRIPTION
## 变更内容

### 1. dsh-quest-ui v0.6.0 — synapse 适配双 UI 通用
- dsh-synapse 会话地图适配（切换按钮对齐 Session log 行、画布避开 Electron 标题栏 top:36、iframe 主题注入）此前锁在 \ody[data-dsh-quest-ui]\ 作用域，仅 Quest 模式生效；现上移为无作用域 \SYNAPSE_CSS\，默认 UI 与 Quest UI 均生效
- 颜色从 \--qdu-*\ 令牌改字面量（默认 UI 下令牌不存在）
- 注入改为启动期有界探测（12 次×800ms），模式关闭不再拆除注入，仅插件卸载时清理

### 2. 会话持久化容错补丁 — 损坏会话不击穿启动
2026-08 事故：卷影副本恢复带回零填充头部的会话日志，\listArtifacts\ 读首行抛 \corrupt Zstandard session log\，整个 plugin tree 初始化崩溃，应用无法启动。
- \untime-patches.js\：新增 \	ransformPersistenceCorruptGuard\（读首行 try/catch，损坏则告警跳过该会话）+ \	ransformPersistenceAll\（与既有 torn-tail 补丁串接）
- \patch-session-persistence.js\ / \sync-companion-plugins.js\ / \main.js\：前缀升级为「会话持久化容错补丁」

## 验证
- unit-quest-ui 7/7 通过；transform 对安装版真实文件应用后产物语法 OK
- 实机：安装版打补丁后冷启动成功，损坏会话被跳过并记录告警，13 工作区/54 会话注册的界面正常渲染