### PR TITLE
refactor: 插件集成层模块化重构 —— 收敛 monkey-patch、消除高耦合、统一错误隔离

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
@@ -69,6 +69,7 @@ window.__ModuleLoader__.load({
 			diagSelfHealTitle: "最近启动自愈",
 			diagSelfHealRemoved: "已自动移出启动清单 {0}",
 			diagSelfHealDisabled: "已自动禁用 {0}",
+			diagSelfHealReset: "已重置补丁配置 {0}",
 			backupTitle: "备份配置",
 			backupExport: "导出备份…",
 			backupExporting: "导出中…",
@@ -933,7 +934,7 @@ window.__ModuleLoader__.load({
 					if (!items || items.length === 0) return null;
 					return jsxs("div", { style: { fontSize: 12, padding: "8px 10px", borderRadius: 8, marginTop: 6, background: "color-mix(in srgb, var(--dsw-alias-state-info-primary, #5b9bd5) 10%, transparent)", color: "var(--dsw-alias-state-info-primary, #5b9bd5)", display: "flex", flexDirection: "column", gap: 3 }, children: [
 						jsx("span", { style: { fontWeight: 600 }, children: L.diagSelfHealTitle }),
-						items.map((it, i) => jsx("div", { key: i, style: { wordBreak: "break-all" }, children: (it.kind === "overlay" ? L.diagSelfHealDisabled : L.diagSelfHealRemoved).replace("{0}", (it.names || []).join("、")) + "（" + new Date(it.ts).toLocaleString() + "）" }))
+						items.map((it, i) => jsx("div", { key: i, style: { wordBreak: "break-all" }, children: (it.kind === "overlay" ? L.diagSelfHealDisabled : it.kind === "patch-layer" ? L.diagSelfHealReset : L.diagSelfHealRemoved).replace("{0}", (it.kind === "patch-layer" && it.backup ? String(it.backup).split(/[\\/]/).pop() : (it.names || []).join("、"))) + "（" + new Date(it.ts).toLocaleString() + "）" }))
 					] });
 				};
 				// 自愈历史随报告放在 sections.selfHeal（顶层仅 ok/errors/warnings/infos），

--- a/dsh-desktop/assets/plugins/dsh-session-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-session-manager/lib/client.js
@@ -2,11 +2,12 @@
 //   1. 设置页「归档对话管理」栏：列出全部已归档会话（标题/项目/更新时间），
 //      每条提供「恢复」与「删除」；
 //   2. 暴露 window.__dshSessionManager 桥，供官方会话行 ⋯ 菜单补丁
-//      （patch-session-manage.js 注入的「删除对话」项）调用；
-//   3. 暴露 window.__dshDesktopOpenDir 桥（issue #85），供侧栏项目/会话行
-//      ⋯ 菜单「打开项目目录」项调用（patch-open-project-dir.js 注入），
-//      复用 preload 的 window.dshDesktop.openPath → dsh:file-open →
-//      shell.openPath。
+//      （patch-session-manage.js 注入的「删除对话」项）调用；该桥是「删除对话」
+//      菜单项的显式能力契约——patch-session-manage.js 按此桥是否存在决定是否
+//      显示「删除对话」项（桥缺失时隐藏，见 host-capabilities.js）；
+//   3. 「打开项目目录」（issue #85）由 patch-open-project-dir.js 注入，现直接
+//      引用 preload 宿主能力 window.dshDesktop.openPath；下方 window.__dshDesktopOpenDir
+//      别名仅保留给旧版已打补丁文件（向后兼容，可随一个版本周期后移除）。
 // 底层 RPC：workspace.unarchiveSession / workspace.deleteSession（由
 // patch-session-manage.js 补进 dsh-host-apiproxy 与 dsh-client-connection）；
 // 状态更新走官方 host 帧（archived-sessions-changed / session-removed），

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -42,28 +42,18 @@ const {
 const { installBuiltinPresets } = require('./scripts/install-minimal-win-preset');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { RendererRecovery } = require('./renderer-recovery');
-const { CORE_BUNDLE_NAMES } = require('./profile-manifest');
-const { dedupePatchEntries, parseFailedLoaderIds, mapPackagesToPatchIds, findMissingBundleDeclarations, scanBundleContracts, removeBundlesFromProfile } = require('./profile-patch-heal');
-const { PROFILE_BUNDLE_GUARD_MARKER, PROFILE_BOOT_GUARD_MARKER, verifyBundleDir, isPatchListValid, applyAppBootBundleGuard, applyProfileBootBundleGuard, applyProfileBootHealGuard } = require('./profile-bundle-heal');
+const { parseFailedLoaderIds, mapPackagesToPatchIds, findMissingBundleDeclarations, scanBundleContracts, removeBundlesFromProfile } = require('./profile-patch-heal');
 // profile manifest 装配对账（唯一实现）：启动前把 dsh.profile.bundles 对账到
 // 「每条登记都可装配」状态（无效登记移除 + 隔离记录、核心补齐、损坏重建、
 // 重置恢复），配合 profile-bundle-heal 的运行时防护构成双层防线。
-const { reconcileProfileBundles, createEntryListYamlParser, resolveBundleDirLike } = require('./scripts/lib/profile-reconcile');
+const { createEntryListYamlParser } = require('./scripts/lib/profile-reconcile');
 // 统一补丁引擎与共享数据源（scripts/lib/）：main.js 的运行时补丁、同步脚本
 // 与 after-pack 共用同一实现，杜绝重复与漂移。
 const { COMPANION_PLUGINS } = require('./scripts/lib/companion-plugins');
 const { writeFileAtomic } = require('./scripts/lib/patch-io');
-const { applyPatchToFiles } = require('./scripts/lib/patch-engine');
 const { selectReleaseAsset } = require('./scripts/lib/github-release-assets');
-const { FLASH_PKG_REL, EXPOSE_PKG_REL, PW_REL, BASH_REL, CODE_PRESET_REL, patchTargets, localCopyFiles, guardCopyFiles, localNodeModulesRoots, slotCompatCopyFiles, slotCompatPatchTargets, transformFlashFix, transformExposeFix, transformShellDescriptionOptional, transformCodeModeCompat, transformAttachmentMimeTrust, transformLegacySlotKey, transformSlotUnkeyedCompat, transformSlotErrorIsolation, SLOT_ERROR_ISOLATE_MARKER, SLOT_KEY_COMPAT_PKG_REL, ATTACH_LOCAL_REL } = require('./scripts/lib/runtime-patches');
-const { ACP_DISABLE_BLOCK, PET_DISABLE_BLOCK, removeLegacyMarketplacePatchLines, removedPluginIdsFromPatch, ensureDisabledPatchEntry, registerCompanionPatchEntries, syncCompanionFiles } = require('./scripts/lib/companion-profile');
 // 内置 Agent 预设保护：客户端更新（覆盖安装）前快照用户改过的预设，更新后恢复。
 const presetGuard = require('./scripts/lib/preset-guard');
-const { patchWebSearchBaseUrl } = require('./scripts/patch-web-search-baseurl');
-const { patchMenuViewport } = require('./scripts/patch-menu-viewport');
-const { patchSessionManage } = require('./scripts/patch-session-manage');
-const { patchOpenProjectDir } = require('./scripts/patch-open-project-dir');
-const { patchSessionPersistence } = require('./scripts/patch-session-persistence');
 // 「设置 → 插件 → 诊断与管理」：诊断 / 备份与恢复 / 日志包导出 / 防砖体检 /
 // bundle 顺序检测与重排（纯函数模块，node --test 单测覆盖）。
 const desktopDiagnostics = require('./scripts/desktop-diagnostics');
@@ -74,6 +64,10 @@ const zlib = require('node:zlib');
 // 插件保护中心（借鉴 EAC）：快照 / 回滚 / 静态体检 / 自动修复 / 守护启动 /
 // 事故报告。跑在 Electron 主进程里，绝不动 harness 内核或用户会话数据。
 const { createGuard } = require('./plugin-guard');
+// 第三方插件集成层（同步 / 补丁 / 预检 / 故障隔离）唯一编排入口：main.js 只
+// 调 createPluginIntegration + 细粒度方法，不再各自维护 syncCompanionPlugins
+// 与 18 个 apply* 样板。
+const { createPluginIntegration } = require('./scripts/integration');
 
 // ---------------------------------------------------------------------------
 // 启动期崩溃兜底（issue #30「便携版有进程无界面」）：模块加载 / 启动早期
@@ -1052,10 +1046,51 @@ function notifyBundleRepair(removed) {
   }
 }
 
+// 补丁层自愈重置的用户可见提示：cordis.patch.yml 解析失败被重置为最小文件（原内容
+// 已备份到 backup）。用户数据被改写，属数据类事件，须给出可见提示 + 备份路径。
+function notifyPatchReset(kind, backup) {
+  if (process.env.DSH_DESKTOP_TEST === '1') return;
+  try {
+    const label = kind === 'home' ? '家级补丁层（cordis.patch.yml）' : 'profile 补丁层（cordis.patch.yml）';
+    showNotification({
+      title: 'DSH Desktop 补丁配置已重置',
+      body: `检测到 ${label} 无法解析，已备份原内容并重置为最小文件，避免启动失败。原配置已备份为 ${path.basename(backup)}，完整路径见「设置 → 插件 → 诊断与管理 → 诊断」。`,
+    });
+    appendSelfHealHistory('patch-layer', ['补丁配置'], backup);
+  } catch (err) {
+    log('boot', '补丁重置提示失败: ' + err.message);
+  }
+}
+
+// 插件补丁应用失败的用户可见提示：消除「部分失败静默」。区分三类信号——
+// degraded（关键补丁已降级，建议升级）、errors/failed（补丁未生效）、
+// anchorMissing（锚点失配，版本差异）——任一非零即提示。集成测试态不弹真实
+// 通知（与其它自愈提示一致，断言走 desktop.log）。
+function notifyPatchFailures(report) {
+  try {
+    if (!report) return;
+    const degradedCount = (report.degraded || []).length;
+    const hardCount = (report.errors || []).length + (report.failed || 0);
+    const anchorMiss = report.anchorMissing || 0;
+    if (degradedCount === 0 && hardCount === 0 && anchorMiss === 0) return;
+    const parts = [];
+    if (degradedCount > 0) parts.push(`${degradedCount} 个关键补丁已降级（建议升级 DSH Desktop）`);
+    if (hardCount > 0) parts.push(`${hardCount} 个插件补丁未生效`);
+    if (anchorMiss > 0) parts.push(`${anchorMiss} 处补丁锚点失配（版本差异）`);
+    if (process.env.DSH_DESKTOP_TEST === '1') return;
+    showNotification({
+      title: 'DSH Desktop 插件补丁提示',
+      body: `检测到 ${parts.join('、')}，相关第三方插件可能异常，建议升级 DSH Desktop 后重试。`,
+    });
+  } catch (err) {
+    log('boot', '补丁提示失败: ' + err.message);
+  }
+}
+
 // 自愈事件持久化：模态框/系统通知都是一次性的，错过就没了；写入
 // userData/self-heal-history.json 后，用户随时可在「设置 → 插件 →
 // 诊断与管理 → 诊断」中回看「上次启动自愈了什么」。
-function appendSelfHealHistory(kind, names) {
+function appendSelfHealHistory(kind, names, backup) {
   try {
     const file = path.join(userDataDir, 'self-heal-history.json');
     let items = [];
@@ -1063,11 +1098,13 @@ function appendSelfHealHistory(kind, names) {
       const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
       if (Array.isArray(parsed)) items = parsed;
     }
-    items.unshift({
-      kind: kind === 'overlay' ? 'overlay' : 'bundle',
+    const entry = {
+      kind,
       names: Array.isArray(names) ? names : [names],
       ts: Date.now(),
-    });
+    };
+    if (typeof backup === 'string' && backup) entry.backup = backup;
+    items.unshift(entry);
     fs.writeFileSync(file, JSON.stringify(items.slice(0, 5), null, 2) + '\n', 'utf8');
   } catch (err) {
     log('boot', '自愈历史写入失败: ' + err.message);
@@ -1314,6 +1351,38 @@ function ensureGuard() {
   return guardInstance;
 }
 
+// ---------------------------------------------------------------------------
+// 插件集成门面实例（scripts/integration）。延迟创建：依赖 userDataDir / dshHome
+// / 后端模式解析就绪，首次调用发生在 boot 或更新流程阶段。
+// ---------------------------------------------------------------------------
+let pluginIntegration = null;
+function ensurePluginIntegration() {
+  if (!pluginIntegration) {
+    pluginIntegration = createPluginIntegration({
+      getHome: () => effectiveDshHome(),
+      appDir: __dirname,
+      getUserDataDir: () => userDataDir,
+      wslMode: () => isWslMode(),
+      log: (m) => log('boot', m),
+      loadYaml: () => loadDshYamlDialect(),
+      loadSettings: () => updater.loadSettings(updCtx()),
+      saveSettings: (s) => updater.saveSettings(updCtx(), s),
+      getInstallAnchorDir: () => path.dirname(dshPackageJson()),
+      onManifestResetRecovered: (recovered) => notifyManifestResetRecovered(recovered),
+      onHealReset: (kind, backup) => notifyPatchReset(kind, backup),
+      hostDetectors: {
+        // preload 在 Electron 壳内始终暴露 window.dshDesktop.openPath。
+        openPath: () => true,
+        // 桥 window.__dshSessionManager 由 dsh-session-manager 插件提供：
+        // 以「插件已同步落盘」作为主进程侧探测信号（渲染进程运行时仍以注入的
+        // 桥守卫为准，二者共同构成显式降级 + 告警）。
+        deleteSession: () => fs.existsSync(path.join(effectiveDshHome() || path.join(os.homedir(), '.dsh'), 'profiles', 'web', 'node_modules', 'dsh-session-manager')),
+      },
+    });
+  }
+  return pluginIntegration;
+}
+
 // 设置页「WSL 后端」用的状态快照：当前 local 模式（未配置过）或 force 时，
 // 按已保存的 wslDistro/wslInstallDir 做一次探测；失败不抛错，错误进 status。
 // 全部探测走异步原语（configureAsync/statusAsync），绝不阻塞主进程
@@ -1352,9 +1421,7 @@ async function startServer(unsafePortRetries = 4, overlays = []) {
     await killTree(serverProc);
     serverProc = null;
   }
-  healProfilePatch();
-  healHomePatch();
-  logProfileBundleHealth();
+  ensurePluginIntegration().healBeforeServer();
   if (isWslMode()) {
     // WSL 托管模式：经 wsl.exe 在 WSL 内启动 dsh web（仍 --port 0 由 WSL 内 OS
     // 分配；稳定端口持久化只作用于本地 spawn）。受限端口重启走同一递归。
@@ -2537,54 +2604,18 @@ async function runUpdateFlow(manual) {
         // 新 WSL agent 已就位：与 local 一致，立即补同步配套插件/内置预设并重打
         // 运行时补丁（全部幂等），否则「稍后重启」后再重启服务会以未修复、且
         // 缺少壳内置模式的新版本启动。
-        syncCompanionPlugins();
+        ensurePluginIntegration().syncPlugins();
         syncBuiltinAgentPresets();
-        applySlotCompatFix();
-        preScanPluginHealth();
-        applyRuntimeFlashFix();
-        applyPromptExposeFix();
-        applyShellDescriptionCompatFix();
-        applyCodeModeCompatFix();
-        applyImageSendFix();
-        applyAttachmentMimeTrustFix();
-        applyVisionKeyFix();
-        applyProfilePatchGuard();
-        applyProfileBundleGuard();
-        applySettingsSectionGuard();
-        applyWorkspaceSearchRailFix();
-        applyPluginInventoryTabMergeFix();
-        // 与 local 分支、与 WSL 启动分支一致：包级补丁同样立即重打（幂等），
-        // 避免「稍后重启」后以未修复的新 WSL agent 启动（历史漂移补齐）。
-        applyWebSearchBaseUrlFix();
-        applyMenuViewportFix();
-        applySessionManageFix();
-        applyOpenProjectDirFix();
-        applySessionPersistenceFix();
+        notifyPatchFailures(ensurePluginIntegration().applyPatches());
+        ensurePluginIntegration().preflightHealth();
       } else {
         await updater.applyUpdate(ctx, latest);
         // 新 overlay 已就位：立即重打运行时补丁（全部幂等），否则「稍后重启」后再
         // 点「重启 dsh web 服务」会用未修复的新版本启动（识图发送、设置暴露等回归）。
         // 同时把壳内置 Agent 预设补进新 overlay（干净 npm 包不含 8 个壳预设）。
         syncLocalAgentPresets();
-        applySlotCompatFix();
-        preScanPluginHealth();
-        applyRuntimeFlashFix();
-        applyPromptExposeFix();
-        applyShellDescriptionCompatFix();
-        applyCodeModeCompatFix();
-        applyImageSendFix();
-        applyAttachmentMimeTrustFix();
-        applyVisionKeyFix();
-        applyProfilePatchGuard();
-        applyProfileBundleGuard();
-        applySettingsSectionGuard();
-        applyWorkspaceSearchRailFix();
-        applyPluginInventoryTabMergeFix();
-        applyWebSearchBaseUrlFix();
-        applyMenuViewportFix();
-        applySessionManageFix();
-        applyOpenProjectDirFix();
-        applySessionPersistenceFix();
+        notifyPatchFailures(ensurePluginIntegration().applyPatches());
+        ensurePluginIntegration().preflightHealth();
       }
       // 进度窗已非模态，但完成对话框弹出前仍先关闭它，避免叠窗/对话框被遮挡。
       closeUpdateWindow(progressWin);
@@ -3781,32 +3812,6 @@ function startBalanceLoop() {
   ensureBalanceScheduler().start();
 }
 
-// ---------------------------------------------------------------------------
-// 配套 dsh 插件同步（注入 web profile：余额小部件 + 文件更改追踪/还原）
-// ---------------------------------------------------------------------------
-// 配套插件清单 COMPANION_PLUGINS 的唯一数据源在 scripts/lib/companion-plugins.js
-//（与 scripts/sync-companion-plugins.js 共用，杜绝两处清单漂移）。
-// 过期插件清理 / 旧市场清理 / 文件同步 / bundle 校验 / 补丁条目注册等纯逻辑
-// 也统一收口在 scripts/lib/companion-profile.js，本文件只保留与桌面壳耦合的
-// manifest 恢复流程。
-
-// ---------------------------------------------------------------------------
-// profile patch 自愈：cordis.patch.yml 损坏会让 dsh web 装配 profile 时抛错并
-// 以 exit 1 退出，桌面端「启动失败」。每次启动 dsh web 前调用本函数：
-//   1. 顶层孤立 `[]` 与列表条目混存 → 移除 `[]` 行（修复为单一顶层列表）；
-//   2. issue #17 存量：同一 loader id 被注册多次（旧版本插件安装写入的重复
-//      insert 条目 → cordis loader "duplicate loader entry id: X"）→ 注册行级
-//      去重，保留首次注册、备份原文件；config 覆盖/disabled 禁用条目是用户
-//      配置，绝不改动（PR #24 v2）；
-//   3. 仍无法解析（其它损坏形态）→ 备份为 cordis.patch.yml.broken-<ts> 并
-//      重置为最小合法文件，日志告警，备份保留用户内容供恢复。
-//   健康文件零写入（幂等）。
-// ---------------------------------------------------------------------------
-function profilePatchFile() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  return path.join(home, 'profiles', 'web', 'cordis.patch.yml');
-}
-
 // 原子写统一收口在 scripts/lib/patch-io.js 的 writeFileAtomic（临时文件 + rename）。
 // 惰性加载 js-yaml（随内置 dsh 存在于 resources/app/node_modules，传递依赖）；
 // 缺失时静默降级为仅做结构化修复（不阻断启动）。方言构造与
@@ -3819,376 +3824,6 @@ function loadDshYamlDialect() {
   const parse = createEntryListYamlParser();
   dshYamlDialect = parse ? { load: (content) => parse(content) } : null;
   return dshYamlDialect;
-}
-
-// profile patch 自愈的签名缓存：cordis.patch.yml 是本项目高频自愈对象，但
-// 每次启动实际需要改动的情形很少。以「文件路径 + 大小 + 精确 mtimeMs」为
-// 签名，签名一致说明文件内容未被任何写入方触碰（写入必改 mtime），可跳过
-// 读文件 + js-yaml 解析 + 去重扫描。进程内 memo 同时消除 startServer 里对
-// 同一文件的第二次全量解析。文件被改（含本进程后续的同步写入）→ 签名变化
-// → 自动重新自愈，无陈旧判断。
-let patchHealMemo = null; // { file, size, mtimeMs }
-
-function patchHealCachePath() {
-  return path.join(userDataDir, 'profile-patch-heal-cache.json');
-}
-
-function patchFileSignature(file) {
-  try {
-    const st = fs.statSync(file);
-    return { size: st.size, mtimeMs: st.mtimeMs };
-  } catch {
-    return null;
-  }
-}
-
-function readPersistedPatchHeal() {
-  try {
-    const c = JSON.parse(fs.readFileSync(patchHealCachePath(), 'utf8'));
-    if (c && c.v === 1 && typeof c.file === 'string' && typeof c.size === 'number' && typeof c.mtimeMs === 'number') return c;
-  } catch {}
-  return null;
-}
-
-function writePersistedPatchHeal(file, sig) {
-  try {
-    fs.writeFileSync(patchHealCachePath(), JSON.stringify({
-      v: 1,
-      file,
-      size: sig.size,
-      mtimeMs: sig.mtimeMs,
-      at: new Date().toISOString(),
-    }));
-  } catch {}
-}
-
-function healProfilePatch() {
-  try {
-    const file = profilePatchFile();
-    if (!fs.existsSync(file)) return;
-    // 启动提速：签名一致 → 该文件已在当前内容状态下自愈过，直接跳过。
-    const sig = patchFileSignature(file);
-    if (sig) {
-      const memoHit = patchHealMemo && patchHealMemo.file === file &&
-        patchHealMemo.size === sig.size && patchHealMemo.mtimeMs === sig.mtimeMs;
-      if (memoHit) return;
-      const persisted = readPersistedPatchHeal();
-      if (persisted && persisted.file === file && persisted.size === sig.size && persisted.mtimeMs === sig.mtimeMs) {
-        patchHealMemo = { file, size: sig.size, mtimeMs: sig.mtimeMs };
-        return;
-      }
-    }
-    let text = fs.readFileSync(file, 'utf8');
-    const bareArray = /^\s*\[\]\s*$/m.test(text);
-    const hasEntries = /^\s*-\s+(?:id|insert)\s*:/m.test(text);
-    if (bareArray && hasEntries) {
-      text = text.replace(/^\s*\[\]\s*$\n?/m, '');
-      writeFileAtomic(file, text);
-      log('boot', 'profile patch 自愈: 移除了与列表混存的顶层 []（cordis.patch.yml）');
-    }
-    const yaml = loadDshYamlDialect();
-    if (!yaml) return;
-    let parsed;
-    let error = null;
-    try { parsed = yaml.load(text); } catch (err) { error = err; }
-    // 合法判定与 dsh-app-boot parsePatchList 同构：顶层数组且每项为映射。
-    if (!error && isPatchListValid(parsed)) {
-      // issue #17 存量自愈：注册行级去重（PR #24 v2）。重复注册（旧版本
-      // 插件安装写入的第二个同 id insert 条目）会让 cordis loader 抛
-      // "duplicate loader entry id: X"，且该状态永远无法自愈；只删重复
-      // 注册行，用户手写的 config/disabled 覆盖条目原样保留。
-      const dedupe = dedupePatchEntries(text);
-      if (dedupe.removed.length > 0) {
-        const backup = file + '.dup-' + Date.now();
-        try { fs.copyFileSync(file, backup); } catch {}
-        writeFileAtomic(file, dedupe.text);
-        log('boot', 'profile patch 自愈: 移除了重复注册的 loader 条目 ' + [...new Set(dedupe.removed)].join(', ') + '，原文件已备份到 ' + backup);
-        text = dedupe.text;
-      }
-    }
-    if (error || !isPatchListValid(parsed)) {
-      const backup = file + '.broken-' + Date.now();
-      try { fs.renameSync(file, backup); } catch { fs.copyFileSync(file, backup); }
-      fs.writeFileSync(file, '# recovered by DSH Desktop: 原内容无法解析，已备份到\n# ' + backup + '\n[]\n', 'utf8');
-      const cause = error ? String((error && error.message) || error)
-        : (Array.isArray(parsed) ? '条目不是映射（顶层数组每项须为映射）' : '顶层非数组');
-      log('boot', 'profile patch 自愈: 解析失败（' + cause + '），已备份到 ' + backup + ' 并重置为最小文件');
-    }
-    // 完整自愈流程已跑完（含 yaml 解析）：记录当前内容签名，下次启动命中跳过。
-    const after = patchFileSignature(file);
-    if (after) {
-      patchHealMemo = { file, size: after.size, mtimeMs: after.mtimeMs };
-      writePersistedPatchHeal(file, after);
-    }
-  } catch (err) {
-    log('boot', 'profile patch 自愈失败: ' + err.message);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// 家级补丁层预检（$DSH_HOME/cordis.patch.yml）：dsh 官方 composeProfile 对
-// 该文件 fail-loud（"failed to parse patches" → dsh web 退出码 1），此前只由
-// dsh profile-boot 的运行时防护（锚点改写）兜底。这里在启动前用与 dsh 相同
-// 的 entry-list 方言预检：损坏 → 备份 .broken-<ts> + 重置为最小合法文件
-// （与 healProfilePatch 同款语义，原文永不丢弃）。健康文件零写入（幂等，
-// 进程内签名 memo，避免重复解析）。
-// ---------------------------------------------------------------------------
-let homePatchHealMemo = null; // { file, size, mtimeMs }
-
-function healHomePatch() {
-  try {
-    const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-    const file = path.join(home, 'cordis.patch.yml');
-    if (!fs.existsSync(file)) return;
-    const sig = patchFileSignature(file);
-    if (sig && homePatchHealMemo && homePatchHealMemo.file === file &&
-        homePatchHealMemo.size === sig.size && homePatchHealMemo.mtimeMs === sig.mtimeMs) {
-      return;
-    }
-    const yaml = loadDshYamlDialect();
-    if (!yaml) return; // 无 yaml 依赖：跳过解析（运行时防护兜底）
-    let parsed = null;
-    let error = null;
-    try { parsed = yaml.load(fs.readFileSync(file, 'utf8')); } catch (err) { error = err; }
-    // 合法判定与 dsh-app-boot parsePatchList 同构：顶层数组且每项为映射
-    // （只查 Array.isArray 会放过「条目是标量/字符串/嵌套数组/null」的畸形
-    // 文件，composeProfile 仍会 fail-loud）。
-    if (!error && isPatchListValid(parsed)) {
-      homePatchHealMemo = { file, size: sig.size, mtimeMs: sig.mtimeMs };
-      return;
-    }
-    const backup = file + '.broken-' + Date.now();
-    try { fs.renameSync(file, backup); } catch { fs.copyFileSync(file, backup); }
-    fs.writeFileSync(file, '# recovered by DSH Desktop: 原内容无法解析，已备份到\n# ' + backup + '\n[]\n', 'utf8');
-    const cause = error ? String((error && error.message) || error)
-      : (Array.isArray(parsed) ? '条目不是映射（顶层数组每项须为映射）' : '顶层非数组');
-    log('boot', '家级补丁层自愈: 解析失败（' + cause + '），已备份到 ' + backup + ' 并重置为最小文件');
-    const after = patchFileSignature(file);
-    if (after) homePatchHealMemo = { file, size: after.size, mtimeMs: after.mtimeMs };
-  } catch (err) {
-    log('boot', '家级补丁层自愈失败: ' + err.message);
-  }
-}
-
-// 目录级同步（dirNeedsSync + syncDir）收口在 scripts/lib/companion-profile.js，
-// 由 syncCompanionFiles 使用；本文件不再维护副本。
-
-// ---------------------------------------------------------------------------
-// profile bundle 健康检查（只读）：启动对账（reconcileProfileBundles）已把
-// 无效的非核心登记从 manifest 移除，这里把对账后仍存在的异常条目（核心
-// bundle 缺失 / 损坏等，启动防护兜底跳过）落到 desktop.log。不修改任何文件。
-// ---------------------------------------------------------------------------
-function logProfileBundleHealth() {
-  try {
-    const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-    const profileDir = path.join(home, 'profiles', 'web');
-    let manifest = null;
-    try {
-      manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
-    } catch (err) {
-      log('boot', 'profile bundle 健康检查: manifest 不可读（' + err.message + '），交由启动防护自愈');
-      return;
-    }
-    const bundles = (manifest && manifest.dsh && manifest.dsh.profile && Array.isArray(manifest.dsh.profile.bundles)) ? manifest.dsh.profile.bundles : [];
-    const installAnchor = path.dirname(dshPackageJson());
-    for (const name of bundles) {
-      if (typeof name !== 'string' || name === '') continue;
-      // 与对账（reconcileProfileBundles）同一解析实现（createRequire.resolve.paths
-      // 双锚点，含 NODE_PATH / 全局 node_modules）：诊断口径与对账判定一致，
-      // 避免「对账判定可解析、健康检查误报缺失」的口径撕裂。
-      const dir = resolveBundleDirLike(path.join(installAnchor, 'package.json'), name)
-        || resolveBundleDirLike(path.join(profileDir, 'package.json'), name);
-      if (!dir) {
-        log('boot', 'profile bundle 缺失（对账后仍存在，启动防护兜底跳过）: ' + name + ' —— 用 dsh plugin --profile web install 可修复');
-        continue;
-      }
-      const check = verifyBundleDir(dir);
-      if (!check.ok) log('boot', 'profile bundle 不可用（对账后仍存在，启动防护兜底跳过）: ' + name + ' —— ' + check.reason);
-    }
-  } catch (err) {
-    log('boot', 'profile bundle 健康检查失败: ' + err.message);
-  }
-}
-
-function syncCompanionPlugins() {
-  if (!IS_WIN) return;
-  try {
-    healProfilePatch();
-    const home = effectiveDshHome();
-    if (!home) { log('boot', 'DSH_HOME 未解析，跳过配套插件同步'); return; }
-    const profileDir = path.join(home, 'profiles', 'web');
-    const patchFile = path.join(profileDir, 'cordis.patch.yml');
-    // 插件管理「卸载」标记（removed: true 的顶层条目）：本次启动跳过文件复制
-    // 与 manifest 装配，避免「卸载后一重启又被复活」。纯文本提取（共享实现
-    // removedPluginIdsFromPatch，与 scripts/sync-companion-plugins.js 同一数据源），
-    // 解析失败不影响同步。
-    let patchText = '';
-    try { patchText = fs.readFileSync(patchFile, 'utf8'); } catch { /* 无 patch 文件 */ }
-    const removedIds = removedPluginIdsFromPatch(patchText);
-    // 插件文件同步 / 过期插件清理 / 旧市场目录清理 / 源缺失扫描 / bundle
-    // 落盘校验 / 卸载标记跳过 / 更新版本保留：与 scripts/sync-companion-plugins.js
-    // 共用 scripts/lib/companion-profile.js 的同一实现（日志文案经回调保持
-    // 本函数原有输出）。
-    // 源缺失原则（issue #34 诊断的自愈死循环）：缺失源一律不写 patch 注册
-    //（否则「注册了但包不存在」会让 dsh web 启动崩溃）；若 manifest 仍登记
-    // 为 bundle，则视为用户意图禁用，从 bundles 移除。
-    const { bundleNames, missingNames: missingSourceNames } = syncCompanionFiles({
-      assetsRoot: path.join(__dirname, 'assets', 'plugins'),
-      profileDir,
-      vendorRoot: path.join(__dirname, 'node_modules'),
-      removedIds,
-      log: (m) => log('boot', m),
-      fail: (m) => log('boot', m),
-      onCopyFail: (sf, err) => log('boot', '同步配套插件文件失败 ' + sf + ': ' + err.message),
-      onVerifyFail: (name, reason) => log('boot', '配套 bundle 校验失败（按源缺失处理，不注册）: ' + name + ' —— ' + reason),
-    });
-
-    // v0.3.5 起插件市场整体切换为 zat-dsh-engine（MIT）：清理旧版
-    // @deepseek-ai/dsh-plugin-marketplace 的 patch 行（幂等）。
-    try {
-      let legacyPatch = fs.readFileSync(patchFile, 'utf8');
-      const legacy = removeLegacyMarketplacePatchLines(legacyPatch);
-      if (legacy.changed) {
-        writeFileAtomic(patchFile, legacy.patch);
-        log('boot', '已从 cordis.patch.yml 移除旧插件市场条目');
-      }
-    } catch {}
-
-    // v0.3.11 起内置插件市场 zat-dsh-engine 默认移除（用户要求）：存量 profile
-    // 里已装配的副本一次性清理（目录 + manifest bundles 登记）。settings 标记
-    // zatEngineRetired 保证只清一次——用户之后从 dshmarket 主动重装不受影响。
-    retireZatEngine(profileDir);
-
-    // billion-context-dsh（compaction-acp）是模型驱动的 ACP 压缩后端：同一
-    // realm 内与 dsh 默认的 compaction-basic 不能并存（插件 README 的官方
-    // 安装说明）。幂等写入禁用条目：patch 中已存在 compaction-basic 条目
-    // （含用户手写的 disabled 块）则不动，尊重用户配置。
-    if (bundleNames.has('billion-context-dsh')) {
-      try {
-        let patch = '';
-        try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
-        const entry = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*compaction-basic\\b'), ACP_DISABLE_BLOCK);
-        if (entry.changed) {
-          writeFileAtomic(patchFile, entry.patch);
-          log('boot', '已禁用 compaction-basic（billion-context-dsh 接管压缩后端）');
-        }
-      } catch (err) {
-        log('boot', '写入 compaction-basic 禁用条目失败: ' + err.message);
-      }
-    }
-
-    // 桌面宠物（harness-pet）默认关闭：客户端常驻 rAF 逐帧绘制 canvas（issue
-    // #34 诊断为软渲染/流式输出下的持续阻塞源），且旧版保存的开关值会覆盖
-    // 客户端默认。插件级 disabled 条目一票否决任何已保存状态；需要时可在
-    // 设置 → 插件 → 管理 一键开启（与 dsh-plugin-manager 同机制）。幂等：
-    // patch 中已存在 harness-pet 条目（含用户手写）则不动，尊重用户配置。
-    if (bundleNames.has('harness-pet')) {
-      try {
-        let patch = '';
-        try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
-        const entry = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*harness-pet\\b'), PET_DISABLE_BLOCK);
-        if (entry.changed) {
-          writeFileAtomic(patchFile, entry.patch);
-          log('boot', '已默认关闭桌面宠物（harness-pet，可在插件管理开启）');
-        }
-      } catch (err) {
-        log('boot', '写入 harness-pet 禁用条目失败: ' + err.message);
-      }
-    }
-
-    // profile manifest 装配对账（收口在 scripts/lib/profile-reconcile.js 唯一
-    // 实现，main.js 与 sync-companion-plugins.js 共用）：损坏备份重建、核心
-    // 补齐、全量逐条校验（无效且非核心的登记移除并记入隔离记录
-    // dsh-desktop.broken-bundles.json）、配套登记追加、源缺失/卸载标记移除、
-    // 重置后用户 bundle 恢复（issue #48）。全部原子写，健康 manifest 零写入
-    // （幂等）。parsePatch 注入与 dsh 相同的 entry-list 方言（js-yaml 缺失时
-    // 降级为不检查补丁层可解析性，运行时防护兜底）。
-    const removedBundles = COMPANION_PLUGINS.filter((p) => removedIds.has(p.id)).map((p) => p.name);
-    const reconciled = reconcileProfileBundles(profileDir, {
-      installAnchorDir: path.dirname(dshPackageJson()),
-      coreNames: CORE_BUNDLE_NAMES,
-      addNames: bundleNames,
-      missingNames: missingSourceNames,
-      removedBundles: new Set(removedBundles),
-      excludeFromRecover: new Set([...CORE_BUNDLE_NAMES, ...COMPANION_PLUGINS.map((p) => p.name)]),
-      parsePatch: loadDshYamlDialect(),
-      log: (m) => log('boot', m),
-    });
-    if (reconciled.reset && reconciled.manifest &&
-        Array.isArray(reconciled.manifest.dsh && reconciled.manifest.dsh.profile && reconciled.manifest.dsh.profile.bundles)) {
-      notifyManifestResetRecovered(reconciled.recovered);
-    }
-
-    // 非 bundle 插件注册到 profile 的 patch 层（幂等）。bundle 迁移自愈
-    //（issue #17 同族：升级为 bundle 的插件残留 insert 行会造成同 id 双登记）、
-    // 源缺失残留移除、卸载标记跳过、用户已有条目尊重与 name 就地改名统一收口
-    // 在共享实现 registerCompanionPatchEntries（与 scripts/sync-companion-plugins.js
-    // 同一数据源；用户手写的 config/disabled 覆盖条目由 dropBlocksByIds 语义原样保留）。
-    // 注意：必须在 legacy/ACP/PET 三步落盘之后重新读盘——它们都可能改写过
-    // 文件，注册层基于旧快照写回会覆盖这几步的成果。
-    let patch = '';
-    try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { patch = ''; }
-    const registration = registerCompanionPatchEntries(patch, {
-      plugins: COMPANION_PLUGINS,
-      bundleNames,
-      missingNames: missingSourceNames,
-      removedIds,
-      onDrop: (m) => log('boot', m),
-    });
-    if (registration.changed) {
-      writeFileAtomic(patchFile, registration.patch);
-      log('boot', '已同步配套插件到 web profile: ' + COMPANION_PLUGINS.map((p) => p.id).join(', '));
-    }
-  } catch (err) {
-    log('boot', '同步配套插件失败: ' + err.message);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// 插件管理数据与写盘（设置页「插件」页「管理」标签；IPC 见 dsh:plugin-list /
-// dsh:plugin-set-enabled）
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// 退役插件一次性清理：v0.3.11 起内置插件市场 zat-dsh-engine 默认移除。
-// 存量 profile 里已装配的副本（profile node_modules 目录 + manifest bundles
-// 登记）清一次；settings 标记 zatEngineRetired 保证幂等且不再干预——用户
-// 之后从 dshmarket 主动重装不受影响。
-// ---------------------------------------------------------------------------
-function retireZatEngine(profileDir) {
-  const RETIRED_NAME = 'zat-dsh-engine';
-  try {
-    const s = updater.loadSettings(updCtx());
-    if (s.zatEngineRetired) return;
-    const pkgDir = path.join(profileDir, 'node_modules', RETIRED_NAME);
-    if (fs.existsSync(pkgDir)) {
-      // 只清内置装配特征（dsh.bundle.patch 声明）的副本，避免误删同名第三方包。
-      let isBuiltin = false;
-      try {
-        const p = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8'));
-        isBuiltin = !!(p && p.dsh && p.dsh.bundle && p.dsh.bundle.patch);
-      } catch {}
-      if (isBuiltin) {
-        fs.rmSync(pkgDir, { recursive: true, force: true });
-        log('boot', '已移除内置插件市场 ' + RETIRED_NAME + '（v0.3.11 起默认移除）');
-      }
-    }
-    const manifestFile = path.join(profileDir, 'package.json');
-    try {
-      const m = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
-      if (m && m.dsh && m.dsh.profile && Array.isArray(m.dsh.profile.bundles) && m.dsh.profile.bundles.includes(RETIRED_NAME)) {
-        m.dsh.profile.bundles = m.dsh.profile.bundles.filter((n) => n !== RETIRED_NAME);
-        writeFileAtomic(manifestFile, JSON.stringify(m, null, 2) + '\n');
-        log('boot', '已从 web profile bundles 移除 ' + RETIRED_NAME + ' 登记');
-      }
-    } catch (err) {
-      log('boot', '清理 ' + RETIRED_NAME + ' manifest 登记失败: ' + err.message);
-    }
-    s.zatEngineRetired = true;
-    updater.saveSettings(updCtx(), s);
-  } catch (err) {
-    log('boot', '退役清理 ' + RETIRED_NAME + ' 失败: ' + err.message);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -4825,741 +4460,6 @@ function syncLocalAgentPresets() {
   }
 }
 
-// ---------------------------------------------------------------------------
-// 运行时补丁候选路径（构造收口在 scripts/lib/runtime-patches.js 的纯函数里，
-// 这里只绑定模块级变量）：
-//   本地模式三副本 = profile fallback（junction 写穿内置副本）→ 内置 app 副本
-//   → 用户更新过的 agent overlay；防护类补丁（app-boot / settings / workspace /
-//   插件页标签合并）另覆盖 overlay 嵌套 dsh 依赖副本，且内置副本优先。
-//   WSL 托管模式目标 = WSL 安装目录（profile fallback + agent，经 UNC 写穿），
-//   由 patchTargets 统一构造；包级补丁在 WSL 模式追加 WSL agent 直连根。
-// ---------------------------------------------------------------------------
-function runtimeCopyFiles(pkgRel) {
-  return localCopyFiles(dshHome || path.join(os.homedir(), '.dsh'), __dirname, userDataDir, pkgRel);
-}
-
-function runtimeGuardFiles(pkgRel) {
-  return guardCopyFiles(effectiveDshHome() || path.join(os.homedir(), '.dsh'), __dirname, userDataDir, pkgRel);
-}
-
-// node_modules 根目录版本（web-search / menu-viewport / session-manage 三个
-// 包级补丁用）：WSL 模式下 home 为 UNC 等价路径（经 UNC 覆盖 WSL profile），
-// 并追加 WSL agent 直连根兜底（与 patchTargets 的 agent 条目语义一致）。
-function runtimeNodeModulesRoots() {
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const extraRoots = isWslMode() ? [path.join(home, 'agent', 'node_modules')] : [];
-  return localNodeModulesRoots(home, __dirname, userDataDir, extraRoots);
-}
-
-// ---------------------------------------------------------------------------
-// keyed slot 兼容补丁：rc.6 旧插件把 keyed slot 的注册身份放在 `id`，rc.7
-// 改为强制 `key`；dsh-advisor / dsh-llm-fallbacks 则 key/id 都不传，会导致
-// 单个第三方插件拖垮整个 loader（keyed slot "settings.plugin.item" requires
-// options.key）。ui-slots 侧把旧 `id` 提升为 `key`；runner 侧在真正调用
-// register 前为既无 key 又无 id 的注册派生包级兜底 key。两份补丁都幂等，
-// 并覆盖顶层与 dsh 嵌套依赖副本，dsh 更新后下次启动自动重打。
-// ---------------------------------------------------------------------------
-function applySlotCompatFix() {
-  const wslHome = effectiveDshHome();
-  const files = isWslMode()
-    ? slotCompatPatchTargets(wslHome)
-    : slotCompatCopyFiles(dshHome || path.join(os.homedir(), '.dsh'), __dirname, userDataDir);
-  applyPatchToFiles({
-    prefix: 'keyed slot 旧插件兼容补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: transformLegacySlotKey,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已兼容旧插件的 keyed slot id ' + file,
-    failLog: (file, err) => 'keyed slot 旧插件兼容补丁失败(' + file + '): ' + err.message,
-  });
-  applyPatchToFiles({
-    prefix: 'keyed slot 无 key 兼容补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: transformSlotUnkeyedCompat,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已兼容 keyed slot 无 key 注册 ' + file,
-    failLog: (file, err) => 'keyed slot 无 key 兼容补丁失败(' + file + '): ' + err.message,
-  });
-  // 第三轮：keyed slot 注册错误隔离（安全网）。
-  // 当前两轮补丁因版本差异均未命中时，在 ui-slots register 函数的 throw
-  // 语句前注入 guard，让缺少 key 的注册自动派生 key 而不是 throw，避免
-  // 单个第三方插件拖垮整个 loader（dsh web 60s 超时 → 桌面版 + 网页版均不可用）。
-  // 目标文件与第一轮相同（SLOT_KEY_COMPAT_PKG_REL = dsh-client-ui-slots）。
-  applyPatchToFiles({
-    prefix: 'keyed slot 错误隔离补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: transformSlotErrorIsolation,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file, note) => '已隔离 keyed slot 注册错误 ' + file + (note ? ' (' + note + ')' : ''),
-    failLog: (file, err) => 'keyed slot 错误隔离补丁失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// 启动前 bundle 健康预检：扫描 profile 中的 bundle 包，检查是否存在已知的
-// "未提供 key 的 keyed slot 注册" 模式（dsh-vision-router 等第三方插件）。
-// 对已知会崩溃且补丁未命中的 bundle，在日志中警告并通知用户。
-// 纯读操作，不修改任何文件；实际修复由上述三层补丁负责。
-// ---------------------------------------------------------------------------
-function preScanPluginHealth() {
-  try {
-    const home = effectiveDshHome() || dshHome || path.join(os.homedir(), '.dsh');
-    const profileDir = path.join(home, 'profiles', 'web');
-    const pkgJsonPath = path.join(profileDir, 'package.json');
-    if (!fs.existsSync(pkgJsonPath)) return;
-    let pkgJson;
-    try { pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')); } catch { return; }
-    const bundles = (pkgJson['dsh'] && pkgJson['dsh'].profile && pkgJson['dsh'].profile.bundles) || [];
-    if (!Array.isArray(bundles) || bundles.length === 0) return;
-    // 检查每个 bundle 的 dsh-cordis-client-runner / dsh-client-ui-slots 副本是否已被补丁。
-    const nmRoots = [
-      path.join(home, 'profiles', 'node_modules'),
-      path.join(__dirname, 'node_modules'),
-      path.join(userDataDir, 'agent', 'node_modules'),
-    ];
-    const unpatched = [];
-    for (const root of nmRoots) {
-      const uiSlotsFile = path.join(root, '@deepseek-ai', SLOT_KEY_COMPAT_PKG_REL);
-      if (!fs.existsSync(uiSlotsFile)) continue;
-      try {
-        const content = fs.readFileSync(uiSlotsFile, 'utf8');
-        // 若三层补丁均未命中，说明 ui-slots 文件存在但锚点不匹配
-        const hasAnyPatch = content.includes(SLOT_ERROR_ISOLATE_MARKER)
-          || content.includes('dsh-desktop compat: accept legacy keyed-slot id as key');
-        if (!hasAnyPatch) {
-          unpatched.push(uiSlotsFile);
-        }
-      } catch {}
-    }
-    if (unpatched.length > 0) {
-      log('boot', '插件健康预检: ui-slots 文件未被补丁覆盖（版本差异），slot 错误隔离可能未生效: ' + unpatched.join(', '));
-      log('boot', '建议: 若启动后出现 "keyed slot requires options.key" 错误，请升级 DSH Desktop 或联系插件开发者添加 options.key');
-    }
-  } catch (err) {
-    log('boot', '插件健康预检失败（不影响启动）: ' + ((err && err.message) || err));
-  }
-}
-
-// ---------------------------------------------------------------------------
-// dsh web 运行时闪跳修复：官方 dsh-client-runtime 在会话列表刷新
-// （mergeOrderedBaseline）时会丢弃「本地已创建、宿主全量列表尚未回显」的
-// 新会话，使 current 瞬时变 undefined，UI 闪回「选择工作区/无会话」状态。
-// 这里幂等地把补丁写进运行时文件；dsh 包更新后本函数会在下次启动重新应用。
-// ---------------------------------------------------------------------------
-function applyRuntimeFlashFix() {
-  // 覆盖运行副本：profile fallback、内置 app 副本、更新 overlay；
-  // wsl 托管模式目标换成 WSL 安装目录（profile fallback + agent，经 UNC 写穿，
-  // fallback 符号链接未创建时由 agent 直连目标兜底）。
-  const wslHome = effectiveDshHome();
-  const files = isWslMode()
-    ? patchTargets(wslHome, FLASH_PKG_REL)
-    : runtimeCopyFiles(FLASH_PKG_REL);
-  applyPatchToFiles({
-    prefix: 'runtime 补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: transformFlashFix,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已修复会话列表刷新闪跳 ' + file,
-    failLog: (file, err) => 'runtime 补丁失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// dsh-host-apiproxy 设置暴露补丁：官方代理只把少数命名空间暴露给浏览器端
-// 配置客户端（WEB_SETTINGS_NAMESPACES 白名单）。我们配套的 dsh-prompt-custom /
-// dsh-third-party-thinking / dsh-vision / dsh-conversation-tweaks 等设置节
-// 依赖这些命名空间暴露，否则设置页对应栏目显示「设置不可用」甚至消失。
-// 这里幂等地把命名空间追加进白名单，并同时覆盖三处运行副本：
-//   - profile fallback（即内置 app 副本，通过 junction 写穿）
-//   - 内置 app node_modules
-//   - 用户更新过的 agent overlay（部分用户看不见插件设置的根因：overlay 副本从未被补）
-// ---------------------------------------------------------------------------
-function applyPromptExposeFix() {
-  // 覆盖运行副本：profile fallback、内置 app 副本、更新 overlay；
-  // wsl 托管模式目标换成 WSL 安装目录（profile fallback + agent，经 UNC 写穿）。
-  const wslHome = effectiveDshHome();
-  const files = isWslMode()
-    ? patchTargets(wslHome, EXPOSE_PKG_REL)
-    : runtimeCopyFiles(EXPOSE_PKG_REL);
-  applyPatchToFiles({
-    prefix: '提示词暴露补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: transformExposeFix,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file, note) => '已把 ' + note.join(', ') + ' 加入设置白名单 ' + file,
-    failLog: (file, err) => '提示词暴露补丁失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// shell 工具 description 可选化补丁：code 模式的 run_code 程序经常省略
-// `description`（该字段只用于 UI/日志，不影响执行），但官方 schema 与
-// validate 都强制要求，导致大量 INVALID_ARGS。本补丁把 pwsh/bash 的
-// description 改为可选，缺省时用 command 首行生成。幂等；覆盖三份运行副本，
-// WSL 覆盖 profile fallback + agent。
-// ---------------------------------------------------------------------------
-function applyShellDescriptionCompatFix() {
-  const wslHome = effectiveDshHome();
-  for (const rel of [PW_REL, BASH_REL]) {
-    const files = isWslMode()
-      ? patchTargets(wslHome, rel)
-      : runtimeCopyFiles(rel);
-    applyPatchToFiles({
-      prefix: 'shell description 兼容补丁',
-      files,
-      log: (m) => log('boot', m),
-      transform: transformShellDescriptionOptional,
-      alreadyLog: (file) => '已应用，跳过 ' + file,
-      doneLog: (file) => '已把 description 改为可选 ' + file,
-      failLog: (file, err) => 'shell description 兼容补丁失败(' + file + '): ' + err.message,
-    });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// code preset 兼容补丁：官方 code 模式只允许直接调用 run_code，但 DeepSeek
-// 模型会直接调用 read/grep/todo_write/report 而收到 UNKNOWN_TOOL。把
-// tool-presentation 从 code 改为 both：run_code 保留，原生工具也可直接调用。
-// 幂等；覆盖三份运行副本，WSL 覆盖 profile fallback + agent。
-// ---------------------------------------------------------------------------
-function applyCodeModeCompatFix() {
-  const wslHome = effectiveDshHome();
-  const files = isWslMode()
-    ? patchTargets(wslHome, CODE_PRESET_REL)
-    : runtimeCopyFiles(CODE_PRESET_REL);
-  applyPatchToFiles({
-    prefix: 'code 模式兼容补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: transformCodeModeCompat,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已把 code preset 切换为 both ' + file,
-    failLog: (file, err) => 'code 模式兼容补丁失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// 图片字节信任补丁：官方 attachment-local 严格比对「浏览器声明的 MIME」与
-// 「字节解码出的格式」，而声明跟随文件扩展名不可信（webp/jpeg 改名 .png 后
-// file.type 仍是 image/png，字节却是 webp），不一致直接拒发整条消息，用户
-// 看到「仅支持 PNG、JPG、WebP、GIF」却发不出去。本补丁把声明为 image/* 时
-// 的媒体类型改为以字节实际格式为准记录，不再拒绝发送。幂等；覆盖三份运行
-// 副本，WSL 覆盖 profile fallback + agent。
-// ---------------------------------------------------------------------------
-function applyAttachmentMimeTrustFix() {
-  const wslHome = effectiveDshHome();
-  const files = isWslMode()
-    ? patchTargets(wslHome, ATTACH_LOCAL_REL)
-    : runtimeCopyFiles(ATTACH_LOCAL_REL);
-  applyPatchToFiles({
-    prefix: '图片字节信任补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: transformAttachmentMimeTrust,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已信任图片解码字节 ' + file,
-    failLog: (file, err) => '图片字节信任补丁失败(' + file + '): ' + err.message,
-  });
-}
-// ---------------------------------------------------------------------------
-// 文本模型自动识图补丁：官方 apiproxy 在 session.prompt 入口检查模型是否支持
-// image 输入，不支持就直接拒绝。本补丁复用已安装的 dsh-vision 插件配置
-// （设置 → 识图插件（view_image）的 VLM baseURL/model/apiKey），把图片转述为
-// 详细文字（含 OCR）后再发送，文本模型也能“看图”。幂等；本地模式覆盖三处
-// 运行副本，WSL 托管模式覆盖 WSL profile fallback + agent（与闪跳/白名单
-// 补丁同模式，经 UNC 写穿）。
-// ---------------------------------------------------------------------------
-function applyImageSendFix() {
-  // 幂等标记必须是桌面端自有注释：历史实现用「存在同名函数」判已应用，
-  // 新版 dsh-host-apiproxy 已原生内置 describeImagesWithVision —— 会误判
-  // 「已应用」而静默跳过门槛补丁，文本模型图片发送重新失效。
-  const DESKTOP_MARKER = 'DSH Desktop: reuse the dsh-vision VLM config';
-  const HELPER_ANCHOR = '/** Validate one prompt as a batch before publishing any durable image object. */';
-  const HELPER = `
-/** DSH Desktop: reuse the dsh-vision VLM config to describe images as text so text-only models can "see" them. */
-async function describeImagesWithVision(ctx, content) {
-	const settings = ctx.get("settings");
-	let vision = null;
-	if (settings !== void 0 && typeof settings.get === "function") {
-		// dsh-desktop fix: read the resolved HOST-side value (settings.get), not the
-		// redacted wire snapshot. redactSecrets strips role('secret') fields, so
-		// describe({redactSecrets:true}) drops apiKey and every keyed VLM endpoint
-		// answers 401 — image sends failed for configured users.
-		const resolved = settings.get("dsh-vision");
-		if (resolved !== void 0 && typeof resolved === "object") vision = resolved;
-	}
-	if (vision === null && settings !== void 0 && typeof settings.describe === "function") {
-		try {
-			const descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");
-			if (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;
-		} catch {}
-	}
-	if (vision === null || typeof vision.baseURL !== "string" || vision.baseURL.trim() === "" || typeof vision.model !== "string" || vision.model.trim() === "") {
-		throw new Error("未配置识图服务：请到 设置 → 识图插件（view_image） 填写 VLM 接口地址与模型");
-	}
-	const apiKey = typeof vision.apiKey === "string" ? vision.apiKey.trim() : "";
-	const endpoint = vision.baseURL.replace(/\\/+$/, "") + "/chat/completions";
-	const out = [];
-	let imageNo = 0;
-	for (const part of content) {
-		if (part.type !== "image") {
-			if (part.type === "text") out.push(part);
-			continue;
-		}
-		imageNo += 1;
-		const dataUrl = \`data:\${part.mediaType};base64,\${part.data}\`;
-		const payload = {
-			model: vision.model,
-			stream: false,
-			messages: [
-				{ role: "system", content: "You are an image understanding assistant. Describe the image in exhaustive detail and transcribe every visible text (OCR). If it is a UI, document, table, chart or code, preserve its structure. Answer in Chinese unless the user's language clearly differs." },
-				{ role: "user", content: [
-					{ type: "text", text: "请把这张图片完整转述为文字：包含画面内容、结构与全部可见文字（逐字 OCR）。" },
-					{ type: "image_url", image_url: { url: dataUrl } }
-				] }
-			]
-		};
-		const headers = { "content-type": "application/json" };
-		if (apiKey !== "") headers.authorization = "Bearer " + apiKey;
-		const response = await fetch(endpoint, {
-			method: "POST",
-			headers,
-			body: JSON.stringify(payload),
-			signal: AbortSignal.timeout(120000)
-		});
-		if (!response.ok) {
-			const bodyText = await response.text().catch(() => "");
-			throw new Error("识图服务返回 HTTP " + response.status + "：" + bodyText.slice(0, 400));
-		}
-		const data = await response.json();
-		const description = data && data.choices && data.choices[0] && data.choices[0].message ? data.choices[0].message.content : "";
-		if (typeof description !== "string" || description.trim() === "") throw new Error("识图服务未返回有效文字描述");
-		out.push({ type: "text", text: "[图片" + imageNo + "] " + description.trim() });
-	}
-	return out;
-}
-`;
-  const GATE_MARKER = 'if (modelInfo.inputModalities !== void 0 && !modelInfo.inputModalities.includes("image")) return err(request, {';
-  const GATE_NEW = `if (modelInfo.inputModalities !== void 0 && !modelInfo.inputModalities.includes("image")) {
-							try {
-								admittedContent = await describeImagesWithVision(ctx, content);
-							} catch (error) {
-								return err(request, {
-									code: "attachment-error",
-									message: \`图片自动转述失败：\${error instanceof Error ? error.message : String(error)}。请在 设置 → 识图插件（view_image） 配置 VLM 后重试。\`,
-									details: { reason: "IMAGE_DESCRIPTION_FAILED" }
-								});
-							}
-						}`;
-
-  const wslHome = effectiveDshHome();
-  const files = isWslMode()
-    ? patchTargets(wslHome, EXPOSE_PKG_REL)
-    : runtimeCopyFiles(EXPOSE_PKG_REL);
-  applyPatchToFiles({
-    prefix: '识图发送补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: (src, file) => {
-      if (src.includes(DESKTOP_MARKER)) return { status: 'already' };
-      // 上游已原生内置同名 helper（新版 dsh）：不重复插入（重复定义会留下
-      // 被后者遮蔽的死代码），只做门槛替换；其 apiKey 脱敏缺陷由
-      // applyVisionKeyFix 就地修复。
-      const nativeHelper = src.includes('async function describeImagesWithVision');
-      if (!nativeHelper) {
-        // 1) 插入转述 helper（此后所有索引必须基于插入后的 src 重新计算）
-        const anchorIdx = src.indexOf(HELPER_ANCHOR);
-        if (anchorIdx === -1) {
-          return { status: 'anchor-missing', detail: '未找到 helper 插入锚点（版本可能已变更），跳过 ' + file };
-        }
-        src = src.slice(0, anchorIdx) + HELPER + '\n' + src.slice(anchorIdx);
-      }
-      // 2) prompt 入口：声明 admittedContent
-      const hasImageIdx = src.indexOf('const hasImage = content.some((part) => part.type === "image");');
-      if (hasImageIdx === -1) {
-        return { status: 'anchor-missing', detail: '未找到 hasImage 入口（版本可能已变更），跳过 ' + file };
-      }
-      src = src.slice(0, hasImageIdx) + 'let admittedContent = content;\n\t\t\t\t' + src.slice(hasImageIdx);
-      // 3) 把“模型不支持图片”的直接拒绝替换为自动转述
-      const gateIdx = src.indexOf(GATE_MARKER);
-      if (gateIdx === -1) {
-        return { status: 'anchor-missing', detail: '未找到模型图片门槛（版本可能已变更），跳过 ' + file };
-      }
-      const gateEnd = src.indexOf('});', gateIdx);
-      if (gateEnd === -1) {
-        return { status: 'anchor-missing', detail: '图片门槛收尾异常，跳过 ' + file };
-      }
-      src = src.slice(0, gateIdx) + GATE_NEW + src.slice(gateEnd + 3);
-      // 4) durablePromptContent 使用转述后的内容（从门槛之后查找调用点，避免命中函数定义）
-      const callIdx = src.indexOf('durablePromptContent(ctx, content)', gateIdx);
-      if (callIdx === -1) {
-        return { status: 'anchor-missing', detail: '未找到 durablePromptContent 调用，跳过 ' + file };
-      }
-      src = src.slice(0, callIdx) + 'durablePromptContent(ctx, admittedContent)' + src.slice(callIdx + 'durablePromptContent(ctx, content)'.length);
-      return { status: 'changed', src };
-    },
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已启用文本模型图片自动转述 ' + file,
-    failLog: (file, err) => '识图发送补丁失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// 图片自动转述 apiKey 修复：官方 apiproxy 内置的 describeImagesWithVision 用
-// settings.describe({ redactSecrets: true }) 读 dsh-vision 配置——redactSecrets
-// 会把 role('secret') 的 apiKey 整字段删除，带密钥校验的 VLM 端点必然 401，
-// prompt 被拒、客户端提示「图片发送失败」。这里幂等改写为先读 settings.get()
-// 的宿主侧未脱敏解析值（保留 apiKey），describe 快照降级为回退。dsh 更新后
-// 本函数会在下次启动重新应用。本地模式覆盖三处运行副本；WSL 托管模式覆盖
-// WSL profile fallback + agent（与闪跳/白名单补丁同模式，经 UNC 写穿）。
-// ---------------------------------------------------------------------------
-function applyVisionKeyFix() {
-  const guardMarker = 'dsh-desktop fix: read the resolved HOST-side value';
-  const from = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
-  const to = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.get === "function") {\n\t\t// dsh-desktop fix: read the resolved HOST-side value (settings.get), not the\n\t\t// redacted wire snapshot. redactSecrets strips role(\'secret\') fields, so\n\t\t// describe({redactSecrets:true}) drops apiKey and every keyed VLM endpoint\n\t\t// answers 401 — image sends failed for configured users.\n\t\tconst resolved = settings.get("dsh-vision");\n\t\tif (resolved !== void 0 && typeof resolved === "object") vision = resolved;\n\t}\n\tif (vision === null && settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
-  const wslHome = effectiveDshHome();
-  const files = isWslMode()
-    ? patchTargets(wslHome, EXPOSE_PKG_REL)
-    : runtimeCopyFiles(EXPOSE_PKG_REL);
-  applyPatchToFiles({
-    prefix: '识图密钥补丁',
-    files,
-    log: (m) => log('boot', m),
-    transform: (src, file) => {
-      if (src.includes(guardMarker)) return { status: 'already' };
-      if (!src.includes(from)) {
-        return { status: 'anchor-missing', detail: '锚点未匹配（版本可能已变化），跳过 ' + file };
-      }
-      return { status: 'changed', src: src.replace(from, to) };
-    },
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已修复 apiKey 被脱敏截断 ' + file,
-    failLog: (file, err) => '识图密钥补丁失败(' + file + '): ' + err.message,
-  });
-}
-// ---------------------------------------------------------------------------
-// dsh 装配层防护：profile 自有的 cordis.patch.yml 属于用户数据，dsh 官方设计是
-// 「补丁文件损坏必须启动失败」（fail loud）。但该文件损坏会让桌面端永久无法
-// 启动。这里像 applyRuntimeFlashFix 一样幂等地改写 @deepseek-ai/dsh-app-boot：
-// 把 loadProfile 对 profile patch 的严格加载替换为「解析失败 → 备份 + 重置为
-// 空列表并继续启动」的自愈加载；CLI 等其它入口同样受益。dsh 更新后本函数会在
-// 下次启动重新应用。
-// ---------------------------------------------------------------------------
-function applyProfilePatchGuard() {
-  const guardMarker = 'function loadUserPatchLayer';
-  const callSite = '\t\tpatches: options.userLayer !== false && existsSync(patchPath) ? loadOverlayPatches(binName, patchPath) : []';
-  const callReplacement = '\t\tpatches: loadUserPatchLayer(binName, patchPath, options)';
-  const insertAfter = '\treturn parsePatchList(binName, file, content, "overlay");\n}';
-  const injected =
-    '/** dsh-desktop guard: the profile\'s own patch layer is user-owned data; a broken file must not brick\n' +
-    ' * the surface. Back the broken file up, reset the layer to an empty list, and boot without it.\n' +
-    ' */\n' +
-    'function loadUserPatchLayer(binName, patchPath, options) {\n' +
-    '\tif (options.userLayer === false || !existsSync(patchPath)) return [];\n' +
-    '\ttry {\n' +
-    '\t\treturn loadOverlayPatches(binName, patchPath);\n' +
-    '\t} catch (error) {\n' +
-    '\t\ttry {\n' +
-    '\t\t\tconst backup = `${patchPath}.broken-${Date.now()}`;\n' +
-    '\t\t\twriteFileSync(backup, readFileSync(patchPath, "utf8"));\n' +
-    '\t\t\twriteFileSync(patchPath, "# recovered by dsh: the previous content failed to parse and was moved to\\n# " + backup + "\\n[]\\n");\n' +
-    '\t\t} catch {}\n' +
-    '\t\tprocess.stderr.write(`${binName}: ${patchPath} failed to parse (${String(error?.message ?? error)}); the broken file was moved aside and the profile booted without its patch layer\\n`);\n' +
-    '\t\treturn [];\n' +
-    '\t}\n' +
-    '}';
-  applyPatchToFiles({
-    prefix: 'profile patch 防护',
-    files: runtimeGuardFiles(path.join('dsh-app-boot', 'lib', 'index.js')),
-    log: (m) => log('boot', m),
-    transform: (src, file) => {
-      if (src.includes(guardMarker)) return { status: 'already' }; // 已应用（幂等，静默）
-      if (!src.includes(callSite) || !src.includes(insertAfter)) {
-        return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
-      }
-      const out = src.replace(callSite, callReplacement);
-      return { status: 'changed', src: out.replace(insertAfter, insertAfter + '\n\n' + injected) };
-    },
-    doneLog: (file) => '已注入自愈加载到 ' + file,
-    failLog: (file, err) => 'profile patch 防护失败: ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// profile bundle 装配防护：官方 dsh-app-boot 对 profile bundle 缺失/损坏
-// fail-loud（resolveBundleDir 抛 cannot resolve profile bundle、无
-// dsh.bundle.patch 声明抛 declares no dsh.bundle、bundle 补丁层损坏抛
-// failed to parse overlay），都会让 dsh web 以退出码 1 启动失败。这里像
-// applyProfilePatchGuard 一样幂等地改写 @deepseek-ai/dsh-app-boot：bundle
-// 层逐个跳过（stderr 诊断，profile manifest 损坏则备份 + 模板重建）；同时
-// 改写 dsh 的 profile-boot 装配（家级 cordis.patch.yml 与 profile 补丁层
-// 损坏时备份 + 重置，覆盖启动与 HMR 热重载）。变换逻辑收口在
-// profile-bundle-heal.js；dsh 更新后本函数会在下次启动重新应用。
-// ---------------------------------------------------------------------------
-function applyProfileBundleGuard() {
-  const appBootFiles = runtimeGuardFiles(path.join('dsh-app-boot', 'lib', 'index.js'));
-  const appBootTransform = (src, file) => {
-    const out = applyAppBootBundleGuard(src);
-    if (!out.changed) {
-      if (!src.includes(PROFILE_BUNDLE_GUARD_MARKER)) {
-        return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
-      }
-      return { status: 'already' }; // 已注入（幂等，静默）
-    }
-    return { status: 'changed', src: out.src };
-  };
-  applyPatchToFiles({
-    prefix: 'profile bundle 防护',
-    files: appBootFiles,
-    log: (m) => log('boot', m),
-    transform: appBootTransform,
-    doneLog: (file) => '已注入自愈装配到 ' + file,
-    failLog: (file, err) => 'profile bundle 防护失败(' + file + '): ' + err.message,
-  });
-
-  // dsh/lib/profile-boot-*.js：家级 cordis.patch.yml 与 profile 补丁层自愈。
-  const home = effectiveDshHome() || path.join(os.homedir(), '.dsh');
-  const profileBootDirs = [
-    path.join(__dirname, 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
-  ];
-  const profileBootFiles = [];
-  for (const dir of profileBootDirs) {
-    let names;
-    try { names = fs.readdirSync(dir).filter((f) => /^profile-boot-.+\.js$/.test(f)); } catch { continue; }
-    for (const name of names) profileBootFiles.push(path.join(dir, name));
-  }
-  const profileBootTransform = (src, file) => {
-    let current = src;
-    let changed = false;
-    // heal 调用防护（独立幂等标记）：入口 bundle 无 heal 调用时静默。
-    const heal = applyProfileBootHealGuard(current);
-    if (heal.changed) { current = heal.src; changed = true; }
-    const bundle = applyProfileBootBundleGuard(current);
-    if (bundle.changed) { current = bundle.src; changed = true; }
-    if (changed) return { status: 'changed', src: current };
-    if (!current.includes(PROFILE_BOOT_GUARD_MARKER)) {
-      return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
-    }
-    return { status: 'already' }; // 已注入（幂等，静默）
-  };
-  applyPatchToFiles({
-    prefix: 'profile bundle 防护',
-    files: profileBootFiles,
-    log: (m) => log('boot', m),
-    transform: profileBootTransform,
-    doneLog: (file) => '已注入自愈装配到 ' + file,
-    failLog: (file, err) => 'profile bundle 防护失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// dsh-settings 注册防护：settings.yaml 中某命名空间的存储配置节非法（非对象或
-// 字段类型错误，常见于手改文件）时，installSettingsSection 里的 register() 会
-// 抛异常 → 消费插件 fiber 失败 → dsh fail-loud 启动崩溃。这里幂等地改写
-// @deepseek-ai/dsh-settings：register 失败改为告警 + 回退组合配置，命名空间
-// 本次启动不可用但不阻断启动。dsh 更新后本函数会在下次启动重新应用。
-// ---------------------------------------------------------------------------
-function applySettingsSectionGuard() {
-  const guardMarker = 'dsh-desktop guard: an invalid stored section must not brick';
-  const anchor = '\t\tconst scope = sctx.settings.register(ns, schema, {';
-  const guarded =
-    '\t\tlet scope;\n' +
-    '\t\ttry {\n' +
-    '\t\t\tscope = sctx.settings.register(ns, schema, {\n' +
-    '\t\t\t\tbase: entry,\n' +
-    '\t\t\t\t...hooks.validate === void 0 ? {} : { validate: hooks.validate }\n' +
-    '\t\t\t});\n' +
-    '\t\t} catch (error) {\n' +
-    '\t\t\t// dsh-desktop guard: an invalid stored section must not brick the consumer\n' +
-    '\t\t\t// fiber (fail-loud boot). Fall back to the composition config; the\n' +
-    '\t\t\t// namespace simply stays unavailable until the stored section is fixed.\n' +
-    '\t\t\tsctx.logger.warn("settings: registration for \\"%s\\" failed; falling back to the composition config this boot", ns);\n' +
-    '\t\t\tsctx.logger.warn(error);\n' +
-    '\t\t\ttry {\n' +
-    '\t\t\t\thooks.setSource(() => entry);\n' +
-    '\t\t\t\thooks.onChange();\n' +
-    '\t\t\t} catch {}\n' +
-    '\t\t\treturn;\n' +
-    '\t\t}\n' +
-    '\t\thooks.setSource(() => scope.get());';
-  const from2 = '\t\tconst scope = sctx.settings.register(ns, schema, {\n\t\t\tbase: entry,\n\t\t\t...hooks.validate === void 0 ? {} : { validate: hooks.validate }\n\t\t});\n\t\thooks.setSource(() => scope.get());';
-  applyPatchToFiles({
-    prefix: 'settings 注册防护',
-    files: runtimeGuardFiles(path.join('dsh-settings', 'lib', 'index.js')),
-    log: (m) => log('boot', m),
-    transform: (src, file) => {
-      if (src.includes(guardMarker)) return { status: 'already' }; // 已应用（幂等，静默）
-      if (!src.includes(anchor)) {
-        return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
-      }
-      return { status: 'changed', src: src.replace(from2, guarded) };
-    },
-    doneLog: (file) => '已注入到 ' + file,
-    failLog: (file, err) => 'settings 注册防护失败: ' + err.message,
-  });
-}
-// ---------------------------------------------------------------------------
-// ---------------------------------------------------------------------------
-// dsh-client-ui-workspace 搜索栏修复：侧边栏收起（rail）时点「搜索会话」会
-// 先 expandSidebar() 再 setSearchExpanded(true)。React 状态提交后，宽侧边栏
-// 新挂的 document click 监听会捕获同一个 click（旧 rail 按钮已不在 searchRoot
-// 内），立即把 searchExpanded 复位为 false——表现为「只是切到对话，搜索框没
-// 展开」。这里幂等地给监听加 searchOnExpand 宽限，并补进依赖数组。
-// ---------------------------------------------------------------------------
-function applyWorkspaceSearchRailFix() {
-  const guardMarker = 'dsh-desktop fix: rail search expansion';
-  const oldGuard = '\t\t\t\tif (!wide || !searchExpanded) return;';
-  const newGuard = '\t\t\t\tif (!wide || !searchExpanded || searchOnExpand) return; // ' + guardMarker;
-  const oldDeps = '\t\t\t}, [\n\t\t\t\tnormalizedQuery,\n\t\t\t\twide,\n\t\t\t\tsearchExpanded\n\t\t\t]);';
-  const newDeps = '\t\t\t}, [\n\t\t\t\tnormalizedQuery,\n\t\t\t\twide,\n\t\t\t\tsearchExpanded,\n\t\t\t\tsearchOnExpand\n\t\t\t]);';
-  applyPatchToFiles({
-    prefix: 'workspace 搜索栏修复',
-    files: runtimeGuardFiles(path.join('dsh-client-ui-workspace', 'lib', 'client.js')),
-    log: (m) => log('boot', m),
-    transform: (src, file) => {
-      if (src.includes(guardMarker)) return { status: 'already' };
-      if (!src.includes(oldGuard) || !src.includes(oldDeps)) {
-        return { status: 'anchor-missing', detail: '锚点未匹配（dsh 版本可能已变化），跳过 ' + file };
-      }
-      return { status: 'changed', src: src.replace(oldGuard, newGuard).replace(oldDeps, newDeps) };
-    },
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已注入到 ' + file,
-    failLog: (file, err) => 'workspace 搜索栏修复失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// 插件页标签合并补丁：官方「全部」只读清单与 dsh-plugin-manager 的「管理」标签
-// 功能重叠（管理已含全量列表 + 搜索 + 分类 + 开关）。幂等地从插件页标签列表
-// 中过滤掉 id 为 "all" 的只读清单，让「管理」成为唯一的插件列表入口。
-// 目标与其它防护类补丁一致：内置副本 + 更新 overlay（含嵌套 dsh 依赖副本）+
-// profile fallback；锚点不匹配（上游将来修复后）自动跳过。
-// ---------------------------------------------------------------------------
-function applyPluginInventoryTabMergeFix() {
-  const marker = 'dsh-desktop fix: hide inventory tab';
-  const oldPat = 'tabs = ctx.slots.entries("settings.plugins.tab").map((entry) => ({';
-  const newPat = 'tabs = ctx.slots.entries("settings.plugins.tab").filter((entry) => (entry.options.id ?? "") !== "all").map((entry) => ({ // ' + marker;
-  const files = runtimeGuardFiles(path.join('dsh-client-ui-settings-plugins', 'lib', 'client.js'));
-  applyPatchToFiles({
-    prefix: '插件页标签合并',
-    files,
-    log: (m) => log('boot', m),
-    transform: (src, file) => {
-      if (src.includes(marker)) return { status: 'already' };
-      if (!src.includes(oldPat)) {
-        return { status: 'anchor-missing', detail: '锚点未匹配（dsh 版本可能已变化），跳过 ' + file };
-      }
-      return { status: 'changed', src: src.replace(oldPat, newPat) };
-    },
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已隐藏「全部」只读清单 ' + file,
-    failLog: (file, err) => '插件页标签合并失败(' + file + '): ' + err.message,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// issue #20 运行时补丁：dsh-web-search-deepseek 的「接口地址」契约与拼接修复。
-// 补丁本体在 scripts/patch-web-search-baseurl.js（与打包补丁共用同一实现，
-// 避免两处漂移）；这里覆盖三处运行副本：profile fallback（junction 写穿）、
-// 内置 app 副本、用户更新过的 agent overlay。锚点不匹配（上游将来修复后）
-// 自动跳过，绝不损坏文件。
-// ---------------------------------------------------------------------------
-function applyWebSearchBaseUrlFix() {
-  const targets = runtimeNodeModulesRoots();
-  for (const root of targets) {
-    if (!root || !fs.existsSync(root)) continue;
-    try {
-      const n = patchWebSearchBaseUrl(root, (m) => log('boot', m));
-      if (n > 0) log('boot', 'web-search baseURL 补丁: 已应用到 ' + root);
-    } catch (err) {
-      log('boot', 'web-search baseURL 补丁失败(' + root + '): ' + err.message);
-    }
-  }
-}
-// ---------------------------------------------------------------------------
-// issue #36 运行时补丁：dsh-client-ui-primitives 的 Menu portal 弹层在条目很多
-// （内置 8 个 Agent 预设 + npm 自带 + 用户安装叠加）时没有高度上限，place()
-// 会把超出视口的弹层推到屏幕上方，顶部条目被裁掉且无法触达（「预设多了
-// 上面的会不显示」）。补丁本体在 scripts/patch-menu-viewport.js（与打包补丁
-// 共用同一实现）；覆盖三处运行副本：profile fallback、内置 app 副本、用户
-// 更新过的 agent overlay。锚点不匹配（上游将来修复后）自动跳过，绝不损坏。
-// ---------------------------------------------------------------------------
-function applyMenuViewportFix() {
-  const targets = runtimeNodeModulesRoots();
-  for (const root of targets) {
-    if (!root || !fs.existsSync(root)) continue;
-    try {
-      const n = patchMenuViewport(root, (m) => log('boot', m));
-      if (n > 0) log('boot', 'menu 视口补丁: 已应用到 ' + root);
-    } catch (err) {
-      log('boot', 'menu 视口补丁失败(' + root + '): ' + err.message);
-    }
-  }
-}
-// ---------------------------------------------------------------------------
-// 对话删除 / 归档管理运行时补丁（dsh-session-manager 插件的前置依赖）：
-// dsh-workspace（unarchiveSession）+ dsh-host-apiproxy（unarchiveSession /
-// deleteSession RPC）+ dsh-client-connection（API 面 + schema）+
-// dsh-client-ui-workspace（会话行菜单「删除对话」）。补丁本体在
-// scripts/patch-session-manage.js（幂等、锚点不匹配自动跳过）；覆盖三处运行
-// 副本：profile fallback、内置 app 副本、用户更新过的 agent overlay。
-// ---------------------------------------------------------------------------
-function applySessionManageFix() {
-  const targets = runtimeNodeModulesRoots();
-  for (const root of targets) {
-    if (!root || !fs.existsSync(root)) continue;
-    try {
-      const n = patchSessionManage(root, (m) => log('boot', m));
-      if (n > 0) log('boot', '对话删除补丁: 已应用到 ' + root);
-    } catch (err) {
-      log('boot', '对话删除补丁失败(' + root + '): ' + err.message);
-    }
-  }
-}
-// ---------------------------------------------------------------------------
-// issue #85 运行时补丁：侧栏项目/会话行 ⋯ 菜单「打开项目目录」+ 右键菜单
-// （dsh-client-ui-workspace）。补丁本体在 scripts/patch-open-project-dir.js
-// （幂等、锚点不匹配自动跳过）；覆盖三处运行副本：profile fallback、内置
-// app 副本、用户更新过的 agent overlay。桥 window.__dshDesktopOpenDir 由
-// dsh-session-manager 插件提供（window.dshDesktop.openPath → shell.openPath）。
-// ---------------------------------------------------------------------------
-function applyOpenProjectDirFix() {
-  const targets = runtimeNodeModulesRoots();
-  for (const root of targets) {
-    if (!root || !fs.existsSync(root)) continue;
-    try {
-      const n = patchOpenProjectDir(root, (m) => log('boot', m));
-      if (n > 0) log('boot', '打开项目目录补丁: 已应用到 ' + root);
-    } catch (err) {
-      log('boot', '打开项目目录补丁失败(' + root + '): ' + err.message);
-    }
-  }
-}
-// ---------------------------------------------------------------------------
-// 会话持久化容错补丁：进程中断可能留下一个结构完整的 zstd frame，但其
-// 解压文本以半条 JSONL 结束。只允许最终 frame 进入官方已有的 torn-tail
-// 截断/重放流程；中段损坏继续拒绝。
-// ---------------------------------------------------------------------------
-function applySessionPersistenceFix() {
-  const targets = runtimeNodeModulesRoots();
-  for (const root of targets) {
-    if (!root || !fs.existsSync(root)) continue;
-    try {
-      const n = patchSessionPersistence(root, (m) => log('boot', m));
-      if (n > 0) log('boot', '会话持久化容错补丁: 已应用到 ' + root);
-    } catch (err) {
-      log('boot', '会话持久化容错补丁失败(' + root + '): ' + err.message);
-    }
-  }
-}
 // 快捷方式维护：修复「没有桌面快捷方式 / 快捷方式指向的文件消失」，
 // 并让快捷方式图标跟随图标设计更新（.lnk 单独指定 icon.ico）。
 // ---------------------------------------------------------------------------
@@ -6277,51 +5177,17 @@ async function boot() {
     // 目录选择器 overlay（只作用于本地内置 dsh）。
     setupTestChannel();
     await wslBackend.ensureInstalled();
-    syncCompanionPlugins();
+    ensurePluginIntegration().syncPlugins();
     syncBuiltinAgentPresets();
-    applySlotCompatFix();
-    preScanPluginHealth();
-    applyRuntimeFlashFix();
-    applyPromptExposeFix();
-    applyShellDescriptionCompatFix();
-    applyCodeModeCompatFix();
-    applyImageSendFix();
-    applyAttachmentMimeTrustFix();
-    applyVisionKeyFix();
-    applyProfilePatchGuard();
-    applyProfileBundleGuard();
-    applySettingsSectionGuard();
-    applyWorkspaceSearchRailFix();
-    applyPluginInventoryTabMergeFix();
-    applyWebSearchBaseUrlFix();
-    applyMenuViewportFix();
-    applySessionManageFix();
-    applyOpenProjectDirFix();
-    applySessionPersistenceFix();
+    notifyPatchFailures(ensurePluginIntegration().applyPatches());
+    ensurePluginIntegration().preflightHealth();
   } else {
     // 先修复 profile fallback 联接再同步/补丁依赖文件：EPERM 环境下补丁写不进去。
     await repairProfileFallback(home);
-    syncCompanionPlugins();
+    ensurePluginIntegration().syncPlugins();
     syncLocalAgentPresets();
-    applySlotCompatFix();
-    preScanPluginHealth();
-    applyRuntimeFlashFix();
-    applyPromptExposeFix();
-    applyShellDescriptionCompatFix();
-    applyCodeModeCompatFix();
-    applyImageSendFix();
-    applyAttachmentMimeTrustFix();
-    applyVisionKeyFix();
-    applyProfilePatchGuard();
-    applyProfileBundleGuard();
-    applySettingsSectionGuard();
-    applyWorkspaceSearchRailFix();
-    applyPluginInventoryTabMergeFix();
-    applyWebSearchBaseUrlFix();
-    applyMenuViewportFix();
-    applySessionManageFix();
-    applyOpenProjectDirFix();
-    applySessionPersistenceFix();
+    notifyPatchFailures(ensurePluginIntegration().applyPatches());
+    ensurePluginIntegration().preflightHealth();
     setupTestChannel();
     if (runKoffiPreflight()) clearAutoPickerBrowseOverlay();
     else enablePickerBrowseOverlay();

--- a/dsh-desktop/scripts/desktop-diagnostics.js
+++ b/dsh-desktop/scripts/desktop-diagnostics.js
@@ -245,9 +245,10 @@ function readSelfHealHistory(file, fs = require('node:fs')) {
     return data
       .filter((it) => it && typeof it === 'object' && typeof it.ts === 'number' && Array.isArray(it.names))
       .map((it) => ({
-        kind: it.kind === 'overlay' ? 'overlay' : 'bundle',
+        kind: ['bundle', 'overlay', 'patch-layer'].includes(it.kind) ? it.kind : 'bundle',
         names: it.names.filter((n) => typeof n === 'string'),
         ts: it.ts,
+        backup: typeof it.backup === 'string' && it.backup ? it.backup : undefined,
       }))
       .filter((it) => it.names.length > 0)
       .slice(0, 5);
@@ -325,8 +326,9 @@ function runDiagnostics(opts, fs = require('node:fs')) {
   const selfHeal = readSelfHealHistory(opts.selfHealHistoryFile, fs);
   sections.selfHeal = selfHeal;
   for (const it of selfHeal) {
-    const action = it.kind === 'overlay' ? '已自动禁用' : '已自动移除';
-    infos.push(e(`最近启动自愈（${new Date(it.ts).toLocaleString()}）：${action} ${it.names.join('、')}`));
+    const action = it.kind === 'overlay' ? '已自动禁用' : it.kind === 'patch-layer' ? '已重置补丁配置' : '已自动移除';
+    const label = it.kind === 'patch-layer' && it.backup ? path.basename(it.backup) : it.names.join('、');
+    infos.push(e(`最近启动自愈（${new Date(it.ts).toLocaleString()}）：${action} ${label}`));
   }
 
   // --- 环境 ---

--- a/dsh-desktop/scripts/integration/fault-isolation.js
+++ b/dsh-desktop/scripts/integration/fault-isolation.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 单插件故障隔离收口。
+//
+// 三层「单插件不拖垮整树」统一收口：
+//   1. transform 安全网：transformSlotErrorIsolation（registry 的
+//      slot-error-isolation spec）——缺 key 时 warn + 派生 key，不 throw；
+//   2. 只读预检：preScanPluginHealth 迁入，按 ui-slots 实际落盘 marker 判定
+//      「已补丁 / 失配 / 未覆盖」三态；
+//   3. 守护触发：plugin-guard.js 的 heal 触发/判定收口到健康检查管线
+//      （P1-10），fault-isolation 只提供「预检结果」作为输入。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { markers } = require('../lib/patch-adapters');
+const { SLOT_KEY_COMPAT_PKG_REL, resolveNmRoots } = require('../lib/patch-target-resolver');
+
+/**
+ * 预检目标 ui-slots（dsh-client-ui-slots/lib/index.js）实际会被写入的 marker。
+ * 显式列出，避免从 registry 反推时误收「锚点只在 cordis-client-runner、其
+ * marker 从不写入 ui-slots」的 slot-unkeyed-compat 补丁 marker（历史 QA 曾因此
+ * 误报）。同时兼容 error-isolation 的 v1 / v2 两种标记（v2 修复了无条件 throw）。
+ * @returns {string[]}
+ */
+function uiSlotsMarkers() {
+  return [markers.SLOT_KEY_COMPAT_MARKER, markers.SLOT_ERROR_ISOLATE_MARKER, markers.SLOT_ERROR_ISOLATE_MARKER_V2];
+}
+
+/**
+ * 启动前 bundle 健康预检（只读，不修改任何文件）。
+ * 扫描 profile bundle 的 dsh-client-ui-slots 副本，检查是否已被补丁覆盖；
+ * 未覆盖时记录「版本差异」告警 + 升级建议（与旧 preScanPluginHealth 文案一致）。
+ * @param {Object} ctx { home, appDir, userDataDir, log }
+ * @returns {{scanned: number, unpatched: string[]}}
+ */
+function preflight(ctx) {
+  try {
+    const profileDir = path.join(ctx.home, 'profiles', 'web');
+    const pkgJsonPath = path.join(profileDir, 'package.json');
+    if (!fs.existsSync(pkgJsonPath)) return { scanned: 0, unpatched: [] };
+    let pkgJson;
+    try { pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')); } catch { return { scanned: 0, unpatched: [] }; }
+    const bundles = (pkgJson['dsh'] && pkgJson['dsh'].profile && pkgJson['dsh'].profile.bundles) || [];
+    if (!Array.isArray(bundles) || bundles.length === 0) return { scanned: 0, unpatched: [] };
+    const nmRoots = resolveNmRoots(ctx, { layout: 'nm-roots' });
+    // 局部用 slotMarkers 命名，避免遮蔽模块级的 markers 对象（单一导出源）。
+    const slotMarkers = uiSlotsMarkers();
+    const unpatched = [];
+    for (const root of nmRoots) {
+      const uiSlotsFile = path.join(root, '@deepseek-ai', SLOT_KEY_COMPAT_PKG_REL);
+      if (!fs.existsSync(uiSlotsFile)) continue;
+      try {
+        const content = fs.readFileSync(uiSlotsFile, 'utf8');
+        // 若三层补丁均未命中，说明 ui-slots 文件存在但锚点不匹配。
+        const hasAnyPatch = slotMarkers.some((m) => content.includes(m));
+        if (!hasAnyPatch) {
+          unpatched.push(uiSlotsFile);
+        }
+      } catch {}
+    }
+    if (unpatched.length > 0) {
+      ctx.log('插件健康预检: ui-slots 文件未被补丁覆盖（版本差异），slot 错误隔离可能未生效: ' + unpatched.join(', '));
+      ctx.log('建议: 若启动后出现 "keyed slot requires options.key" 错误，请升级 DSH Desktop 或联系插件开发者添加 options.key');
+    }
+    return { scanned: nmRoots.length, unpatched };
+  } catch (err) {
+    ctx.log('插件健康预检失败（不影响启动）: ' + ((err && err.message) || err));
+    return { scanned: 0, unpatched: [] };
+  }
+}
+
+module.exports = { preflight, uiSlotsMarkers };

--- a/dsh-desktop/scripts/integration/index.js
+++ b/dsh-desktop/scripts/integration/index.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 插件集成门面（PluginIntegration）。
+//
+// 单一入口：main.js 只调 createPluginIntegration(ctx) + run()（或细粒度
+// syncPlugins / applyPatches / preflightHealth / healBeforeServer），不再各自
+// 编排 syncCompanionPlugins + 18 个 apply* + preScanPluginHealth。
+//
+//   run() = syncPlugins → applyPatches → preflightHealth
+// ---------------------------------------------------------------------------
+
+const path = require('node:path');
+const os = require('node:os');
+const { createPluginSync } = require('./plugin-sync');
+const { applyAll } = require('./patch-runner');
+const { preflight } = require('./fault-isolation');
+
+/**
+ * @param {Object} opts
+ * @param {() => string} opts.getHome          effectiveDshHome()
+ * @param {string} opts.appDir                 __dirname
+ * @param {() => string} opts.getUserDataDir   () => userDataDir
+ * @param {() => boolean} opts.wslMode         () => isWslMode()
+ * @param {(msg: string) => void} opts.log     topic 已绑定为 'boot'
+ * @param {() => ({load:(c:string)=>any}|null)} opts.loadYaml
+ * @param {() => Object} opts.loadSettings
+ * @param {(s: Object) => void} opts.saveSettings
+ * @param {() => string} opts.getInstallAnchorDir
+ * @param {(recovered: string[]) => void} [opts.onManifestResetRecovered]
+ * @param {Object} [opts.hostDetectors]        宿主能力探测器（可注入，供单测）
+ */
+function createPluginIntegration(opts) {
+  const {
+    getHome,
+    appDir,
+    getUserDataDir,
+    wslMode,
+    log,
+    loadYaml,
+    loadSettings,
+    saveSettings,
+    getInstallAnchorDir,
+    onManifestResetRecovered,
+    onHealReset,
+    hostDetectors,
+  } = opts;
+
+  const pluginSync = createPluginSync({
+    getHome,
+    appDir,
+    getUserDataDir,
+    log,
+    loadYaml,
+    loadSettings,
+    saveSettings,
+    getInstallAnchorDir,
+    onManifestResetRecovered,
+    onHealReset,
+  });
+
+  /** 构造 patch-runner / fault-isolation 共用的解析 ctx（纯参数注入）。 */
+  function buildCtx() {
+    return {
+      home: getHome() || path.join(os.homedir(), '.dsh'),
+      appDir,
+      userDataDir: getUserDataDir(),
+      wslMode: !!wslMode(),
+      log,
+      hostDetectors,
+    };
+  }
+
+  const syncPlugins = () => pluginSync.sync();
+  const healBeforeServer = () => {
+    pluginSync.healProfilePatch();
+    pluginSync.healHomePatch();
+    pluginSync.logProfileBundleHealth();
+  };
+  const applyPatches = () => applyAll(buildCtx());
+  const preflightHealth = () => preflight(buildCtx());
+
+  return {
+    ctx: opts,
+    /** 七步插件同步 / 自愈 / 对账。 */
+    syncPlugins,
+    /** 启动前自愈（startServer 复用）：profile patch + 家级补丁层 + bundle 健康检查。 */
+    healBeforeServer,
+    /** 注册表驱动应用全部运行时补丁。 */
+    applyPatches,
+    /** 只读三态健康预检。 */
+    preflightHealth,
+    /** 门面编排：syncPlugins → applyPatches → preflightHealth（闭包调用，不依赖 this）。 */
+    // run() 为聚合门面（syncPlugins → applyPatches → preflightHealth），当前 main.js
+    // 走细粒度方法分步调用并各自消费 patchReport；run() 供集成测试/未来单一入口
+    // 使用，非死代码。
+    run() {
+      return {
+        syncResult: syncPlugins(),
+        patchReport: applyPatches(),
+        healthReport: preflightHealth(),
+      };
+    },
+  };
+}
+
+module.exports = { createPluginIntegration };

--- a/dsh-desktop/scripts/integration/patch-runner.js
+++ b/dsh-desktop/scripts/integration/patch-runner.js
@@ -1,0 +1,172 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 补丁编排（注册表驱动，逐补丁容错）。
+//
+// 替代 main.js 里顺序硬编码的 18 个 apply* 函数与 WSL/本地两份列表：遍历
+// patch-registry 的 PATCH_SPECS（order 升序），逐补丁 try-catch + failPolicy
+// 分级，异常绝不越出补丁边界，全部进 patchReport。
+//
+//   kind='file' ：resolvePatchTargets → applyPatchToFiles（复用唯一引擎）；
+//   kind='root' ：resolveNmRoots → 逐根调用 patch-*.js 的根应用器。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { applyPatchToFiles } = require('../lib/patch-engine');
+const { getSpecsByGroup } = require('../lib/patch-registry');
+const { resolvePatchTargets, resolveNmRoots } = require('../lib/patch-target-resolver');
+const { probe, missingBridgeWarning } = require('../lib/host-capabilities');
+
+/**
+ * 解析单个 file 补丁的落盘文件列表。profile-boot 防护需要运行时 glob
+ * `profile-boot-*.js`，其余布局直接经 resolvePatchTargets 解析。
+ * @param {Object} ctx
+ * @param {Object} spec
+ * @returns {string[]}
+ */
+function resolveFiles(ctx, spec) {
+  const layoutKey = (spec.wslLayout && ctx.wslMode) ? spec.wslLayout : spec.layout;
+  if (layoutKey === 'profile-boot-dirs') {
+    const dirs = resolvePatchTargets(ctx, spec);
+    const files = [];
+    for (const dir of dirs) {
+      let names;
+      try { names = fs.readdirSync(dir).filter((f) => /^profile-boot-.+\.js$/.test(f)); } catch { continue; }
+      for (const name of names) files.push(path.join(dir, name));
+    }
+    return files;
+  }
+  return resolvePatchTargets(ctx, spec);
+}
+
+/**
+ * 单次落盘调用（applyPatchToFiles 的日志契约封装）。
+ * options 为场景覆盖（CLI 同步期：dryRun + donePrefix:false + anchorLog=warn）。
+ */
+function applyToFiles(ctx, spec, prefix, logs, files, stats, options = {}) {
+  const doneLog = logs.doneLog || ((file) => '已应用 ' + file);
+  return applyPatchToFiles({
+    prefix,
+    files,
+    log: (m) => ctx.log(m),
+    transform: spec.transform,
+    alreadyLog: logs.alreadyLog || null,
+    doneLog,
+    donePrefix: options.donePrefix ?? logs.donePrefix ?? true,
+    anchorLog: options.anchorLog ?? ((m) => ctx.log(m)),
+    failLog: logs.failLog || ((file, err) => `${prefix}失败(${file}): ${err.message}`),
+    dryRun: options.dryRun ?? false,
+    // doneLog 默认以「已」开头，replace(/^已/,'') 只剥首个「已」（无「已」前缀时原样），
+    // 语义更稳健；registry 的 cli spec 未来提供独立 dryRunChangedLog 时经 options 透传优先。
+    dryRunChangedLog: options.dryRunChangedLog ?? ((file, note) => 'dry-run: 将' + doneLog(file, note).replace(/^已/, '')),
+    stats,
+  });
+}
+
+/**
+ * file 补丁：多文件相对路径时逐份应用（shell-description / slot-compat 共用）。
+ *
+ * 布局分两类：
+ *   - 逐文件布局（runtime-local / guard / wsl / slot-compat / slot-compat-wsl）：
+ *     布局函数读单个 spec.pkgRel，须对每个 pkgRel 循环调用一次；
+ *   - 无 pkgRel 语义布局（profile-boot-dirs 内部 glob）或单 pkgRel 补丁：
+ *     直接调用一次 resolveFiles(spec)，不得覆盖 pkgRel 为 undefined。
+ */
+function applyFile(ctx, spec, stats, options = {}) {
+  const logs = spec.logs || {};
+  const prefix = logs.prefix || spec.id;
+  let written = 0;
+  const multi = Array.isArray(spec.pkgRels) && spec.pkgRels.length > 0;
+  if (multi) {
+    for (const pkgRel of spec.pkgRels) {
+      written += applyToFiles(ctx, spec, prefix, logs, resolveFiles(ctx, { ...spec, pkgRel }), stats, options);
+    }
+  } else {
+    written += applyToFiles(ctx, spec, prefix, logs, resolveFiles(ctx, spec), stats, options);
+  }
+  return written;
+}
+
+/** root 补丁：逐 node_modules 根 try-catch（单根失败不拖垮其余根）。 */
+function applyRoot(ctx, spec, stats, options = {}) {
+  let written = 0;
+  const roots = resolveNmRoots(ctx, spec);
+  for (const root of roots) {
+    if (!root || !fs.existsSync(root)) continue;
+    try {
+      const n = spec.apply(root, (m) => ctx.log(m), stats, options);
+      if (n > 0 && options.donePrefix !== false) ctx.log(spec.successLog(root));
+      written += n;
+    } catch (err) {
+      ctx.log(spec.failLog(root, err));
+      if (stats) stats.failed += 1;
+    }
+  }
+  return written;
+}
+
+/**
+ * 遍历注册表应用全部补丁，返回 patchReport。
+ * @param {Object} ctx { home, appDir, userDataDir, wslMode, log, hostDetectors? }
+ * @param {Array<Object>} [specs] 补丁清单（默认 getSpecsByGroup()，供单测注入）。
+ * @param {Object} [options] 场景覆盖（CLI 同步期用 dryRun + donePrefix:false + anchorLog=warn）。
+ * @returns {{total:number, changed:number, degraded:string[], warnings:string[], errors:string[], host:Object}}
+ */
+function applyAll(ctx, specs = getSpecsByGroup(), options = {}) {
+  const host = probe(ctx.hostDetectors);
+  // warnings 为降级告警但非硬失败（requires 缺失且非 degrade/required 时），已通过
+  // ctx.log 输出，notifyPatchFailures 不重复提示——避免「未消费」歧义。
+  const report = { total: 0, changed: 0, anchorMissing: 0, failed: 0, degraded: [], warnings: [], errors: [], host };
+  for (const spec of specs) {
+    const policy = spec.failPolicy || 'warn';
+    const stats = { anchorMissing: 0, failed: 0 };
+    report.total += 1; // 每个 spec 处理即计数（含异常），修复规格级异常时 total 低报。
+    try {
+      let n = 0;
+      if (spec.kind === 'root') n = applyRoot(ctx, spec, stats, options);
+      else n = applyFile(ctx, spec, stats, options);
+      if (n > 0) report.changed += n;
+      report.failed += stats.failed;
+      // failPolicy 分流（互斥）：degrade/fatal 档补丁的 anchor-missing（失配）视为
+      // 降级告警，只进 report.degraded；warn 档才计入 report.anchorMissing（版本
+      // 差异）。二者互斥，避免同一事件在汇总日志与用户通知中被双计数。
+      if (policy === 'degrade' || policy === 'fatal') {
+        if (stats.anchorMissing > 0) report.degraded.push(spec.id);
+      } else {
+        report.anchorMissing += stats.anchorMissing;
+      }
+      // 宿主能力依赖：required 能力缺失 → 降级告警 + 记入报告。
+      for (const capKey of (spec.requires || [])) {
+        const cap = host[capKey];
+        if (cap && cap.available === false) {
+          const warn = missingBridgeWarning(capKey);
+          if (warn) ctx.log(warn);
+          if (policy === 'degrade' || cap.required) report.degraded.push(spec.id);
+          else report.warnings.push(spec.id);
+        }
+      }
+    } catch (err) {
+      // 异常不越出补丁边界；按 failPolicy 分级入账（此前 failPolicy 是未执行的死字段）。
+      if (policy === 'fatal') {
+        // fatal 仅 build 期语义：运行时降级为「降级 + 告警」，绝不 throw 中断启动。
+        ctx.log(`${spec.id} 补丁应用失败（fatal→degrade）: ${err.message}`);
+        report.degraded.push(spec.id);
+      } else if (policy === 'degrade') {
+        ctx.log(`${spec.id} 补丁应用失败（降级）: ${err.message}`);
+        report.degraded.push(spec.id);
+      } else {
+        ctx.log(`${spec.id} 补丁应用异常: ${err.message}`);
+        report.errors.push(spec.id);
+      }
+    }
+  }
+  // 汇总日志：让「失配 / 部分失败 / 降级 / 告警」在启动日志中显式可见，避免静默失效。
+  // 互斥分流后，anchorMissing 仅计 warn 档失配（版本差异）；degrade/fatal 档失配体现
+  // 在 degraded（降级 J 项）；failed 为逐文件回流计数（含逐根失败）；warnings（requires
+  // 缺失非降级）显式列出，消除「采集但静默」。
+  ctx.log(`补丁应用汇总: 写入 ${report.changed} 处 / 失配 ${report.anchorMissing} 项 / 失败 ${report.failed + report.errors.length} 项 / 降级 ${report.degraded.length} 项 / 告警 ${report.warnings.length} 项 / 共 ${report.total} 项`);
+  return report;
+}
+
+module.exports = { applyAll, applyFile, applyRoot, resolveFiles };

--- a/dsh-desktop/scripts/integration/plugin-sync.js
+++ b/dsh-desktop/scripts/integration/plugin-sync.js
@@ -1,0 +1,379 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 插件同步 / 自愈 / 对账（迁移 main.js 的 syncCompanionPlugins 七步）。
+//
+// 七步：heal（profile patch 自愈）→ 同步（syncCompanionFiles）→ 清市场
+// （removeLegacyMarketplacePatchLines）→ 退役（retireZatEngine）→ 禁用
+// （ACP / PET）→ 对账（reconcileProfileBundles）→ 注册
+// （registerCompanionPatchEntries）。纯编排：只调 companion-profile /
+// profile-reconcile / profile-patch-heal 的唯一实现，不写锚点与复制逻辑。
+//
+// 另收口家级补丁层预检（healHomePatch）与 profile bundle 健康检查
+// （logProfileBundleHealth），供 startServer 的启动前自愈复用。
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { writeFileAtomic } = require('../lib/patch-io');
+const { COMPANION_PLUGINS } = require('../lib/companion-plugins');
+const { CORE_BUNDLE_NAMES } = require('../../profile-manifest');
+const { isPatchListValid, verifyBundleDir } = require('../../profile-bundle-heal');
+const { dedupePatchEntries } = require('../../profile-patch-heal');
+const { reconcileProfileBundles, resolveBundleDirLike } = require('../lib/profile-reconcile');
+const {
+  ACP_DISABLE_BLOCK,
+  PET_DISABLE_BLOCK,
+  removeLegacyMarketplacePatchLines,
+  removedPluginIdsFromPatch,
+  ensureDisabledPatchEntry,
+  registerCompanionPatchEntries,
+  syncCompanionFiles,
+} = require('../lib/companion-profile');
+
+/**
+ * @param {Object} ctx
+ * @param {() => string} ctx.getHome            effectiveDshHome()（可为空串）
+ * @param {string} ctx.appDir                   __dirname
+ * @param {() => string} ctx.getUserDataDir     () => userDataDir
+ * @param {(msg: string) => void} ctx.log       topic 已绑定为 'boot'
+ * @param {() => ({load:(c:string)=>any}|null)} ctx.loadYaml
+ * @param {() => Object} ctx.loadSettings
+ * @param {(s: Object) => void} ctx.saveSettings
+ * @param {() => string} ctx.getInstallAnchorDir  dshPackageJson() 所在目录
+ * @param {(recovered: string[]) => void} [ctx.onManifestResetRecovered]
+ */
+function createPluginSync(ctx) {
+  const {
+    getHome,
+    appDir,
+    getUserDataDir,
+    log,
+    loadYaml,
+    loadSettings,
+    saveSettings,
+    getInstallAnchorDir,
+    onManifestResetRecovered = () => {},
+    onHealReset = () => {},
+  } = ctx;
+
+  const homeOrFallback = () => getHome() || path.join(os.homedir(), '.dsh');
+
+  // 备份文件名后缀：时间戳 + 随机串，避免同毫秒内多次自愈/并发导致备份名碰撞覆盖。
+  const backupSuffix = () => Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+
+  function profilePatchFile() {
+    return path.join(homeOrFallback(), 'profiles', 'web', 'cordis.patch.yml');
+  }
+
+  // profile patch 自愈的签名缓存（进程内 memo + userData 持久化）。
+  // 签名 = size + mtimeMs + 内容 hash：mtimeMs 在「快速连续写 / 跨盘拷贝」下可能
+  // 精度丢失导致漏自愈，加内容 hash 兜底（patch 文件很小，全读成本可忽略）。
+  let patchHealMemo = null; // { file, size, mtimeMs, hash }
+  function patchHealCachePath() {
+    return path.join(getUserDataDir(), 'profile-patch-heal-cache.json');
+  }
+  function patchFileSignature(file) {
+    try {
+      const st = fs.statSync(file);
+      const hash = crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+      return { size: st.size, mtimeMs: st.mtimeMs, hash };
+    } catch {
+      return null;
+    }
+  }
+  function readPersistedPatchHeal() {
+    try {
+      const c = JSON.parse(fs.readFileSync(patchHealCachePath(), 'utf8'));
+      if (c && c.v === 2 && typeof c.file === 'string' && typeof c.size === 'number' && typeof c.mtimeMs === 'number' && typeof c.hash === 'string') return c;
+    } catch {}
+    return null;
+  }
+  function writePersistedPatchHeal(file, sig) {
+    try {
+      fs.writeFileSync(patchHealCachePath(), JSON.stringify({
+        v: 2,
+        file,
+        size: sig.size,
+        mtimeMs: sig.mtimeMs,
+        hash: sig.hash,
+        at: new Date().toISOString(),
+      }));
+    } catch {}
+  }
+
+  function healProfilePatch() {
+    try {
+      const file = profilePatchFile();
+      if (!fs.existsSync(file)) return;
+      // 启动提速：签名一致 → 该文件已在当前内容状态下自愈过，直接跳过。
+      const sig = patchFileSignature(file);
+      if (sig) {
+        const memoHit = patchHealMemo && patchHealMemo.file === file &&
+          patchHealMemo.size === sig.size && patchHealMemo.mtimeMs === sig.mtimeMs && patchHealMemo.hash === sig.hash;
+        if (memoHit) return;
+        const persisted = readPersistedPatchHeal();
+        if (persisted && persisted.file === file && persisted.size === sig.size && persisted.mtimeMs === sig.mtimeMs && persisted.hash === sig.hash) {
+          patchHealMemo = { file, size: sig.size, mtimeMs: sig.mtimeMs, hash: sig.hash };
+          return;
+        }
+      }
+      let text = fs.readFileSync(file, 'utf8');
+      const bareArray = /^\s*\[\]\s*$/m.test(text);
+      const hasEntries = /^\s*-\s+(?:id|insert)\s*:/m.test(text);
+      if (bareArray && hasEntries) {
+        text = text.replace(/^\s*\[\]\s*$\n?/m, '');
+        writeFileAtomic(file, text);
+        log('profile patch 自愈: 移除了与列表混存的顶层 []（cordis.patch.yml）');
+      }
+      const yaml = loadYaml();
+      if (!yaml) return;
+      let parsed;
+      let error = null;
+      try { parsed = yaml.load(text); } catch (err) { error = err; }
+      // 合法判定与 dsh-app-boot parsePatchList 同构：顶层数组且每项为映射。
+      if (!error && isPatchListValid(parsed)) {
+        // issue #17 存量自愈：注册行级去重（PR #24 v2）。
+        const dedupe = dedupePatchEntries(text);
+        if (dedupe.removed.length > 0) {
+          const backup = file + '.dup-' + backupSuffix();
+          try { fs.copyFileSync(file, backup); } catch {}
+          writeFileAtomic(file, dedupe.text);
+          log('profile patch 自愈: 移除了重复注册的 loader 条目 ' + [...new Set(dedupe.removed)].join(', ') + '，原文件已备份到 ' + backup);
+          text = dedupe.text;
+        }
+      }
+      if (error || !isPatchListValid(parsed)) {
+        const backup = file + '.broken-' + backupSuffix();
+        try { fs.renameSync(file, backup); } catch { fs.copyFileSync(file, backup); }
+        fs.writeFileSync(file, '# recovered by DSH Desktop: 原内容无法解析，已备份到\n# ' + backup + '\n[]\n', 'utf8');
+        const cause = error ? String((error && error.message) || error)
+          : (Array.isArray(parsed) ? '条目不是映射（顶层数组每项须为映射）' : '顶层非数组');
+        log('profile patch 自愈: 解析失败（' + cause + '），已备份到 ' + backup + ' 并重置为最小文件');
+        onHealReset('profile', backup);
+      }
+      // 完整自愈流程已跑完（含 yaml 解析）：记录当前内容签名，下次启动命中跳过。
+      const after = patchFileSignature(file);
+      if (after) {
+        patchHealMemo = { file, size: after.size, mtimeMs: after.mtimeMs, hash: after.hash };
+        writePersistedPatchHeal(file, after);
+      }
+    } catch (err) {
+      log('profile patch 自愈失败: ' + err.message);
+    }
+  }
+
+  let homePatchHealMemo = null; // { file, size, mtimeMs, hash }
+  function healHomePatch() {
+    try {
+      const file = path.join(homeOrFallback(), 'cordis.patch.yml');
+      if (!fs.existsSync(file)) return;
+      const sig = patchFileSignature(file);
+      if (sig && homePatchHealMemo && homePatchHealMemo.file === file &&
+          homePatchHealMemo.size === sig.size && homePatchHealMemo.mtimeMs === sig.mtimeMs &&
+          homePatchHealMemo.hash === sig.hash) {
+        return;
+      }
+      const yaml = loadYaml();
+      if (!yaml) return; // 无 yaml 依赖：跳过解析（运行时防护兜底）
+      let parsed = null;
+      let error = null;
+      try { parsed = yaml.load(fs.readFileSync(file, 'utf8')); } catch (err) { error = err; }
+      if (!error && isPatchListValid(parsed)) {
+        homePatchHealMemo = { file, size: sig.size, mtimeMs: sig.mtimeMs, hash: sig.hash };
+        return;
+      }
+      const backup = file + '.broken-' + backupSuffix();
+      try { fs.renameSync(file, backup); } catch { fs.copyFileSync(file, backup); }
+      fs.writeFileSync(file, '# recovered by DSH Desktop: 原内容无法解析，已备份到\n# ' + backup + '\n[]\n', 'utf8');
+      const cause = error ? String((error && error.message) || error)
+        : (Array.isArray(parsed) ? '条目不是映射（顶层数组每项须为映射）' : '顶层非数组');
+      log('家级补丁层自愈: 解析失败（' + cause + '），已备份到 ' + backup + ' 并重置为最小文件');
+      onHealReset('home', backup);
+      const after = patchFileSignature(file);
+      if (after) homePatchHealMemo = { file, size: after.size, mtimeMs: after.mtimeMs, hash: after.hash };
+    } catch (err) {
+      log('家级补丁层自愈失败: ' + err.message);
+    }
+  }
+
+  function logProfileBundleHealth() {
+    try {
+      const profileDir = path.join(homeOrFallback(), 'profiles', 'web');
+      let manifest = null;
+      try {
+        manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+      } catch (err) {
+        log('profile bundle 健康检查: manifest 不可读（' + err.message + '），交由启动防护自愈');
+        return;
+      }
+      const bundles = (manifest && manifest.dsh && manifest.dsh.profile && Array.isArray(manifest.dsh.profile.bundles)) ? manifest.dsh.profile.bundles : [];
+      const installAnchor = getInstallAnchorDir();
+      for (const name of bundles) {
+        if (typeof name !== 'string' || name === '') continue;
+        const dir = resolveBundleDirLike(path.join(installAnchor, 'package.json'), name)
+          || resolveBundleDirLike(path.join(profileDir, 'package.json'), name);
+        if (!dir) {
+          log('profile bundle 缺失（对账后仍存在，启动防护兜底跳过）: ' + name + ' —— 用 dsh plugin --profile web install 可修复');
+          continue;
+        }
+        const check = verifyBundleDir(dir);
+        if (!check.ok) log('profile bundle 不可用（对账后仍存在，启动防护兜底跳过）: ' + name + ' —— ' + check.reason);
+      }
+    } catch (err) {
+      log('profile bundle 健康检查失败: ' + err.message);
+    }
+  }
+
+  // 退役插件一次性清理：v0.3.11 起内置插件市场 zat-dsh-engine 默认移除。
+  function retireZatEngine(profileDir) {
+    const RETIRED_NAME = 'zat-dsh-engine';
+    try {
+      const s = loadSettings();
+      if (s.zatEngineRetired) return;
+      const pkgDir = path.join(profileDir, 'node_modules', RETIRED_NAME);
+      if (fs.existsSync(pkgDir)) {
+        // 只清内置装配特征（dsh.bundle.patch 声明）的副本，避免误删同名第三方包。
+        let isBuiltin = false;
+        try {
+          const p = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8'));
+          isBuiltin = !!(p && p.dsh && p.dsh.bundle && p.dsh.bundle.patch);
+        } catch {}
+        if (isBuiltin) {
+          fs.rmSync(pkgDir, { recursive: true, force: true });
+          log('已移除内置插件市场 ' + RETIRED_NAME + '（v0.3.11 起默认移除）');
+        }
+      }
+      const manifestFile = path.join(profileDir, 'package.json');
+      try {
+        const m = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+        if (m && m.dsh && m.dsh.profile && Array.isArray(m.dsh.profile.bundles) && m.dsh.profile.bundles.includes(RETIRED_NAME)) {
+          m.dsh.profile.bundles = m.dsh.profile.bundles.filter((n) => n !== RETIRED_NAME);
+          writeFileAtomic(manifestFile, JSON.stringify(m, null, 2) + '\n');
+          log('已从 web profile bundles 移除 ' + RETIRED_NAME + ' 登记');
+        }
+      } catch (err) {
+        log('清理 ' + RETIRED_NAME + ' manifest 登记失败: ' + err.message);
+      }
+      s.zatEngineRetired = true;
+      saveSettings(s);
+    } catch (err) {
+      log('退役清理 ' + RETIRED_NAME + ' 失败: ' + err.message);
+    }
+  }
+
+  function sync() {
+    if (process.platform !== 'win32') return;
+    try {
+      healProfilePatch();
+      const home = getHome();
+      if (!home) { log('DSH_HOME 未解析，跳过配套插件同步'); return; }
+      const profileDir = path.join(home, 'profiles', 'web');
+      const patchFile = path.join(profileDir, 'cordis.patch.yml');
+      let patchText = '';
+      try { patchText = fs.readFileSync(patchFile, 'utf8'); } catch { /* 无 patch 文件 */ }
+      const removedIds = removedPluginIdsFromPatch(patchText);
+      const { bundleNames, missingNames: missingSourceNames } = syncCompanionFiles({
+        assetsRoot: path.join(appDir, 'assets', 'plugins'),
+        profileDir,
+        vendorRoot: path.join(appDir, 'node_modules'),
+        removedIds,
+        log: (m) => log(m),
+        fail: (m) => log(m),
+        onCopyFail: (sf, err) => log('同步配套插件文件失败 ' + sf + ': ' + err.message),
+        onVerifyFail: (name, reason) => log('配套 bundle 校验失败（按源缺失处理，不注册）: ' + name + ' —— ' + reason),
+      });
+
+      // v0.3.5 起插件市场整体切换为 zat-dsh-engine（MIT）：清理旧版
+      // @deepseek-ai/dsh-plugin-marketplace 的 patch 行（幂等）。
+      try {
+        let legacyPatch = fs.readFileSync(patchFile, 'utf8');
+        const legacy = removeLegacyMarketplacePatchLines(legacyPatch);
+        if (legacy.changed) {
+          writeFileAtomic(patchFile, legacy.patch);
+          log('已从 cordis.patch.yml 移除旧插件市场条目');
+        }
+      } catch {}
+
+      // v0.3.11 起内置插件市场 zat-dsh-engine 默认移除（用户要求）。
+      retireZatEngine(profileDir);
+
+      // billion-context-dsh（compaction-acp）与 compaction-basic 不能并存。
+      if (bundleNames.has('billion-context-dsh')) {
+        try {
+          let patch = '';
+          try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
+          const entry = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*compaction-basic\\b'), ACP_DISABLE_BLOCK);
+          if (entry.changed) {
+            writeFileAtomic(patchFile, entry.patch);
+            log('已禁用 compaction-basic（billion-context-dsh 接管压缩后端）');
+          }
+        } catch (err) {
+          log('写入 compaction-basic 禁用条目失败: ' + err.message);
+        }
+      }
+
+      // 桌面宠物（harness-pet）默认关闭。
+      if (bundleNames.has('harness-pet')) {
+        try {
+          let patch = '';
+          try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { /* 全新 profile：patch 文件尚未创建，视为空 */ }
+          const entry = ensureDisabledPatchEntry(patch, new RegExp('(?:^|\\n)\\s*-?\\s*id\\s*:\\s*harness-pet\\b'), PET_DISABLE_BLOCK);
+          if (entry.changed) {
+            writeFileAtomic(patchFile, entry.patch);
+            log('已默认关闭桌面宠物（harness-pet，可在插件管理开启）');
+          }
+        } catch (err) {
+          log('写入 harness-pet 禁用条目失败: ' + err.message);
+        }
+      }
+
+      // profile manifest 装配对账（唯一实现）。
+      const removedBundles = COMPANION_PLUGINS.filter((p) => removedIds.has(p.id)).map((p) => p.name);
+      const reconciled = reconcileProfileBundles(profileDir, {
+        installAnchorDir: getInstallAnchorDir(),
+        coreNames: CORE_BUNDLE_NAMES,
+        addNames: bundleNames,
+        missingNames: missingSourceNames,
+        removedBundles: new Set(removedBundles),
+        excludeFromRecover: new Set([...CORE_BUNDLE_NAMES, ...COMPANION_PLUGINS.map((p) => p.name)]),
+        parsePatch: loadYaml(),
+        log: (m) => log(m),
+      });
+      if (reconciled.reset && reconciled.manifest &&
+          Array.isArray(reconciled.manifest.dsh && reconciled.manifest.dsh.profile && reconciled.manifest.dsh.profile.bundles)) {
+        onManifestResetRecovered(reconciled.recovered);
+      }
+
+      // 非 bundle 插件注册到 profile 的 patch 层（幂等）。必须在 legacy/ACP/PET
+      // 三步落盘之后重新读盘。
+      let patch = '';
+      try { patch = fs.readFileSync(patchFile, 'utf8'); } catch { patch = ''; }
+      const registration = registerCompanionPatchEntries(patch, {
+        plugins: COMPANION_PLUGINS,
+        bundleNames,
+        missingNames: missingSourceNames,
+        removedIds,
+        onDrop: (m) => log(m),
+      });
+      if (registration.changed) {
+        writeFileAtomic(patchFile, registration.patch);
+        log('已同步配套插件到 web profile: ' + COMPANION_PLUGINS.map((p) => p.id).join(', '));
+      }
+    } catch (err) {
+      log('同步配套插件失败: ' + err.message);
+    }
+  }
+
+  return {
+    sync,
+    healProfilePatch,
+    healHomePatch,
+    logProfileBundleHealth,
+  };
+}
+
+module.exports = { createPluginSync };

--- a/dsh-desktop/scripts/lib/host-capabilities.js
+++ b/dsh-desktop/scripts/lib/host-capabilities.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 宿主能力清单 / 探测 / 降级。
+//
+// 现状：patch 注入 `window.__dshDesktopOpenDir` / `window.__dshSessionManager`，
+// 由 dsh-session-manager 插件 client.js 提供——补丁与插件之间的隐式契约。
+// 本模块把「补丁依赖的宿主能力」显式声明为清单，供 patch-runner 探测并记录
+// 降级告警，同时提供注入代码里用的桥表达式（单一数据源）。
+//
+//   openPath     ：preload 已暴露的宿主能力 window.dshDesktop.openPath（required）；
+//   deleteSession：dsh-session-manager 插件提供的 window.__dshSessionManager
+//                  .deleteSession（非 required，桥缺失时菜单项隐藏 + 告警）。
+// ---------------------------------------------------------------------------
+
+const HOST_CAPABILITIES = {
+  openPath: {
+    bridge: 'window.dshDesktop.openPath',
+    provider: 'preload',
+    required: true,
+  },
+  deleteSession: {
+    bridge: 'window.__dshSessionManager.deleteSession',
+    provider: 'dsh-session-manager',
+    required: false,
+  },
+};
+
+/** 注入代码里引用的桥表达式（可选链，桥缺失时静默降级到 undefined）。 */
+const BRIDGE_EXPRS = {
+  openPath: 'window.dshDesktop?.openPath',
+  deleteSession: 'window.__dshSessionManager?.deleteSession',
+};
+
+/** deleteSession 菜单项可见性守卫（桥缺失时隐藏「删除对话」项）。 */
+const DELETE_SESSION_MENU_GUARD = 'window.__dshSessionManager && typeof window.__dshSessionManager.deleteSession === "function"';
+
+/** 桥缺失时的降级告警文案。 */
+function missingBridgeWarning(capKey) {
+  const cap = HOST_CAPABILITIES[capKey];
+  if (!cap) return '';
+  if (capKey === 'deleteSession') {
+    return '会话删除依赖 dsh-session-manager 插件，未加载；「删除对话」菜单项已隐藏';
+  }
+  return '宿主能力 ' + cap.bridge + ' 不可用（' + cap.provider + '），相关菜单项已降级';
+}
+
+/**
+ * 探测宿主能力并生成报告。
+ * @param {{[key: string]: (() => boolean)|undefined}} [detectors] 可注入探测器
+ * @returns {{[key: string]: {available: boolean|null, provider: string, required: boolean}}}
+ *   available: true/false 由探测器给出；探测器缺失时为 null（未知，运行时判定）。
+ */
+function probe(detectors = {}) {
+  const report = {};
+  for (const key of Object.keys(HOST_CAPABILITIES)) {
+    const cap = HOST_CAPABILITIES[key];
+    const detect = detectors[key];
+    report[key] = {
+      available: typeof detect === 'function' ? !!detect() : null,
+      provider: cap.provider,
+      required: cap.required,
+    };
+  }
+  return report;
+}
+
+module.exports = {
+  HOST_CAPABILITIES,
+  BRIDGE_EXPRS,
+  DELETE_SESSION_MENU_GUARD,
+  missingBridgeWarning,
+  probe,
+};

--- a/dsh-desktop/scripts/lib/patch-adapters.js
+++ b/dsh-desktop/scripts/lib/patch-adapters.js
@@ -1,0 +1,367 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 补丁适配器（唯一 transform 收口）。
+//
+// 所有运行时补丁的「变换」纯函数都从这里取用：
+//   - runtime-patches.js 的 9 个 transform 原样 re-export（变换实现仍留在该
+//     模块，锚点常量/注入代码字节级不变）；
+//   - 原 main.js 内联的 6 个 transform（image-send / vision-key /
+//     profile-patch-guard / settings-section-guard / workspace-search-rail /
+//     plugin-inventory-tab-merge）在此声明化，字节级输出与旧实现一致；
+//   - profile-bundle-guard 的两个 transform（app-boot / profile-boot）委托
+//     profile-bundle-heal.js 的唯一实现；
+//   - 包级补丁（web-search / menu-viewport / session-manage /
+//     open-project-dir / session-persistence）以「node_modules 根应用器」形态
+//     收口，patch-runner 直接调用，不复制其锚点逻辑。
+//
+// 本模块不读写文件（除 rootAppliers 委托的 patch-*.js 外），纯声明。
+// ---------------------------------------------------------------------------
+
+const {
+  transformFlashFix,
+  transformExposeFix,
+  transformPersistenceAll,
+  transformLegacySlotKey,
+  transformSlotUnkeyedCompat,
+  transformSlotErrorIsolation,
+  transformShellDescriptionOptional,
+  transformCodeModeCompat,
+  transformAttachmentMimeTrust,
+  SLOT_KEY_COMPAT_MARKER,
+  SLOT_UNKEYED_COMPAT_MARKER,
+  SLOT_ERROR_ISOLATE_MARKER,
+  SLOT_ERROR_ISOLATE_MARKER_V2,
+} = require('./runtime-patches');
+
+const {
+  PROFILE_BUNDLE_GUARD_MARKER,
+  PROFILE_BOOT_GUARD_MARKER,
+  applyAppBootBundleGuard,
+  applyProfileBootHealGuard,
+  applyProfileBootBundleGuard,
+} = require('../../profile-bundle-heal');
+
+// 包级补丁（node_modules 根应用器，唯一实现；签名 (nmRoot, log) => number）。
+const { patchWebSearchBaseUrl } = require('../patch-web-search-baseurl');
+const { patchMenuViewport } = require('../patch-menu-viewport');
+const { patchSessionManage } = require('../patch-session-manage');
+const { patchOpenProjectDir } = require('../patch-open-project-dir');
+const { patchSessionPersistence } = require('../patch-session-persistence');
+
+// ---------------------------------------------------------------------------
+// 文本模型自动识图补丁（原 main.js applyImageSendFix 内联 transform）。
+// ---------------------------------------------------------------------------
+const IMAGE_SEND_MARKER = 'DSH Desktop: reuse the dsh-vision VLM config';
+const IMAGE_SEND_HELPER_ANCHOR = '/** Validate one prompt as a batch before publishing any durable image object. */';
+const IMAGE_SEND_HELPER = `
+/** DSH Desktop: reuse the dsh-vision VLM config to describe images as text so text-only models can "see" them. */
+async function describeImagesWithVision(ctx, content) {
+	const settings = ctx.get("settings");
+	let vision = null;
+	if (settings !== void 0 && typeof settings.get === "function") {
+		// dsh-desktop fix: read the resolved HOST-side value (settings.get), not the
+		// redacted wire snapshot. redactSecrets strips role('secret') fields, so
+		// describe({redactSecrets:true}) drops apiKey and every keyed VLM endpoint
+		// answers 401 — image sends failed for configured users.
+		const resolved = settings.get("dsh-vision");
+		if (resolved !== void 0 && typeof resolved === "object") vision = resolved;
+	}
+	if (vision === null && settings !== void 0 && typeof settings.describe === "function") {
+		try {
+			const descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");
+			if (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;
+		} catch {}
+	}
+	if (vision === null || typeof vision.baseURL !== "string" || vision.baseURL.trim() === "" || typeof vision.model !== "string" || vision.model.trim() === "") {
+		throw new Error("未配置识图服务：请到 设置 → 识图插件（view_image） 填写 VLM 接口地址与模型");
+	}
+	const apiKey = typeof vision.apiKey === "string" ? vision.apiKey.trim() : "";
+	const endpoint = vision.baseURL.replace(/\\/+$/, "") + "/chat/completions";
+	const out = [];
+	let imageNo = 0;
+	for (const part of content) {
+		if (part.type !== "image") {
+			if (part.type === "text") out.push(part);
+			continue;
+		}
+		imageNo += 1;
+		const dataUrl = \`data:\${part.mediaType};base64,\${part.data}\`;
+		const payload = {
+			model: vision.model,
+			stream: false,
+			messages: [
+				{ role: "system", content: "You are an image understanding assistant. Describe the image in exhaustive detail and transcribe every visible text (OCR). If it is a UI, document, table, chart or code, preserve its structure. Answer in Chinese unless the user's language clearly differs." },
+				{ role: "user", content: [
+					{ type: "text", text: "请把这张图片完整转述为文字：包含画面内容、结构与全部可见文字（逐字 OCR）。" },
+					{ type: "image_url", image_url: { url: dataUrl } }
+				] }
+			]
+		};
+		const headers = { "content-type": "application/json" };
+		if (apiKey !== "") headers.authorization = "Bearer " + apiKey;
+		const response = await fetch(endpoint, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(payload),
+			signal: AbortSignal.timeout(120000)
+		});
+		if (!response.ok) {
+			const bodyText = await response.text().catch(() => "");
+			throw new Error("识图服务返回 HTTP " + response.status + "：" + bodyText.slice(0, 400));
+		}
+		const data = await response.json();
+		const description = data && data.choices && data.choices[0] && data.choices[0].message ? data.choices[0].message.content : "";
+		if (typeof description !== "string" || description.trim() === "") throw new Error("识图服务未返回有效文字描述");
+		out.push({ type: "text", text: "[图片" + imageNo + "] " + description.trim() });
+	}
+	return out;
+}
+`;
+const IMAGE_SEND_GATE_MARKER = 'if (modelInfo.inputModalities !== void 0 && !modelInfo.inputModalities.includes("image")) return err(request, {';
+const IMAGE_SEND_GATE_NEW = `if (modelInfo.inputModalities !== void 0 && !modelInfo.inputModalities.includes("image")) {
+							try {
+								admittedContent = await describeImagesWithVision(ctx, content);
+							} catch (error) {
+								return err(request, {
+									code: "attachment-error",
+									message: \`图片自动转述失败：\${error instanceof Error ? error.message : String(error)}。请在 设置 → 识图插件（view_image） 配置 VLM 后重试。\`,
+									details: { reason: "IMAGE_DESCRIPTION_FAILED" }
+								});
+							}
+						}`;
+
+function transformImageSendFix(src, file) {
+  if (src.includes(IMAGE_SEND_MARKER)) return { status: 'already' };
+  // 上游已原生内置同名 helper（新版 dsh）：不重复插入（重复定义会留下
+  // 被后者遮蔽的死代码），只做门槛替换；其 apiKey 脱敏缺陷由
+  // transformVisionKeyFix 就地修复。
+  const nativeHelper = src.includes('async function describeImagesWithVision');
+  if (!nativeHelper) {
+    // 1) 插入转述 helper（此后所有索引必须基于插入后的 src 重新计算）
+    const anchorIdx = src.indexOf(IMAGE_SEND_HELPER_ANCHOR);
+    if (anchorIdx === -1) {
+      return { status: 'anchor-missing', detail: '未找到 helper 插入锚点（版本可能已变更），跳过 ' + file };
+    }
+    src = src.slice(0, anchorIdx) + IMAGE_SEND_HELPER + '\n' + src.slice(anchorIdx);
+  }
+  // 2) prompt 入口：声明 admittedContent
+  const hasImageIdx = src.indexOf('const hasImage = content.some((part) => part.type === "image");');
+  if (hasImageIdx === -1) {
+    return { status: 'anchor-missing', detail: '未找到 hasImage 入口（版本可能已变更），跳过 ' + file };
+  }
+  src = src.slice(0, hasImageIdx) + 'let admittedContent = content;\n\t\t\t\t' + src.slice(hasImageIdx);
+  // 3) 把“模型不支持图片”的直接拒绝替换为自动转述
+  const gateIdx = src.indexOf(IMAGE_SEND_GATE_MARKER);
+  if (gateIdx === -1) {
+    return { status: 'anchor-missing', detail: '未找到模型图片门槛（版本可能已变更），跳过 ' + file };
+  }
+  const gateEnd = src.indexOf('});', gateIdx);
+  if (gateEnd === -1) {
+    return { status: 'anchor-missing', detail: '图片门槛收尾异常，跳过 ' + file };
+  }
+  src = src.slice(0, gateIdx) + IMAGE_SEND_GATE_NEW + src.slice(gateEnd + 3);
+  // 4) durablePromptContent 使用转述后的内容（从门槛之后查找调用点，避免命中函数定义）
+  const callIdx = src.indexOf('durablePromptContent(ctx, content)', gateIdx);
+  if (callIdx === -1) {
+    return { status: 'anchor-missing', detail: '未找到 durablePromptContent 调用，跳过 ' + file };
+  }
+  src = src.slice(0, callIdx) + 'durablePromptContent(ctx, admittedContent)' + src.slice(callIdx + 'durablePromptContent(ctx, content)'.length);
+  return { status: 'changed', src };
+}
+
+// ---------------------------------------------------------------------------
+// 图片自动转述 apiKey 修复（原 main.js applyVisionKeyFix 内联 transform）。
+// ---------------------------------------------------------------------------
+const VISION_KEY_MARKER = 'dsh-desktop fix: read the resolved HOST-side value';
+const VISION_KEY_FROM = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
+const VISION_KEY_TO = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.get === "function") {\n\t\t// dsh-desktop fix: read the resolved HOST-side value (settings.get), not the\n\t\t// redacted wire snapshot. redactSecrets strips role(\'secret\') fields, so\n\t\t// describe({redactSecrets:true}) drops apiKey and every keyed VLM endpoint\n\t\t// answers 401 — image sends failed for configured users.\n\t\tconst resolved = settings.get("dsh-vision");\n\t\tif (resolved !== void 0 && typeof resolved === "object") vision = resolved;\n\t}\n\tif (vision === null && settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
+
+function transformVisionKeyFix(src, file) {
+  if (src.includes(VISION_KEY_MARKER)) return { status: 'already' };
+  if (!src.includes(VISION_KEY_FROM)) {
+    return { status: 'anchor-missing', detail: '锚点未匹配（版本可能已变化），跳过 ' + file };
+  }
+  return { status: 'changed', src: src.replace(VISION_KEY_FROM, VISION_KEY_TO) };
+}
+
+// ---------------------------------------------------------------------------
+// dsh 装配层防护：profile patch 损坏自愈加载（原 applyProfilePatchGuard）。
+// ---------------------------------------------------------------------------
+const PROFILE_PATCH_GUARD_MARKER = 'function loadUserPatchLayer';
+const PROFILE_PATCH_GUARD_CALL_SITE = '\t\tpatches: options.userLayer !== false && existsSync(patchPath) ? loadOverlayPatches(binName, patchPath) : []';
+const PROFILE_PATCH_GUARD_CALL_REPLACEMENT = '\t\tpatches: loadUserPatchLayer(binName, patchPath, options)';
+const PROFILE_PATCH_GUARD_INSERT_AFTER = '\treturn parsePatchList(binName, file, content, "overlay");\n}';
+const PROFILE_PATCH_GUARD_INJECTED =
+  '/** dsh-desktop guard: the profile\'s own patch layer is user-owned data; a broken file must not brick\n' +
+  ' * the surface. Back the broken file up, reset the layer to an empty list, and boot without it.\n' +
+  ' */\n' +
+  'function loadUserPatchLayer(binName, patchPath, options) {\n' +
+  '\tif (options.userLayer === false || !existsSync(patchPath)) return [];\n' +
+  '\ttry {\n' +
+  '\t\treturn loadOverlayPatches(binName, patchPath);\n' +
+  '\t} catch (error) {\n' +
+  '\t\ttry {\n' +
+  '\t\t\tconst backup = `${patchPath}.broken-${Date.now()}`;\n' +
+  '\t\t\twriteFileSync(backup, readFileSync(patchPath, "utf8"));\n' +
+  '\t\t\twriteFileSync(patchPath, "# recovered by dsh: the previous content failed to parse and was moved to\\n# " + backup + "\\n[]\\n");\n' +
+  '\t\t} catch {}\n' +
+  '\t\tprocess.stderr.write(`${binName}: ${patchPath} failed to parse (${String(error?.message ?? error)}); the broken file was moved aside and the profile booted without its patch layer\\n`);\n' +
+  '\t\treturn [];\n' +
+  '\t}\n' +
+  '}';
+
+function transformProfilePatchGuard(src, file) {
+  if (src.includes(PROFILE_PATCH_GUARD_MARKER)) return { status: 'already' }; // 已应用（幂等，静默）
+  if (!src.includes(PROFILE_PATCH_GUARD_CALL_SITE) || !src.includes(PROFILE_PATCH_GUARD_INSERT_AFTER)) {
+    return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
+  }
+  const out = src.replace(PROFILE_PATCH_GUARD_CALL_SITE, PROFILE_PATCH_GUARD_CALL_REPLACEMENT);
+  return { status: 'changed', src: out.replace(PROFILE_PATCH_GUARD_INSERT_AFTER, PROFILE_PATCH_GUARD_INSERT_AFTER + '\n\n' + PROFILE_PATCH_GUARD_INJECTED) };
+}
+
+// ---------------------------------------------------------------------------
+// profile bundle 装配防护（原 applyProfileBundleGuard 的两个 transform）。
+// ---------------------------------------------------------------------------
+function transformProfileBundleAppBoot(src, file) {
+  const out = applyAppBootBundleGuard(src);
+  if (!out.changed) {
+    if (!src.includes(PROFILE_BUNDLE_GUARD_MARKER)) {
+      return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
+    }
+    return { status: 'already' }; // 已注入（幂等，静默）
+  }
+  return { status: 'changed', src: out.src };
+}
+
+function transformProfileBundleProfileBoot(src, file) {
+  let current = src;
+  let changed = false;
+  // heal 调用防护（独立幂等标记）：入口 bundle 无 heal 调用时静默。
+  const heal = applyProfileBootHealGuard(current);
+  if (heal.changed) { current = heal.src; changed = true; }
+  const bundle = applyProfileBootBundleGuard(current);
+  if (bundle.changed) { current = bundle.src; changed = true; }
+  if (changed) return { status: 'changed', src: current };
+  if (!current.includes(PROFILE_BOOT_GUARD_MARKER)) {
+    return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
+  }
+  return { status: 'already' }; // 已注入（幂等，静默）
+}
+
+// ---------------------------------------------------------------------------
+// dsh-settings 注册防护（原 applySettingsSectionGuard 内联 transform）。
+// ---------------------------------------------------------------------------
+const SETTINGS_SECTION_MARKER = 'dsh-desktop guard: an invalid stored section must not brick';
+const SETTINGS_SECTION_ANCHOR = '\t\tconst scope = sctx.settings.register(ns, schema, {';
+const SETTINGS_SECTION_GUARDED =
+  '\t\tlet scope;\n' +
+  '\t\ttry {\n' +
+  '\t\t\tscope = sctx.settings.register(ns, schema, {\n' +
+  '\t\t\t\tbase: entry,\n' +
+  '\t\t\t\t...hooks.validate === void 0 ? {} : { validate: hooks.validate }\n' +
+  '\t\t\t});\n' +
+  '\t\t} catch (error) {\n' +
+  '\t\t\t// dsh-desktop guard: an invalid stored section must not brick the consumer\n' +
+  '\t\t\t// fiber (fail-loud boot). Fall back to the composition config; the\n' +
+  '\t\t\t// namespace simply stays unavailable until the stored section is fixed.\n' +
+  '\t\t\tsctx.logger.warn("settings: registration for \\"%s\\" failed; falling back to the composition config this boot", ns);\n' +
+  '\t\t\tsctx.logger.warn(error);\n' +
+  '\t\t\ttry {\n' +
+  '\t\t\t\thooks.setSource(() => entry);\n' +
+  '\t\t\t\thooks.onChange();\n' +
+  '\t\t\t} catch {}\n' +
+  '\t\t\treturn;\n' +
+  '\t\t}\n' +
+  '\t\thooks.setSource(() => scope.get());';
+const SETTINGS_SECTION_FROM = '\t\tconst scope = sctx.settings.register(ns, schema, {\n\t\t\tbase: entry,\n\t\t\t...hooks.validate === void 0 ? {} : { validate: hooks.validate }\n\t\t});\n\t\thooks.setSource(() => scope.get());';
+
+function transformSettingsSectionGuard(src, file) {
+  if (src.includes(SETTINGS_SECTION_MARKER)) return { status: 'already' }; // 已应用（幂等，静默）
+  if (!src.includes(SETTINGS_SECTION_ANCHOR)) {
+    return { status: 'anchor-missing', detail: file + ' 锚点未匹配（dsh 版本可能已变化），跳过' };
+  }
+  return { status: 'changed', src: src.replace(SETTINGS_SECTION_FROM, SETTINGS_SECTION_GUARDED) };
+}
+
+// ---------------------------------------------------------------------------
+// dsh-client-ui-workspace 搜索栏修复（原 applyWorkspaceSearchRailFix）。
+// ---------------------------------------------------------------------------
+const WORKSPACE_SEARCH_RAIL_MARKER = 'dsh-desktop fix: rail search expansion';
+const WORKSPACE_SEARCH_RAIL_OLD_GUARD = '\t\t\t\tif (!wide || !searchExpanded) return;';
+const WORKSPACE_SEARCH_RAIL_NEW_GUARD = '\t\t\t\tif (!wide || !searchExpanded || searchOnExpand) return; // ' + WORKSPACE_SEARCH_RAIL_MARKER;
+const WORKSPACE_SEARCH_RAIL_OLD_DEPS = '\t\t\t}, [\n\t\t\t\tnormalizedQuery,\n\t\t\t\twide,\n\t\t\t\tsearchExpanded\n\t\t\t]);';
+const WORKSPACE_SEARCH_RAIL_NEW_DEPS = '\t\t\t}, [\n\t\t\t\tnormalizedQuery,\n\t\t\t\twide,\n\t\t\t\tsearchExpanded,\n\t\t\t\tsearchOnExpand\n\t\t\t]);';
+
+function transformWorkspaceSearchRailFix(src, file) {
+  if (src.includes(WORKSPACE_SEARCH_RAIL_MARKER)) return { status: 'already' };
+  if (!src.includes(WORKSPACE_SEARCH_RAIL_OLD_GUARD) || !src.includes(WORKSPACE_SEARCH_RAIL_OLD_DEPS)) {
+    return { status: 'anchor-missing', detail: '锚点未匹配（dsh 版本可能已变化），跳过 ' + file };
+  }
+  return { status: 'changed', src: src.replace(WORKSPACE_SEARCH_RAIL_OLD_GUARD, WORKSPACE_SEARCH_RAIL_NEW_GUARD).replace(WORKSPACE_SEARCH_RAIL_OLD_DEPS, WORKSPACE_SEARCH_RAIL_NEW_DEPS) };
+}
+
+// ---------------------------------------------------------------------------
+// 插件页标签合并补丁（原 applyPluginInventoryTabMergeFix）。
+// ---------------------------------------------------------------------------
+const PLUGIN_INVENTORY_TAB_MARKER = 'dsh-desktop fix: hide inventory tab';
+const PLUGIN_INVENTORY_TAB_OLD = 'tabs = ctx.slots.entries("settings.plugins.tab").map((entry) => ({';
+const PLUGIN_INVENTORY_TAB_NEW = 'tabs = ctx.slots.entries("settings.plugins.tab").filter((entry) => (entry.options.id ?? "") !== "all").map((entry) => ({ // ' + PLUGIN_INVENTORY_TAB_MARKER;
+
+function transformPluginInventoryTabMergeFix(src, file) {
+  if (src.includes(PLUGIN_INVENTORY_TAB_MARKER)) return { status: 'already' };
+  if (!src.includes(PLUGIN_INVENTORY_TAB_OLD)) {
+    return { status: 'anchor-missing', detail: '锚点未匹配（dsh 版本可能已变化），跳过 ' + file };
+  }
+  return { status: 'changed', src: src.replace(PLUGIN_INVENTORY_TAB_OLD, PLUGIN_INVENTORY_TAB_NEW) };
+}
+
+module.exports = {
+  // runtime-patches 的 9 个 transform（re-export）。其中
+  // transformPersistenceAll 不被 registry 直接引用，其消费方是
+  // rootAppliers.patchSessionPersistence（session-persistence 以 root 应用器
+  // 形态登记），此处 re-export 仅为保持 transform 收口的对称性，非死代码。
+  transformFlashFix,
+  transformExposeFix,
+  transformPersistenceAll,
+  transformLegacySlotKey,
+  transformSlotUnkeyedCompat,
+  transformSlotErrorIsolation,
+  transformShellDescriptionOptional,
+  transformCodeModeCompat,
+  transformAttachmentMimeTrust,
+  // 原 main.js 内联 transform（声明化，字节级等价）。
+  transformImageSendFix,
+  transformVisionKeyFix,
+  transformProfilePatchGuard,
+  transformProfileBundleAppBoot,
+  transformProfileBundleProfileBoot,
+  transformSettingsSectionGuard,
+  transformWorkspaceSearchRailFix,
+  transformPluginInventoryTabMergeFix,
+  // 包级补丁 node_modules 根应用器（唯一实现）。
+  rootAppliers: {
+    patchWebSearchBaseUrl,
+    patchMenuViewport,
+    patchSessionManage,
+    patchOpenProjectDir,
+    patchSessionPersistence,
+  },
+  // 幂等 marker（单一数据源）：registry 与 transform 的 already 判定引用同一常量，
+  // 杜绝「marker 跨模块复制漂移」。slot 系 marker 来自 runtime-patches（与 slot
+  // transform 同源），bundle-guard 系来自 profile-bundle-heal，其余为本文档声明化。
+  markers: {
+    SLOT_KEY_COMPAT_MARKER,
+    SLOT_UNKEYED_COMPAT_MARKER,
+    SLOT_ERROR_ISOLATE_MARKER,
+    SLOT_ERROR_ISOLATE_MARKER_V2,
+    IMAGE_SEND_MARKER,
+    VISION_KEY_MARKER,
+    PROFILE_PATCH_GUARD_MARKER,
+    PROFILE_BUNDLE_GUARD_MARKER,
+    PROFILE_BOOT_GUARD_MARKER,
+    SETTINGS_SECTION_MARKER,
+    WORKSPACE_SEARCH_RAIL_MARKER,
+    PLUGIN_INVENTORY_TAB_MARKER,
+  },
+};

--- a/dsh-desktop/scripts/lib/patch-engine.js
+++ b/dsh-desktop/scripts/lib/patch-engine.js
@@ -44,6 +44,8 @@ const { writeFileAtomic, readFileCached } = require('./patch-io');
  * @param {boolean} [spec.dryRun]        只判定不落盘（输出 dryRunChangedLog）
  * @param {(file: string, note?: any) => string} [spec.dryRunChangedLog]
  * @param {(file: string, content: string) => void} [spec.write] 写入实现；缺省原子写
+ * @param {{anchorMissing?: number, failed?: number}} [spec.stats] 可观测性计数（锚点失配
+ *   与逐文件失败回流到调用方报告，缺省不累计）
  * @returns {number} 实际写入的文件数
  */
 function applyPatchToFiles(spec) {
@@ -60,6 +62,7 @@ function applyPatchToFiles(spec) {
     dryRun = false,
     dryRunChangedLog = null,
     write = writeFileAtomic,
+    stats = null,
   } = spec;
   let written = 0;
   for (const file of files) {
@@ -77,6 +80,7 @@ function applyPatchToFiles(spec) {
       }
       if (result.status === 'anchor-missing') {
         anchorLog(`${prefix}: ${result.detail}`);
+        if (stats) stats.anchorMissing += 1;
         continue;
       }
       if (dryRun) {
@@ -89,6 +93,7 @@ function applyPatchToFiles(spec) {
       log(donePrefix ? `${prefix}: ${body}` : body);
     } catch (err) {
       log(failLog(file, err));
+      if (stats) stats.failed += 1;
     }
   }
   return written;

--- a/dsh-desktop/scripts/lib/patch-registry.js
+++ b/dsh-desktop/scripts/lib/patch-registry.js
@@ -1,0 +1,554 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 补丁注册表（PatchSpec 唯一清单 / 装配层 composition root）。
+//
+// 每个补丁一条声明，作为运行时补丁编排（patch-runner）与健康预检
+// （fault-isolation.preflight）的唯一数据源。启动编排不再硬编码 WSL/本地
+// 两份 apply* 列表，统一由 layout / wslLayout 字段区分布局、group / order
+// 决定执行顺序。
+//
+// 注意：本模块并非「纯数据」——它反向 require 了 patch-target-resolver
+// （路径常量）、runtime-patches / patch-adapters（transform 与 marker 常量），
+// 是「装配层」而非「数据清单」，字段值里引用的 transform/marker 与对应实现
+// 同源，避免跨模块复制漂移。
+//
+// 字段约定：
+//   id         补丁唯一标识；
+//   group      分组（runtime / guard / package）；
+//   order      组内执行顺序（数字升序）；
+//   kind       'file'（逐文件 transform + applyPatchToFiles）| 'root'
+//              （node_modules 根应用器，逐根 try-catch）；
+//   layout     本地模式布局（见 patch-target-resolver LAYOUTS）；
+//   wslLayout  WSL 模式布局（ctx.wslMode 时优先）；
+//   pkgRel     单文件相对路径；pkgRels 多文件相对路径（slot / shell）；
+//   transform  (src, file) => {status:'already'|'anchor-missing'|'changed'}；
+//   apply      root 应用器 (nmRoot, log) => number；
+//   marker     幂等 marker（与 transform 的 status:'already' 判定同源），
+//              供 preflight 只读体检复用；
+//   requires   宿主能力依赖（见 host-capabilities.js）；
+//   cli        CLI 同步期（sync-companion-plugins.js --with-patches）是否也应用；
+//              cli:true 共 9 项（= 8 个 HEAD 原有补丁 + 1 个 slot-error-isolation，
+//              第一轮 review 有意补漏的第三层错误隔离安全网）；image-send/vision-key
+//              与 guard 组为 false，仅桌面壳运行时应用；
+//   failPolicy 'warn'（失配告警跳过，多数现状）| 'degrade'（失配降级 +
+//              升级提示）| 'fatal'（仅 build 期保留）；作用于规格级异常
+//              （applyAll 的 catch 分支），逐文件/逐根异常由下层吸收并计入
+//              patchReport 的 anchorMissing / failed 计数；degrade 档补丁的
+//              anchor-missing 会分流进 report.degraded（降级告警），warn 档
+//              计入 report.anchorMissing（版本差异）；
+//   logs       kind='file' 的 applyPatchToFiles 日志配置（prefix/alreadyLog/
+//              doneLog/failLog/donePrefix）；
+//   successLog / failLog  kind='root' 的顶层日志字段（successLog(root) /
+//              failLog(root, err)，与 logs 不同，属 root 应用器专用）。
+// ---------------------------------------------------------------------------
+
+const path = require('node:path');
+
+const {
+  FLASH_PKG_REL,
+  EXPOSE_PKG_REL,
+  SLOT_KEY_COMPAT_PKG_REL,
+  SLOT_UNKEYED_COMPAT_PKG_REL,
+  SLOT_COMPAT_PKG_RELS,
+  PW_REL,
+  BASH_REL,
+  CODE_PRESET_REL,
+  ATTACH_LOCAL_REL,
+} = require('./patch-target-resolver');
+
+const {
+  SLOT_KEY_COMPAT_MARKER,
+  SLOT_UNKEYED_COMPAT_MARKER,
+  SLOT_ERROR_ISOLATE_MARKER_V2,
+  IMAGE_SEND_MARKER,
+  VISION_KEY_MARKER,
+  PROFILE_PATCH_GUARD_MARKER,
+  PROFILE_BUNDLE_GUARD_MARKER,
+  PROFILE_BOOT_GUARD_MARKER,
+  SETTINGS_SECTION_MARKER,
+  WORKSPACE_SEARCH_RAIL_MARKER,
+  PLUGIN_INVENTORY_TAB_MARKER,
+} = require('./patch-adapters').markers;
+
+const {
+  transformFlashFix,
+  transformExposeFix,
+  transformLegacySlotKey,
+  transformSlotUnkeyedCompat,
+  transformSlotErrorIsolation,
+  transformShellDescriptionOptional,
+  transformCodeModeCompat,
+  transformAttachmentMimeTrust,
+  transformImageSendFix,
+  transformVisionKeyFix,
+  transformProfilePatchGuard,
+  transformProfileBundleAppBoot,
+  transformProfileBundleProfileBoot,
+  transformSettingsSectionGuard,
+  transformWorkspaceSearchRailFix,
+  transformPluginInventoryTabMergeFix,
+  rootAppliers,
+} = require('./patch-adapters');
+
+/** 通用「已应用」日志主体（多数运行时补丁沿用）。 */
+const alreadySkip = (file) => '已应用，跳过 ' + file;
+
+const PATCH_SPECS = [
+  // -------------------------------------------------------------------------
+  // keyed slot 兼容（rc.6 id → rc.7 key）+ 无 key 兜底 + 错误隔离安全网。
+  // 三层共用 slot-compat 布局（本地 / WSL 两份），逐文件幂等。
+  // -------------------------------------------------------------------------
+  {
+    id: 'slot-legacy-key',
+    group: 'runtime',
+    order: 10,
+    kind: 'file',
+    layout: 'slot-compat',
+    wslLayout: 'slot-compat-wsl',
+    pkgRels: SLOT_COMPAT_PKG_RELS,
+    transform: transformLegacySlotKey,
+    marker: SLOT_KEY_COMPAT_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    logs: {
+      prefix: 'keyed slot 旧插件兼容补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已兼容旧插件的 keyed slot id ' + file,
+      failLog: (file, err) => 'keyed slot 旧插件兼容补丁失败(' + file + '): ' + err.message,
+    },
+  },
+  {
+    id: 'slot-unkeyed-compat',
+    group: 'runtime',
+    order: 20,
+    kind: 'file',
+    layout: 'slot-compat',
+    wslLayout: 'slot-compat-wsl',
+    pkgRels: SLOT_COMPAT_PKG_RELS,
+    transform: transformSlotUnkeyedCompat,
+    marker: SLOT_UNKEYED_COMPAT_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    logs: {
+      prefix: 'keyed slot 无 key 兼容补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已兼容 keyed slot 无 key 注册 ' + file,
+      failLog: (file, err) => 'keyed slot 无 key 兼容补丁失败(' + file + '): ' + err.message,
+    },
+  },
+  {
+    id: 'slot-error-isolation',
+    group: 'runtime',
+    order: 30,
+    kind: 'file',
+    layout: 'slot-compat',
+    wslLayout: 'slot-compat-wsl',
+    pkgRels: SLOT_COMPAT_PKG_RELS,
+    transform: transformSlotErrorIsolation,
+    marker: SLOT_ERROR_ISOLATE_MARKER_V2,
+    requires: [],
+    failPolicy: 'degrade',
+    cli: true,
+    logs: {
+      prefix: 'keyed slot 错误隔离补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file, note) => '已隔离 keyed slot 注册错误 ' + file + (note ? ' (' + note + ')' : ''),
+      failLog: (file, err) => 'keyed slot 错误隔离补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // dsh web 运行时闪跳修复。
+  // -------------------------------------------------------------------------
+  {
+    id: 'runtime-flash-fix',
+    group: 'runtime',
+    order: 40,
+    kind: 'file',
+    layout: 'runtime-local',
+    wslLayout: 'wsl',
+    pkgRel: FLASH_PKG_REL,
+    transform: transformFlashFix,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    logs: {
+      prefix: 'runtime 补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已修复会话列表刷新闪跳 ' + file,
+      failLog: (file, err) => 'runtime 补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // dsh-host-apiproxy 设置暴露白名单补丁。
+  // -------------------------------------------------------------------------
+  {
+    id: 'prompt-expose-fix',
+    group: 'runtime',
+    order: 50,
+    kind: 'file',
+    layout: 'runtime-local',
+    wslLayout: 'wsl',
+    pkgRel: EXPOSE_PKG_REL,
+    transform: transformExposeFix,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    logs: {
+      prefix: '提示词暴露补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file, note) => '已把 ' + note.join(', ') + ' 加入设置白名单 ' + file,
+      failLog: (file, err) => '提示词暴露补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // shell 工具 description 可选化补丁（pwsh/bash 共用同一 transform）。
+  // -------------------------------------------------------------------------
+  {
+    id: 'shell-description-compat',
+    group: 'runtime',
+    order: 60,
+    kind: 'file',
+    layout: 'runtime-local',
+    wslLayout: 'wsl',
+    pkgRels: [PW_REL, BASH_REL],
+    transform: transformShellDescriptionOptional,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    logs: {
+      prefix: 'shell description 兼容补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已把 description 改为可选 ' + file,
+      failLog: (file, err) => 'shell description 兼容补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // code preset 兼容补丁（mode: code → both）。
+  // -------------------------------------------------------------------------
+  {
+    id: 'code-mode-compat',
+    group: 'runtime',
+    order: 70,
+    kind: 'file',
+    layout: 'runtime-local',
+    wslLayout: 'wsl',
+    pkgRel: CODE_PRESET_REL,
+    transform: transformCodeModeCompat,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    logs: {
+      prefix: 'code 模式兼容补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已把 code preset 切换为 both ' + file,
+      failLog: (file, err) => 'code 模式兼容补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // 文本模型自动识图补丁（原 applyImageSendFix 内联 transform）。
+  // -------------------------------------------------------------------------
+  {
+    id: 'image-send-fix',
+    group: 'runtime',
+    order: 80,
+    kind: 'file',
+    layout: 'runtime-local',
+    wslLayout: 'wsl',
+    pkgRel: EXPOSE_PKG_REL,
+    transform: transformImageSendFix,
+    marker: IMAGE_SEND_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: '识图发送补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已启用文本模型图片自动转述 ' + file,
+      failLog: (file, err) => '识图发送补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // 图片字节信任补丁。
+  // -------------------------------------------------------------------------
+  {
+    id: 'attachment-mime-trust',
+    group: 'runtime',
+    order: 90,
+    kind: 'file',
+    layout: 'runtime-local',
+    wslLayout: 'wsl',
+    pkgRel: ATTACH_LOCAL_REL,
+    transform: transformAttachmentMimeTrust,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    logs: {
+      prefix: '图片字节信任补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已信任图片解码字节 ' + file,
+      failLog: (file, err) => '图片字节信任补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // 图片自动转述 apiKey 修复（原 applyVisionKeyFix 内联 transform）。
+  // -------------------------------------------------------------------------
+  {
+    id: 'vision-key-fix',
+    group: 'runtime',
+    order: 100,
+    kind: 'file',
+    layout: 'runtime-local',
+    wslLayout: 'wsl',
+    pkgRel: EXPOSE_PKG_REL,
+    transform: transformVisionKeyFix,
+    marker: VISION_KEY_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: '识图密钥补丁',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已修复 apiKey 被脱敏截断 ' + file,
+      failLog: (file, err) => '识图密钥补丁失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // 防护类补丁（guard 布局）。
+  // -------------------------------------------------------------------------
+  {
+    id: 'profile-patch-guard',
+    group: 'guard',
+    order: 110,
+    kind: 'file',
+    layout: 'guard',
+    wslLayout: 'guard',
+    pkgRel: path.join('dsh-app-boot', 'lib', 'index.js'),
+    transform: transformProfilePatchGuard,
+    marker: PROFILE_PATCH_GUARD_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: 'profile patch 防护',
+      doneLog: (file) => '已注入自愈加载到 ' + file,
+      failLog: (file, err) => 'profile patch 防护失败: ' + err.message,
+    },
+  },
+  {
+    id: 'profile-bundle-guard-appboot',
+    group: 'guard',
+    order: 120,
+    kind: 'file',
+    layout: 'guard',
+    wslLayout: 'guard',
+    pkgRel: path.join('dsh-app-boot', 'lib', 'index.js'),
+    transform: transformProfileBundleAppBoot,
+    marker: PROFILE_BUNDLE_GUARD_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: 'profile bundle 防护',
+      doneLog: (file) => '已注入自愈装配到 ' + file,
+      failLog: (file, err) => 'profile bundle 防护失败(' + file + '): ' + err.message,
+    },
+  },
+  // profile-boot 目录下的 profile-boot-*.js 需要运行时扫描目录，由 patch-runner
+  // 以 layout='profile-boot-dirs' 特殊处理（见 patch-target-resolver LAYOUTS）。
+  {
+    id: 'profile-bundle-guard-profileboot',
+    group: 'guard',
+    order: 130,
+    kind: 'file',
+    layout: 'profile-boot-dirs',
+    wslLayout: 'profile-boot-dirs',
+    pkgRels: [],
+    transform: transformProfileBundleProfileBoot,
+    marker: PROFILE_BOOT_GUARD_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: 'profile bundle 防护',
+      doneLog: (file) => '已注入自愈装配到 ' + file,
+      failLog: (file, err) => 'profile bundle 防护失败(' + file + '): ' + err.message,
+    },
+  },
+  {
+    id: 'settings-section-guard',
+    group: 'guard',
+    order: 140,
+    kind: 'file',
+    layout: 'guard',
+    wslLayout: 'guard',
+    pkgRel: path.join('dsh-settings', 'lib', 'index.js'),
+    transform: transformSettingsSectionGuard,
+    marker: SETTINGS_SECTION_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: 'settings 注册防护',
+      doneLog: (file) => '已注入到 ' + file,
+      failLog: (file, err) => 'settings 注册防护失败: ' + err.message,
+    },
+  },
+  {
+    id: 'workspace-search-rail-fix',
+    group: 'guard',
+    order: 150,
+    kind: 'file',
+    layout: 'guard',
+    wslLayout: 'guard',
+    pkgRel: path.join('dsh-client-ui-workspace', 'lib', 'client.js'),
+    transform: transformWorkspaceSearchRailFix,
+    marker: WORKSPACE_SEARCH_RAIL_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: 'workspace 搜索栏修复',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已注入到 ' + file,
+      failLog: (file, err) => 'workspace 搜索栏修复失败(' + file + '): ' + err.message,
+    },
+  },
+  {
+    id: 'plugin-inventory-tab-merge',
+    group: 'guard',
+    order: 160,
+    kind: 'file',
+    layout: 'guard',
+    wslLayout: 'guard',
+    pkgRel: path.join('dsh-client-ui-settings-plugins', 'lib', 'client.js'),
+    transform: transformPluginInventoryTabMergeFix,
+    marker: PLUGIN_INVENTORY_TAB_MARKER,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    logs: {
+      prefix: '插件页标签合并',
+      alreadyLog: alreadySkip,
+      doneLog: (file) => '已隐藏「全部」只读清单 ' + file,
+      failLog: (file, err) => '插件页标签合并失败(' + file + '): ' + err.message,
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // 包级补丁（node_modules 根应用器，kind='root'）。
+  // -------------------------------------------------------------------------
+  {
+    id: 'web-search-baseurl',
+    group: 'package',
+    order: 170,
+    kind: 'root',
+    layout: 'nm-roots',
+    wslLayout: 'nm-roots',
+    apply: rootAppliers.patchWebSearchBaseUrl,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    successLog: (root) => 'web-search baseURL 补丁: 已应用到 ' + root,
+    failLog: (root, err) => 'web-search baseURL 补丁失败(' + root + '): ' + err.message,
+  },
+  {
+    id: 'menu-viewport',
+    group: 'package',
+    order: 180,
+    kind: 'root',
+    layout: 'nm-roots',
+    wslLayout: 'nm-roots',
+    apply: rootAppliers.patchMenuViewport,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: false,
+    successLog: (root) => 'menu 视口补丁: 已应用到 ' + root,
+    failLog: (root, err) => 'menu 视口补丁失败(' + root + '): ' + err.message,
+  },
+  {
+    id: 'session-manage',
+    group: 'package',
+    order: 190,
+    kind: 'root',
+    layout: 'nm-roots',
+    wslLayout: 'nm-roots',
+    apply: rootAppliers.patchSessionManage,
+    marker: null,
+    requires: ['deleteSession'],
+    failPolicy: 'warn',
+    cli: false,
+    successLog: (root) => '对话删除补丁: 已应用到 ' + root,
+    failLog: (root, err) => '对话删除补丁失败(' + root + '): ' + err.message,
+  },
+  {
+    id: 'open-project-dir',
+    group: 'package',
+    order: 200,
+    kind: 'root',
+    layout: 'nm-roots',
+    wslLayout: 'nm-roots',
+    apply: rootAppliers.patchOpenProjectDir,
+    marker: null,
+    requires: ['openPath'],
+    failPolicy: 'warn',
+    cli: false,
+    successLog: (root) => '打开项目目录补丁: 已应用到 ' + root,
+    failLog: (root, err) => '打开项目目录补丁失败(' + root + '): ' + err.message,
+  },
+  {
+    id: 'session-persistence',
+    group: 'package',
+    order: 210,
+    kind: 'root',
+    layout: 'nm-roots',
+    wslLayout: 'nm-roots',
+    apply: rootAppliers.patchSessionPersistence,
+    marker: null,
+    requires: [],
+    failPolicy: 'warn',
+    cli: true,
+    successLog: (root) => '会话历史尾部恢复补丁: 已应用到 ' + root,
+    failLog: (root, err) => '会话历史尾部恢复补丁失败(' + root + '): ' + err.message,
+  },
+];
+
+/**
+ * 按分组查询补丁清单（无 group 参数返回全部，按 order 升序）。
+ * @param {string} [group]
+ * @returns {Array<Object>}
+ */
+function getSpecsByGroup(group) {
+  const specs = group ? PATCH_SPECS.filter((s) => s.group === group) : PATCH_SPECS.slice();
+  return specs.slice().sort((a, b) => (a.order || 0) - (b.order || 0));
+}
+
+/**
+ * 查询 CLI 同步期（sync-companion-plugins.js --with-patches）需要应用的补丁清单：
+ * 仅返回 cli === true 的 spec，按 order 升序。
+ * @returns {Array<Object>}
+ */
+function getSpecsByCli() {
+  return PATCH_SPECS.filter((s) => s.cli === true)
+    .slice()
+    .sort((a, b) => (a.order || 0) - (b.order || 0));
+}
+
+module.exports = { PATCH_SPECS, getSpecsByGroup, getSpecsByCli };

--- a/dsh-desktop/scripts/lib/patch-target-resolver.js
+++ b/dsh-desktop/scripts/lib/patch-target-resolver.js
@@ -1,0 +1,198 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// 补丁目标解析器（唯一实现）。
+//
+// 现状 `localCopyFiles` / `guardCopyFiles` / `slotCompatCopyFiles` /
+// `patchTargets` / `localNodeModulesRoots` 五函数散落在
+// `scripts/lib/runtime-patches.js`，main.js 再包一层 `runtimeCopyFiles` /
+// `runtimeGuardFiles` / `runtimeNodeModulesRoots` 绑定模块级变量。本模块把
+// 全部路径构造收口为「一个 resolver + 布局枚举」：每个补丁只声明「包相对
+// 路径（pkgRel）+ 布局类型（layout）」，路径归一，杜绝 4~5 处重复落盘漂移。
+//
+// `ctx = { home, appDir, userDataDir, wslMode }` 为纯参数注入，便于单测；
+// main.js 与 CLI 只传 ctx，不再各自构造路径。
+//
+// 兼容期：为让 sync-companion-plugins.js 与既有单测不断链，本模块同时导出
+// 旧签名的五个构造函数（patchTargets / localCopyFiles / guardCopyFiles /
+// localNodeModulesRoots / slotCompatCopyFiles / slotCompatPatchTargets），
+// runtime-patches.js 据此 re-export 一个版本周期后再删。
+// ---------------------------------------------------------------------------
+
+const path = require('node:path');
+
+/** 各补丁目标包内的相对路径（@deepseek-ai/<rel>）。 */
+const FLASH_PKG_REL = path.join('dsh-client-runtime', 'lib', 'client.js');
+const EXPOSE_PKG_REL = path.join('dsh-host-apiproxy', 'lib', 'index.js');
+const PERSISTENCE_PKG_REL = path.join('dsh-session-persistence-jsonl', 'lib', 'index.js');
+const SLOT_KEY_COMPAT_PKG_REL = path.join('dsh-client-ui-slots', 'lib', 'index.js');
+const SLOT_UNKEYED_COMPAT_PKG_REL = path.join('dsh-cordis-client-runner', 'lib', 'client.js');
+const SLOT_COMPAT_PKG_RELS = [SLOT_KEY_COMPAT_PKG_REL, SLOT_UNKEYED_COMPAT_PKG_REL];
+const PW_REL = path.join('dsh-tool-pwsh', 'lib', 'index.js');
+const BASH_REL = path.join('dsh-tool-bash', 'lib', 'index.js');
+const CODE_PRESET_REL = path.join('dsh', 'config', 'agent-presets', 'code', 'agent.cordis.yml');
+const ATTACH_LOCAL_REL = path.join('dsh-attachment-local', 'lib', 'index.js');
+
+/** @deepseek-ai/<pkgRel> 落点（以 node_modules/@deepseek-ai 根为准）。 */
+function mkAi(root, pkgRel) {
+  return path.join(root, 'node_modules', '@deepseek-ai', pkgRel);
+}
+
+/**
+ * 布局（layout）—— 每个补丁只声明 pkgRel + layout，路径构造归一。
+ * 布局函数签名：(ctx, spec) => string[]；spec.pkgRel 为单文件相对路径，
+ * spec.pkgRels 为多文件相对路径（slot-compat / shell-description 共用）。
+ */
+const LAYOUTS = {
+  // 本地模式三副本：profile fallback → app 内置 → agent overlay。
+  'runtime-local': (ctx, spec) => [
+    mkAi(path.join(ctx.home, 'profiles'), spec.pkgRel),
+    mkAi(ctx.appDir, spec.pkgRel),
+    mkAi(path.join(ctx.userDataDir, 'agent'), spec.pkgRel),
+  ],
+  // 防护类补丁四副本：app 优先 + overlay 嵌套 dsh + profile fallback。
+  'guard': (ctx, spec) => [
+    mkAi(ctx.appDir, spec.pkgRel),
+    mkAi(path.join(ctx.userDataDir, 'agent'), spec.pkgRel),
+    mkAi(path.join(ctx.userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh'), spec.pkgRel),
+    mkAi(path.join(ctx.home, 'profiles'), spec.pkgRel),
+  ],
+  // WSL：profile fallback + agent（UNC 写穿）。
+  'wsl': (ctx, spec) => [
+    mkAi(path.join(ctx.home, 'profiles'), spec.pkgRel),
+    mkAi(path.join(ctx.home, 'agent'), spec.pkgRel),
+  ],
+  // 包级补丁的 node_modules 根列表（WSL 追加 agent 直连根兜底）。
+  'nm-roots': (ctx) => [
+    path.join(ctx.home, 'profiles', 'node_modules'),
+    path.join(ctx.appDir, 'node_modules'),
+    path.join(ctx.userDataDir, 'agent', 'node_modules'),
+    ...(ctx.wslMode ? [path.join(ctx.home, 'agent', 'node_modules')] : []),
+  ],
+  // slot 兼容（本地）：单文件布局。逐文件迭代由 patch-runner 的 applyFile 循环
+  // pkgRels 驱动；本布局只处理单个 spec.pkgRel，避免「读完整 pkgRels」导致同一
+  // 文件被循环 2 遍重复处理（历史 bug）。顶层三副本 + guard 四副本 + profile/app
+  // 嵌套 dsh 依赖副本（去重）。
+  'slot-compat': (ctx, spec) => slotCompatFilesFor(ctx, spec.pkgRel),
+  // slot 兼容（WSL）：单文件布局（profile fallback + agent + 嵌套 dsh 依赖副本）。
+  'slot-compat-wsl': (ctx, spec) => slotCompatFilesForWsl(ctx, spec.pkgRel),
+  // profile-boot 防护目标目录（runner 在此 glob `profile-boot-*.js`）。
+  'profile-boot-dirs': (ctx) => [
+    path.join(ctx.appDir, 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
+    path.join(ctx.userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
+    path.join(ctx.home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh', 'lib'),
+  ],
+};
+
+/** 嵌套 dsh 依赖副本落点。 */
+function nestedAi(root, pkgRel) {
+  return path.join(root, 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', pkgRel);
+}
+
+/** slot 兼容（本地）单文件目标：runtime-local + guard + profile/app 嵌套副本（去重）。 */
+function slotCompatFilesFor(ctx, pkgRel) {
+  return [...new Set([
+    ...LAYOUTS['runtime-local'](ctx, { pkgRel }),
+    ...LAYOUTS['guard'](ctx, { pkgRel }),
+    nestedAi(path.join(ctx.home, 'profiles'), pkgRel),
+    nestedAi(ctx.appDir, pkgRel),
+  ])];
+}
+
+/** slot 兼容（WSL）单文件目标：wsl + profile/agent 嵌套副本（去重）。 */
+function slotCompatFilesForWsl(ctx, pkgRel) {
+  return [...new Set([
+    ...LAYOUTS['wsl'](ctx, { pkgRel }),
+    nestedAi(path.join(ctx.home, 'profiles'), pkgRel),
+    nestedAi(path.join(ctx.home, 'agent'), pkgRel),
+  ])];
+}
+
+/**
+ * 解析单个补丁的落盘文件列表。
+ * @param {{home:string, appDir:string, userDataDir:string, wslMode:boolean}} ctx
+ * @param {{layout?:string, wslLayout?:string, pkgRel?:string, pkgRels?:string[]}} spec
+ * @returns {string[]}
+ */
+function resolvePatchTargets(ctx, spec) {
+  const layoutKey = (spec.wslLayout && ctx.wslMode) ? spec.wslLayout : spec.layout;
+  const layout = LAYOUTS[layoutKey];
+  if (!layout) return [];
+  return layout(ctx, spec);
+}
+
+/**
+ * 解析包级补丁的 node_modules 根列表（web-search / menu-viewport /
+ * session-manage / open-project-dir / session-persistence 用）。
+ * @param {{home:string, appDir:string, userDataDir:string, wslMode:boolean}} ctx
+ * @param {{layout?:string, wslLayout?:string}} [spec]
+ * @returns {string[]}
+ */
+function resolveNmRoots(ctx, spec = {}) {
+  const layoutKey = (spec.wslLayout && ctx.wslMode) ? spec.wslLayout : (spec.layout || 'nm-roots');
+  const layout = LAYOUTS[layoutKey] || LAYOUTS['nm-roots'];
+  return layout(ctx, spec);
+}
+
+// ---------------------------------------------------------------------------
+// 旧签名兼容函数（供 runtime-patches.js re-export；main.js 与 CLI 经 resolver
+// 走新接口，这些仅保留一个版本周期）。
+// ---------------------------------------------------------------------------
+
+function patchTargets(home, pkgRel) {
+  return LAYOUTS['wsl']({ home }, { pkgRel });
+}
+
+function localCopyFiles(home, appDir, userDataDir, pkgRel) {
+  return LAYOUTS['runtime-local']({ home, appDir, userDataDir, wslMode: false }, { pkgRel });
+}
+
+function guardCopyFiles(home, appDir, userDataDir, pkgRel) {
+  return LAYOUTS['guard']({ home, appDir, userDataDir, wslMode: false }, { pkgRel });
+}
+
+function localNodeModulesRoots(home, appDir, userDataDir, extraRoots = []) {
+  return [
+    path.join(home, 'profiles', 'node_modules'),
+    path.join(appDir, 'node_modules'),
+    path.join(userDataDir, 'agent', 'node_modules'),
+    ...extraRoots,
+  ];
+}
+
+function slotCompatCopyFiles(home, appDir, userDataDir) {
+  const ctx = { home, appDir, userDataDir, wslMode: false };
+  const files = [];
+  for (const pkgRel of SLOT_COMPAT_PKG_RELS) files.push(...slotCompatFilesFor(ctx, pkgRel));
+  return [...new Set(files)];
+}
+
+function slotCompatPatchTargets(home) {
+  const ctx = { home, wslMode: true };
+  const files = [];
+  for (const pkgRel of SLOT_COMPAT_PKG_RELS) files.push(...slotCompatFilesForWsl(ctx, pkgRel));
+  return [...new Set(files)];
+}
+
+module.exports = {
+  LAYOUTS,
+  FLASH_PKG_REL,
+  EXPOSE_PKG_REL,
+  PERSISTENCE_PKG_REL,
+  SLOT_KEY_COMPAT_PKG_REL,
+  SLOT_UNKEYED_COMPAT_PKG_REL,
+  SLOT_COMPAT_PKG_RELS,
+  PW_REL,
+  BASH_REL,
+  CODE_PRESET_REL,
+  ATTACH_LOCAL_REL,
+  resolvePatchTargets,
+  resolveNmRoots,
+  // 兼容期旧签名（一个版本周期后删除）。
+  patchTargets,
+  localCopyFiles,
+  guardCopyFiles,
+  localNodeModulesRoots,
+  slotCompatCopyFiles,
+  slotCompatPatchTargets,
+};

--- a/dsh-desktop/scripts/lib/runtime-patches.js
+++ b/dsh-desktop/scripts/lib/runtime-patches.js
@@ -13,7 +13,27 @@
 // 变换均为纯函数，字节级输出与旧实现一致；锚点失配时绝不改写文件内容。
 // ---------------------------------------------------------------------------
 
-const path = require('node:path');
+// 路径构造与包内相对路径常量已迁出到 patch-target-resolver.js（唯一实现），
+// 这里 re-export 一个版本周期，避免 main.js / sync-companion-plugins.js /
+// 既有单测断链。变换（transform）与锚点常量仍保留在本模块。
+const {
+  FLASH_PKG_REL,
+  EXPOSE_PKG_REL,
+  PERSISTENCE_PKG_REL,
+  SLOT_KEY_COMPAT_PKG_REL,
+  SLOT_UNKEYED_COMPAT_PKG_REL,
+  SLOT_COMPAT_PKG_RELS,
+  PW_REL,
+  BASH_REL,
+  CODE_PRESET_REL,
+  ATTACH_LOCAL_REL,
+  patchTargets,
+  localCopyFiles,
+  guardCopyFiles,
+  localNodeModulesRoots,
+  slotCompatCopyFiles,
+  slotCompatPatchTargets,
+} = require('./patch-target-resolver');
 
 /** dsh-client-runtime 会话列表刷新闪跳修复（mergeOrderedBaseline 保留本地新会话）。 */
 const FLASH_OLD = '(value) => baselineByKey.get(keyOf(value))).filter((value) => value !== void 0);';
@@ -26,13 +46,6 @@ const SETTINGS_NAMESPACES = ['dsh-prompt', 'dsh-third-party-thinking', 'dsh-visi
 // the legacy list injection is unnecessary and must be treated as idempotent.
 const DYNAMIC_SETTINGS_ANCHOR = 'namespaces: settings.describe({ redactSecrets: true }).map(namespaceView)';
 
-/** 各补丁目标包内的相对路径（@deepseek-ai/<rel>）。 */
-const FLASH_PKG_REL = path.join('dsh-client-runtime', 'lib', 'client.js');
-const EXPOSE_PKG_REL = path.join('dsh-host-apiproxy', 'lib', 'index.js');
-const PERSISTENCE_PKG_REL = path.join('dsh-session-persistence-jsonl', 'lib', 'index.js');
-const SLOT_KEY_COMPAT_PKG_REL = path.join('dsh-client-ui-slots', 'lib', 'index.js');
-const SLOT_UNKEYED_COMPAT_PKG_REL = path.join('dsh-cordis-client-runner', 'lib', 'client.js');
-const SLOT_COMPAT_PKG_RELS = [SLOT_KEY_COMPAT_PKG_REL, SLOT_UNKEYED_COMPAT_PKG_REL];
 // rc.6 keyed slots accepted the registration identity through `id`. rc.7 split
 // list identity (`id`) from keyed dispatch identity (`key`), which makes
 // otherwise compatible third-party browser plugins fail the whole loader. Some
@@ -104,86 +117,9 @@ const PERSISTENCE_COMPLETE_CHECK_NEW = [
   PERSISTENCE_COMPLETE_CHECK,
 ].join('\n');
 
-/**
- * WSL 托管模式 / sync CLI 共用目标：profile fallback + agent 两份副本。
- * bundle 初始化后的 dsh 安装（npm 版）两份副本通常互为同一文件（fallback
- * 符号链接写穿），逐文件幂等判定保证重复目标安全。
- * @param {string} home 目标 dsh 数据目录（WSL 模式为 UNC 等价路径）
- * @param {string} pkgRel @deepseek-ai/<pkgRel>
- * @returns {string[]}
- */
-function patchTargets(home, pkgRel) {
-  const mk = (root) => path.join(root, 'node_modules', '@deepseek-ai', pkgRel);
-  return [
-    mk(path.join(home, 'profiles')),
-    mk(path.join(home, 'agent')),
-  ];
-}
-
-// ---------------------------------------------------------------------------
-// 运行时补丁候选路径构造（纯函数：路径根由调用方传入，便于单测；main.js 绑定
-// 模块级变量）。三种布局与旧实现逐项一致，并补齐同系列补丁的历史覆盖缺口：
-//   - localCopyFiles         本地模式三副本（profile fallback → 内置副本 → 更新 overlay）；
-//   - guardCopyFiles         防护类补丁四副本（内置副本优先 + overlay 嵌套 dsh
-//                            依赖副本 + profile fallback）；
-//   - localNodeModulesRoots  包级补丁的 node_modules 根目录列表（extraRoots 用于
-//                            WSL 模式追加 WSL agent 直连根，与 patchTargets 的
-//                            agent 兜底语义一致）。
-// ---------------------------------------------------------------------------
-
-function localCopyFiles(home, appDir, userDataDir, pkgRel) {
-  return [
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(appDir, 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
-  ];
-}
-
-function guardCopyFiles(home, appDir, userDataDir, pkgRel) {
-  return [
-    path.join(appDir, 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', pkgRel),
-    path.join(home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel),
-  ];
-}
-
-function localNodeModulesRoots(home, appDir, userDataDir, extraRoots = []) {
-  return [
-    path.join(home, 'profiles', 'node_modules'),
-    path.join(appDir, 'node_modules'),
-    path.join(userDataDir, 'agent', 'node_modules'),
-    ...extraRoots,
-  ];
-}
-
-/**
- * Slot compatibility targets include the nested dependency copies shipped by a
- * clean dsh overlay. Some npm layouts do not hoist client-ui-slots or
- * cordis-client-runner to the agent/profile root, so patching only the top-level
- * copies is insufficient.
- */
-function slotCompatCopyFiles(home, appDir, userDataDir) {
-  const nested = (root, pkgRel) => path.join(root, 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', pkgRel);
-  const files = [];
-  for (const pkgRel of SLOT_COMPAT_PKG_RELS) {
-    files.push(...localCopyFiles(home, appDir, userDataDir, pkgRel));
-    files.push(...guardCopyFiles(home, appDir, userDataDir, pkgRel));
-    files.push(nested(path.join(home, 'profiles'), pkgRel));
-    files.push(nested(appDir, pkgRel));
-  }
-  return [...new Set(files)];
-}
-function slotCompatPatchTargets(home) {
-  const nested = (root, pkgRel) => path.join(root, 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', pkgRel);
-  const files = [];
-  for (const pkgRel of SLOT_COMPAT_PKG_RELS) {
-    files.push(...patchTargets(home, pkgRel));
-    files.push(nested(path.join(home, 'profiles'), pkgRel));
-    files.push(nested(path.join(home, 'agent'), pkgRel));
-  }
-  return [...new Set(files)];
-}
+// 路径构造函数（patchTargets / localCopyFiles / guardCopyFiles /
+// localNodeModulesRoots / slotCompatCopyFiles / slotCompatPatchTargets）已迁出
+// 到 patch-target-resolver.js，本模块顶部 re-export 保持兼容。
 
 /**
  * 闪跳修复变换（纯函数）。锚点失配的 detail 含文件路径，与两个调用方
@@ -361,40 +297,56 @@ function transformSlotUnkeyedCompat(src, file) {
 // 目标：register 函数中 throw 语句之前注入 early return。
 // ---------------------------------------------------------------------------
 const SLOT_ERROR_ISOLATE_MARKER = 'dsh-desktop compat: isolate keyed-slot registration errors';
-// 搜索 "requires options.key" 或 "requires.*key" 的 throw 语句及其上下文。
-const SLOT_ERROR_ISOLATE_REGEX = /([ \t]*)(throw new Error\([^)]*keyed slot[^)]*options\.key[^)]*\))/;
-function transformSlotErrorIsolation(src, file) {
-  if (src.includes(SLOT_ERROR_ISOLATE_MARKER)) return { status: 'already' };
-  const m = SLOT_ERROR_ISOLATE_REGEX.exec(src);
-  if (!m) {
-    // 精确搜索已知的 throw 模式（多种变体）
-    const altThrow = /([ \t]*)(throw new Error\([^)]*requires options\.key[^)]*\))/;
-    const m2 = altThrow.exec(src);
-    if (!m2) {
-      return {
-        status: 'anchor-missing',
-        detail: '未找到 keyed slot throw 锚点（版本可能已变更），跳过 ' + file,
-      };
-    }
-    const indent = m2[1];
-    const injected = [
-      indent + '// ' + SLOT_ERROR_ISOLATE_MARKER + ': convert fatal throw into warn+skip so one',
-      indent + '// unkeyed plugin cannot take down the whole dsh web loader.',
-      indent + 'console.warn("[dsh-desktop compat] keyed slot registration missing key, auto-deriving from registrant; plugin:", options.registrant || options.id || "unknown");',
-      indent + 'options.key = options.id !== void 0 ? String(options.id) : String(options.registrant || "auto-" + Math.random().toString(36).slice(2, 8));',
-      m2[0],
-    ].join('\n');
-    return { status: 'changed', src: src.replace(m2[0], injected), note: 'alt throw' };
-  }
-  const indent = m[1];
-  const injected = [
-    indent + '// ' + SLOT_ERROR_ISOLATE_MARKER + ': convert fatal throw into warn+skip so one',
-    indent + '// unkeyed plugin cannot take down the whole dsh web loader.',
-    indent + 'console.warn("[dsh-desktop compat] keyed slot registration missing key, auto-deriving from registrant; plugin:", options.registrant || options.id || "unknown");',
-    indent + 'options.key = options.id !== void 0 ? String(options.id) : String(options.registrant || "auto-" + Math.random().toString(36).slice(2, 8));',
-    m[0],
+// v2 修复标记：v1 曾把 throw 与派生 key 一并注入且保留了原 throw（且 `if` 守卫
+// 被注释吞掉，导致 throw 无条件执行），v2 改为「if 守卫内 warn + 派生 key，不
+// throw」，真正实现「缺 key 时派生而非拖垮 loader」。
+const SLOT_ERROR_ISOLATE_MARKER_V2 = SLOT_ERROR_ISOLATE_MARKER + ' (v2)';
+// 原始单行 throw：`if (options.key === void 0) throw ...`（错误消息任意）。
+const SLOT_ERROR_ISOLATE_ORIGINAL = /([ \t]*)if \(options\.key === void 0\)[ \t]*throw[^\n]*/;
+// v1 buggy 输出：`if (options.key === void 0) // marker...` + 3 行（注释/warn/派生）+ 独立 throw 行。
+const SLOT_ERROR_ISOLATE_V1 = /([ \t]*)if \(options\.key === void 0\)[^\n]*\n(?:[^\n]*\n){3}[ \t]*throw[^\n]*/;
+// v1 buggy 输出（standalone throw 源）：旧 SLOT_ERROR_ISOLATE_REGEX 匹配独立
+// `throw new Error(...)`（无 if 前缀），其注入产物以 `// marker...` 开头，后跟 3 行
+// （注释/warn/派生）+ throw。若只用 SLOT_ERROR_ISOLATE_V1（要求 if 前缀）会漏修、
+// 无条件 throw 保留，故此处补一条无 if 前缀的回退匹配。
+const SLOT_ERROR_ISOLATE_V1_STANDALONE = /([ \t]*)\/\/[^\n]*isolate keyed-slot registration errors[^\n]*\n(?:[^\n]*\n){3}[ \t]*throw[^\n]*/;
+
+/** 构造 v2 隔离块：warn + 派生 key，不 throw。 */
+function buildSlotIsolateBlock(indent) {
+  return [
+    indent + 'if (options.key === void 0) {',
+    indent + '\t// ' + SLOT_ERROR_ISOLATE_MARKER_V2 + ': derive a key instead of throwing so one',
+    indent + '\t// unkeyed plugin cannot take down the whole dsh web loader.',
+    indent + '\tconsole.warn("[dsh-desktop compat] keyed slot registration missing key, auto-deriving from registrant; plugin:", options.registrant || options.id || "unknown");',
+    indent + '\toptions.key = options.id !== void 0 ? String(options.id) : String(options.registrant || "auto-" + Math.random().toString(36).slice(2, 8));',
+    indent + '}',
   ].join('\n');
-  return { status: 'changed', src: src.replace(m[0], injected) };
+}
+
+function transformSlotErrorIsolation(src, file) {
+  if (src.includes(SLOT_ERROR_ISOLATE_MARKER_V2)) return { status: 'already' };
+  // 1) 原始单行 throw → 注入 v2（warn + 派生 key，不 throw）。
+  const m = SLOT_ERROR_ISOLATE_ORIGINAL.exec(src);
+  if (m) {
+    return { status: 'changed', src: src.replace(m[0], buildSlotIsolateBlock(m[1])), note: 'v2' };
+  }
+  // 2) v1 buggy 输出（含旧 marker + 无条件 throw）→ 修复为 v2。
+  if (src.includes(SLOT_ERROR_ISOLATE_MARKER)) {
+    // 2a) 常规 v1：`if (options.key === void 0) // marker...` + 3 行 + throw。
+    const v1 = SLOT_ERROR_ISOLATE_V1.exec(src);
+    if (v1) {
+      return { status: 'changed', src: src.replace(v1[0], buildSlotIsolateBlock(v1[1])), note: 'v1-repair' };
+    }
+    // 2b) standalone v1：旧 SLOT_ERROR_ISOLATE_REGEX 分支的独立 throw 源（无 if 前缀）。
+    const v1s = SLOT_ERROR_ISOLATE_V1_STANDALONE.exec(src);
+    if (v1s) {
+      return { status: 'changed', src: src.replace(v1s[0], buildSlotIsolateBlock(v1s[1])), note: 'v1-repair' };
+    }
+  }
+  return {
+    status: 'anchor-missing',
+    detail: '未找到 keyed slot throw 锚点（版本可能已变更），跳过 ' + file,
+  };
 }
 
 // 模型工具兼容补丁（问题背景：code 模式的 run_code 程序经常省略 shell 工具
@@ -412,9 +364,6 @@ const SHELL_DESC_VALIDATE_NEW = "\tif (typeof args.description !== \"string\" ||
 const SHELL_DESC_SCHEMA_OLD = "\t\t\tdescription: {\n\t\t\t\ttype: \"string\",\n\t\t\t\trequired: true,\n\t\t\t\tdescription: \"Clear, concise description of what this command does in active voice, 5-10 words (shown in the UI). Examples:";
 // 已废弃：仅作旧补丁回滚识别锚点（引擎 schema 校验器拒绝 required: false）。
 const SHELL_DESC_SCHEMA_NEW = "\t\t\tdescription: {\n\t\t\t\ttype: \"string\",\n\t\t\t\trequired: false, // " + SHELL_DESC_MARKER + "\n\t\t\t\tdescription: \"Clear, concise description of what this command does in active voice, 5-10 words (shown in the UI). Examples:";
-
-const PW_REL = path.join("dsh-tool-pwsh", "lib", "index.js");
-const BASH_REL = path.join("dsh-tool-bash", "lib", "index.js");
 
 /** shell 工具 description 兜底变换（pwsh/bash 共用，锚点逐字节一致）。
  *  只改 validate 校验（缺省时用 command 首行补值）；schema 的
@@ -445,8 +394,6 @@ const CODE_MODE_NEW = `- id: tool-presentation
     # ${CODE_MODE_MARKER}
     mode: both`;
 
-const CODE_PRESET_REL = path.join('dsh', 'config', 'agent-presets', 'code', 'agent.cordis.yml');
-
 /** code preset `mode: code` → `mode: both` 变换（幂等，锚点失配跳过）。 */
 // ---------------------------------------------------------------------------
 // 图片字节信任补丁（问题背景：浏览器声明的 MIME 跟随文件扩展名，不可信——
@@ -460,8 +407,6 @@ const CODE_PRESET_REL = path.join('dsh', 'config', 'agent-presets', 'code', 'age
 const ATTACH_MIME_MARKER = "dsh-desktop compat: trust decoded image bytes";
 const ATTACH_MIME_OLD = '\tif (detected.mediaType !== declaredMediaType) throw new AttachmentError("Declared image type does not match its bytes.", "IMAGE_TYPE_MISMATCH");';
 const ATTACH_MIME_NEW = '\t// ' + ATTACH_MIME_MARKER + '. The browser-declared MIME follows the file extension and is\n\t// untrusted (a webp/jpeg renamed to .png arrives as image/png while the bytes decode as\n\t// webp); the decoded bytes are authoritative, so record the detected type instead of\n\t// rejecting the whole send.\n\tif (detected.mediaType !== declaredMediaType && typeof declaredMediaType === "string" && declaredMediaType.startsWith("image/")) declaredMediaType = detected.mediaType;';
-
-const ATTACH_LOCAL_REL = path.join("dsh-attachment-local", "lib", "index.js");
 
 /** attachment-local 图片字节信任变换（幂等，锚点失配跳过）。 */
 function transformAttachmentMimeTrust(src, file) {
@@ -509,6 +454,7 @@ module.exports = {
   transformLegacySlotKey,
   transformSlotUnkeyedCompat,
   SLOT_ERROR_ISOLATE_MARKER,
+  SLOT_ERROR_ISOLATE_MARKER_V2,
   transformSlotErrorIsolation,
   slotCompatCopyFiles,
   slotCompatPatchTargets,

--- a/dsh-desktop/scripts/patch-menu-viewport.js
+++ b/dsh-desktop/scripts/patch-menu-viewport.js
@@ -34,7 +34,7 @@ const NEW_Y_CLAMP = [
 const OLD_STYLE = 'style: portal ? fixedPos ?? MEASURE_STYLE : void 0,';
 const NEW_STYLE = 'style: portal ? { ...(fixedPos ?? MEASURE_STYLE), maxHeight: "min(calc(100vh - 24px), 560px)", overflowY: "auto" } : void 0,';
 
-function patchFile(file, log = () => {}) {
+function patchFile(file, log = () => {}, stats, options) {
   let src;
   try {
     src = fs.readFileSync(file, 'utf8');
@@ -48,11 +48,16 @@ function patchFile(file, log = () => {}) {
   }
   if (!src.includes(OLD_Y_CLAMP) || !src.includes(OLD_STYLE)) {
     log('menu-viewport 补丁: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file);
+    if (stats) stats.anchorMissing += 1;
     return false;
   }
   src = src.replace(OLD_Y_CLAMP, NEW_Y_CLAMP).replace(OLD_STYLE, NEW_STYLE);
   src = '// ' + MARKER + ': Menu portal 列表视口封顶（issue #36）\n' + src;
   try {
+    if (options && options.dryRun) {
+      log('menu-viewport 补丁: dry-run: 将应用 ' + file);
+      return false; // dryRun 不落盘，不计为已写
+    }
     writeFileAtomic(file, src);
     log('menu-viewport 补丁: 已应用 ' + file);
     return true;
@@ -68,10 +73,10 @@ function patchFile(file, log = () => {}) {
  * @param {(msg: string) => void} [log]
  * @returns {number} 实际发生修改的文件数
  */
-function patchMenuViewport(nmRoot, log = () => {}) {
+function patchMenuViewport(nmRoot, log = () => {}, stats, options) {
   const file = path.join(nmRoot, '@deepseek-ai', 'dsh-client-ui-primitives', 'lib', 'index.js');
   if (!fs.existsSync(file)) return 0;
-  return patchFile(file, log) ? 1 : 0;
+  return patchFile(file, log, stats, options) ? 1 : 0;
 }
 
 module.exports = { patchMenuViewport, MARKER };

--- a/dsh-desktop/scripts/patch-open-project-dir.js
+++ b/dsh-desktop/scripts/patch-open-project-dir.js
@@ -19,8 +19,9 @@
 //   4. 菜单锚点矩形统一走 getAnchorRect：⋯ 按钮点击时返回按钮矩形，右键时
 //      返回光标矩形。
 //
-// 桥 window.__dshDesktopOpenDir 由配套插件 dsh-session-manager 提供（复用
-// preload 已暴露的 window.dshDesktop.openPath → dsh:file-open → shell.openPath）。
+// 桥 openPath 为 preload 已暴露的宿主能力 window.dshDesktop.openPath（显式
+// 直接引用，不再经 dsh-session-manager 插件的 window.__dshDesktopOpenDir 别名
+// 中转）；桥缺失时（纯浏览器）`?.` 可选链静默降级为无操作。
 //
 // 用法：
 //   node scripts/patch-open-project-dir.js [<node_modules 根目录>]
@@ -44,7 +45,7 @@ const UI_PROJECT_ITEMS_INSERT = '}, {\n\t\t\t\tid: "delete",\n\t\t\t\tlabel: t("
 
 // 1b. 项目行菜单 onSelect：放行 open-folder 并调用桥。
 const UI_PROJECT_SELECT_ANCHOR = 'if (id !== "rename" && id !== "delete") return;\n\t\t\t\t\t\t\t\tif (id === "rename") actions.rename();\n\t\t\t\t\t\t\t\telse actions.delete();';
-const UI_PROJECT_SELECT_INSERT = 'if (id !== "rename" && id !== "delete" && id !== "open-folder") return;\n\t\t\t\t\t\t\t\tif (id === "rename") actions.rename();\n\t\t\t\t\t\t\t\telse if (id === "delete") actions.delete();\n\t\t\t\t\t\t\t\telse if (id === "open-folder") window.__dshDesktopOpenDir?.(row.cwd);';
+const UI_PROJECT_SELECT_INSERT = 'if (id !== "rename" && id !== "delete" && id !== "open-folder") return;\n\t\t\t\t\t\t\t\tif (id === "rename") actions.rename();\n\t\t\t\t\t\t\t\telse if (id === "delete") actions.delete();\n\t\t\t\t\t\t\t\telse if (id === "open-folder") window.dshDesktop?.openPath?.(row.cwd);';
 
 // 1c. 项目行 div：右键弹出同一菜单（光标锚点；无 actions 的未分组桶不弹）。
 const UI_PROJECT_DIV_ANCHOR = 'role: "treeitem",\n\t\t\t\t"aria-expanded": row.expanded,\n\t\t\t\tonClick: onToggle,';
@@ -71,12 +72,12 @@ const UI_SESSION_STATE_ANCHOR = 'const showStatus = statuses[0].state !== "done"
 const UI_SESSION_STATE_INSERT = 'const showStatus = statuses[0].state !== "done" || row.completed;\n\t\t\tconst [menuOpen, setMenuOpen] = (0, react.useState)(false);\n\t\t\tconst [menuRect, setMenuRect] = (0, react.useState)(null);';
 
 // 2c. 会话行菜单项数组：delete 项后按需追加 open-folder（无 cwd 不显示）。
-const UI_SESSION_ITEMS_ANCHOR = '// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}\n\t\t\t];';
-const UI_SESSION_ITEMS_INSERT = '// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t},\n\t\t\t\t// dsh-desktop patch (open project dir): 打开会话所在项目目录（无 cwd 的孤儿/未分组会话不显示）。\n\t\t\t\t...(cwd ? [{\n\t\t\t\t\tid: "open-folder",\n\t\t\t\t\tlabel: t("menu.openProjectDir"),\n\t\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconFolderOpen16, {})\n\t\t\t\t}] : [])\n\t\t\t];';
+const UI_SESSION_ITEMS_ANCHOR = '// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t// 桥 window.__dshSessionManager 由 dsh-session-manager 插件提供；桥缺失\n\t\t\t\t// 时隐藏「删除对话」项（显式降级，而非可选链静默无反应）。\n\t\t\t\t...(window.__dshSessionManager && typeof window.__dshSessionManager.deleteSession === "function" ? [{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}] : [])\n\t\t\t];';
+const UI_SESSION_ITEMS_INSERT = '// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t// 桥 window.__dshSessionManager 由 dsh-session-manager 插件提供；桥缺失\n\t\t\t\t// 时隐藏「删除对话」项（显式降级，而非可选链静默无反应）。\n\t\t\t\t...(window.__dshSessionManager && typeof window.__dshSessionManager.deleteSession === "function" ? [{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}] : []),\n\t\t\t\t// dsh-desktop patch (open project dir): 打开会话所在项目目录（无 cwd 的孤儿/未分组会话不显示）。\n\t\t\t\t...(cwd ? [{\n\t\t\t\t\tid: "open-folder",\n\t\t\t\t\tlabel: t("menu.openProjectDir"),\n\t\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconFolderOpen16, {})\n\t\t\t\t}] : [])\n\t\t\t];';
 
 // 2d. 会话行菜单 onSelect：open-folder 调用桥。
 const UI_SESSION_SELECT_ANCHOR = 'if (id === "delete") window.__dshSessionManager?.deleteSession(node.id);';
-const UI_SESSION_SELECT_INSERT = 'if (id === "delete") window.__dshSessionManager?.deleteSession(node.id);\n\t\t\t\t\t\t\t\t\tif (id === "open-folder") window.__dshDesktopOpenDir?.(cwd);';
+const UI_SESSION_SELECT_INSERT = 'if (id === "delete") window.__dshSessionManager?.deleteSession(node.id);\n\t\t\t\t\t\t\t\t\tif (id === "open-folder") window.dshDesktop?.openPath?.(cwd);';
 
 // 2e. 会话行 div：右键弹出同一菜单（光标锚点；blank 占位行无菜单不弹）。
 const UI_SESSION_DIV_ANCHOR = '"aria-selected": selected,\n\t\t\t\t\tonClick: () => {\n\t\t\t\t\t\tonOpen(node.id);\n\t\t\t\t\t},';
@@ -127,7 +128,7 @@ const UI_REPLACEMENTS = [
 // ---------------------------------------------------------------------------
 // 工具：在文件中做「锚点必须存在 + 标记幂等」的替换
 // ---------------------------------------------------------------------------
-function applyReplacements(file, replacements, log) {
+function applyReplacements(file, replacements, log, stats, options) {
   let src;
   try {
     src = fs.readFileSync(file, 'utf8');
@@ -142,12 +143,17 @@ function applyReplacements(file, replacements, log) {
   for (const { anchor, insert } of replacements) {
     if (!src.includes(anchor)) {
       log('open-project-dir 补丁: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file + ' :: ' + anchor.slice(0, 60));
+      if (stats) stats.anchorMissing += 1;
       return false;
     }
     src = src.replace(anchor, insert);
   }
   src = '// ' + MARKER + ': 侧栏「打开项目目录」+ 右键菜单（issue #85）\n' + src;
   try {
+    if (options && options.dryRun) {
+      log('open-project-dir 补丁: dry-run: 将应用 ' + file);
+      return false; // dryRun 不落盘，不计为已写
+    }
     writeFileAtomic(file, src);
     log('open-project-dir 补丁: 已应用 ' + file);
     return true;
@@ -163,7 +169,7 @@ function applyReplacements(file, replacements, log) {
  * @param {(msg: string) => void} [log]
  * @returns {number} 实际发生修改的文件数
  */
-function patchOpenProjectDir(nmRoot, log = () => {}) {
+function patchOpenProjectDir(nmRoot, log = () => {}, stats, options) {
   const targets = [
     {
       file: path.join(nmRoot, '@deepseek-ai', 'dsh-client-ui-workspace', 'lib', 'client.js'),
@@ -173,7 +179,7 @@ function patchOpenProjectDir(nmRoot, log = () => {}) {
   let changed = 0;
   for (const t of targets) {
     if (!fs.existsSync(t.file)) continue;
-    if (applyReplacements(t.file, t.replacements, log)) changed += 1;
+    if (applyReplacements(t.file, t.replacements, log, stats, options)) changed += 1;
   }
   return changed;
 }

--- a/dsh-desktop/scripts/patch-portable-template.js
+++ b/dsh-desktop/scripts/patch-portable-template.js
@@ -19,6 +19,14 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { writeFileAtomic } = require('./lib/patch-io');
 
+// 锚点失配 = 便携缓存补丁无法落地。若静默跳过（旧行为），electron-builder 仍会
+// 打包出「每次启动全量解压」的半成品便携包（性能退化且 CI 无感知）。这里改为
+// 阻断：写 stderr + 置非零退出码，使 npm run dist/pack 的 `&&` 链中断、CI 显式失败。
+function fail(msg) {
+  console.error('[portable-cache] 锚点失配（portable.nsi 结构已变更）：' + msg + '，已阻断打包');
+  process.exitCode = 1;
+}
+
 function patch() {
   const libPackage = require.resolve('app-builder-lib/package.json');
   const template = path.join(path.dirname(libPackage), 'templates', 'nsis', 'portable.nsi');
@@ -31,21 +39,24 @@ function patch() {
 
   const before = `  RMDir /r $INSTDIR\n  SetOutPath $INSTDIR\n`;
   if (!text.includes(before)) {
-    throw new Error('portable.nsi structure changed: missing initial extraction block');
+    fail('缺少初始解压块');
+    return;
   }
   const cacheCheck = `  ; DSH_PORTABLE_CACHE_PATCH: reuse previous extraction when version marker matches.\n  ClearErrors\n  FileOpen $R1 "$INSTDIR\\.dsh-portable-version" r\n  IfErrors dsh_portable_extract\n  FileClose $R1\n  IfFileExists "$INSTDIR\\\${APP_EXECUTABLE_FILENAME}" dsh_portable_has_exe dsh_portable_extract\ndsh_portable_has_exe:\n  FileOpen $R1 "$INSTDIR\\.dsh-portable-version" r\n  FileRead $R1 $R2\n  FileClose $R1\n  StrCmp $R2 "\${VERSION}" dsh_portable_run dsh_portable_extract\ndsh_portable_extract:\n  RMDir /r $INSTDIR\n  SetOutPath $INSTDIR\n`;
   text = text.replace(before, cacheCheck);
 
   const extractionEnd = `  !endif\n\n  System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_DIR", "$EXEDIR").r0'\n`;
   if (!text.includes(extractionEnd)) {
-    throw new Error('portable.nsi structure changed: missing extraction end block');
+    fail('缺少解压结束块');
+    return;
   }
   const markerAndRun = `  !endif\n\n  FileOpen $R1 "$INSTDIR\\.dsh-portable-version" w\n  FileWrite $R1 "\${VERSION}"\n  FileClose $R1\n\ndsh_portable_run:\n  System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_DIR", "$EXEDIR").r0'\n`;
   text = text.replace(extractionEnd, markerAndRun);
 
   const cleanup = `  SetOutPath $EXEDIR\n\tRMDir /r $INSTDIR\n`;
   if (!text.includes(cleanup)) {
-    throw new Error('portable.nsi structure changed: missing final cleanup block');
+    fail('缺少最终清理块');
+    return;
   }
   text = text.replace(cleanup, `    SetOutPath $EXEDIR\n    ; DSH_PORTABLE_CACHE_PATCH: keep the extracted cache for next launch.\n`);
 

--- a/dsh-desktop/scripts/patch-session-manage.js
+++ b/dsh-desktop/scripts/patch-session-manage.js
@@ -93,11 +93,11 @@ const CONN_FACADE_INSERT = 'archiveSession: (payload, signal) => this.callUnary(
 // 4. dsh-client-ui-workspace：会话行菜单「删除对话」+ 翻译
 // ---------------------------------------------------------------------------
 const UI_MENU_ANCHOR = '{\n\t\t\t\t\tid: "archive",\n\t\t\t\t\tlabel: t("menu.archiveSession"),\n\t\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconArchiveOutline20, { size: 16 })\n\t\t\t\t}\n\t\t\t];';
-const UI_MENU_INSERT = '{\n\t\t\t\t\tid: "archive",\n\t\t\t\t\tlabel: t("menu.archiveSession"),\n\t\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconArchiveOutline20, { size: 16 })\n\t\t\t\t},\n\t\t\t\t// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}\n\t\t\t];';
+const UI_MENU_INSERT = '{\n\t\t\t\t\tid: "archive",\n\t\t\t\t\tlabel: t("menu.archiveSession"),\n\t\t\t\t\ticon: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconArchiveOutline20, { size: 16 })\n\t\t\t\t},\n\t\t\t\t// dsh-desktop patch (session manage): 归档下方增加删除。\n\t\t\t\t// 桥 window.__dshSessionManager 由 dsh-session-manager 插件提供；桥缺失\n\t\t\t\t// 时隐藏「删除对话」项（显式降级，而非可选链静默无反应）。\n\t\t\t\t...(window.__dshSessionManager && typeof window.__dshSessionManager.deleteSession === "function" ? [{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}] : [])\n\t\t\t];';
 // 旧版补丁（v1：当前会话行不显示删除）→ 升级为无条件显示（用户反馈当前会话
-// 行的 ⋯ 菜单里看不到删除按钮）。
+// 行的 ⋯ 菜单里看不到删除按钮）。v2 起改为按桥可见性显示（桥缺失隐藏）。
 const UI_MENU_UPGRADE_ANCHOR = '...(node.id !== currentId ? [{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}] : [])';
-const UI_MENU_UPGRADE_INSERT = '{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}';
+const UI_MENU_UPGRADE_INSERT = '...(window.__dshSessionManager && typeof window.__dshSessionManager.deleteSession === "function" ? [{\n\t\t\t\t\tid: "delete",\n\t\t\t\t\tlabel: t("menu.deleteSession")\n\t\t\t\t}] : [])';
 
 const UI_SELECT_ANCHOR = 'if (id === "archive") onArchive(node.id);';
 const UI_SELECT_INSERT = 'if (id === "archive") onArchive(node.id);\n\t\t\t\t\t\t\t\t\tif (id === "delete") window.__dshSessionManager?.deleteSession(node.id);';
@@ -110,7 +110,7 @@ const UI_EN_INSERT = '"menu.archiveSession": "Archive session",\n\t\t\t"menu.del
 // ---------------------------------------------------------------------------
 // 工具：在文件中做「锚点必须存在 + 标记幂等」的替换
 // ---------------------------------------------------------------------------
-function applyReplacements(file, replacements, upgradeRules, log) {
+function applyReplacements(file, replacements, upgradeRules, log, stats, options) {
   let src;
   try {
     src = fs.readFileSync(file, 'utf8');
@@ -130,6 +130,10 @@ function applyReplacements(file, replacements, upgradeRules, log) {
     }
     if (upgraded) {
       try {
+        if (options && options.dryRun) {
+          log('session-manage 补丁: dry-run: 将升级 ' + file);
+          return false; // dryRun 不落盘，不计为已写
+        }
         writeFileAtomic(file, src);
         log('session-manage 补丁: 已升级 ' + file);
         return true;
@@ -144,12 +148,17 @@ function applyReplacements(file, replacements, upgradeRules, log) {
   for (const { anchor, insert } of replacements) {
     if (!src.includes(anchor)) {
       log('session-manage 补丁: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file + ' :: ' + anchor.slice(0, 60));
+      if (stats) stats.anchorMissing += 1;
       return false;
     }
     src = src.replace(anchor, insert);
   }
   src = '// ' + MARKER + ': 对话删除/归档管理运行时补丁\n' + src;
   try {
+    if (options && options.dryRun) {
+      log('session-manage 补丁: dry-run: 将应用 ' + file);
+      return false; // dryRun 不落盘，不计为已写
+    }
     writeFileAtomic(file, src);
     log('session-manage 补丁: 已应用 ' + file);
     return true;
@@ -165,7 +174,7 @@ function applyReplacements(file, replacements, upgradeRules, log) {
  * @param {(msg: string) => void} [log]
  * @returns {number} 实际发生修改的文件数
  */
-function patchSessionManage(nmRoot, log = () => {}) {
+function patchSessionManage(nmRoot, log = () => {}, stats, options) {
   const targets = [
     {
       file: path.join(nmRoot, '@deepseek-ai', 'dsh-workspace', 'lib', 'index.js'),
@@ -218,7 +227,7 @@ function patchSessionManage(nmRoot, log = () => {}) {
   let changed = 0;
   for (const t of targets) {
     if (!fs.existsSync(t.file)) continue;
-    if (applyReplacements(t.file, t.replacements, t.upgradeRules || [], log)) changed += 1;
+    if (applyReplacements(t.file, t.replacements, t.upgradeRules || [], log, stats, options)) changed += 1;
   }
   return changed;
 }

--- a/dsh-desktop/scripts/patch-session-persistence.js
+++ b/dsh-desktop/scripts/patch-session-persistence.js
@@ -18,18 +18,27 @@ const {
   transformPersistenceAll,
 } = require('./lib/runtime-patches');
 
-function patchSessionPersistence(nmRoot, log = () => {}) {
+function patchSessionPersistence(nmRoot, log = () => {}, stats, options = {}) {
   const file = path.join(nmRoot, '@deepseek-ai', PERSISTENCE_PKG_REL);
   if (!fs.existsSync(file)) return 0;
+  const doneLog = (target) => '已应用 zstd 尾部/损坏会话容错 ' + target;
   return applyPatchToFiles({
     prefix: '会话持久化容错补丁',
     files: [file],
     log,
     transform: transformPersistenceAll,
     alreadyLog: (target) => '已应用，跳过 ' + target,
-    doneLog: (target) => '已应用 zstd 尾部/损坏会话容错 ' + target,
-    anchorLog: log,
+    doneLog,
+    // CLI 场景经 applyRoot 透传 options：donePrefix=false 输出无前缀单行、
+    // anchorLog=warn 把失配走告警通道；缺省保持原默认（log / true）。
+    donePrefix: options && options.donePrefix,
+    anchorLog: (options && options.anchorLog) || log,
     failLog: (target, error) => '会话持久化容错补丁失败(' + target + '): ' + error.message,
+    // CLI 同步期 dry-run 经 applyRoot 透传 options.dryRun；dry-run 文案与
+    // sync-companion-plugins.js 的新容错措辞（将应用 zstd 尾部/损坏会话容错）一致。
+    dryRun: options && options.dryRun,
+    dryRunChangedLog: (target) => 'dry-run: 将应用 zstd 尾部/损坏会话容错 ' + target,
+    stats,
   });
 }
 

--- a/dsh-desktop/scripts/patch-web-search-baseurl.js
+++ b/dsh-desktop/scripts/patch-web-search-baseurl.js
@@ -125,7 +125,7 @@ function patchClient(src) {
  * @param {(msg: string) => void} [log]
  * @returns {number} 实际发生修改的文件数
  */
-function patchWebSearchBaseUrl(nmRoot, log = () => {}) {
+function patchWebSearchBaseUrl(nmRoot, log = () => {}, stats, options) {
   const targets = [
     path.join(nmRoot, '@deepseek-ai', 'dsh-web-search-deepseek', 'lib', 'index.js'),
     path.join(nmRoot, '@deepseek-ai', 'dsh-client-ui-settings-plugins', 'lib', 'client.js'),
@@ -144,6 +144,7 @@ function patchWebSearchBaseUrl(nmRoot, log = () => {}) {
     const result = patch(src);
     if (result.skipped) {
       log('web-search baseURL 补丁: 锚点未匹配（dsh 版本可能已变化），跳过 ' + file);
+      if (stats) stats.anchorMissing += 1;
       continue;
     }
     if (!result.changed) {
@@ -151,9 +152,13 @@ function patchWebSearchBaseUrl(nmRoot, log = () => {}) {
       continue; // 已应用（幂等）
     }
     try {
-      writeFileAtomic(file, result.src);
-      changedFiles += 1;
-      log('web-search baseURL 补丁: 已应用 ' + file);
+      if (options && options.dryRun) {
+        log('web-search baseURL 补丁: dry-run: 将应用 ' + file);
+      } else {
+        writeFileAtomic(file, result.src);
+        changedFiles += 1;
+        log('web-search baseURL 补丁: 已应用 ' + file);
+      }
     } catch (err) {
       log('web-search baseURL 补丁: 写入失败 ' + file + ': ' + err.message);
     }

--- a/dsh-desktop/scripts/sync-companion-plugins.js
+++ b/dsh-desktop/scripts/sync-companion-plugins.js
@@ -28,23 +28,14 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 
 const { installBuiltinPresets } = require('./install-minimal-win-preset');
 const { COMPANION_PLUGINS } = require('./lib/companion-plugins');
 const { CORE_BUNDLE_NAMES } = require('../profile-manifest');
 const { writeFileAtomic } = require('./lib/patch-io');
-const { applyPatchToFiles } = require('./lib/patch-engine');
+const { applyAll } = require('./integration/patch-runner');
+const { getSpecsByCli } = require('./lib/patch-registry');
 const { reconcileProfileBundles, createEntryListYamlParser } = require('./lib/profile-reconcile');
-const {
-  FLASH_PKG_REL, EXPOSE_PKG_REL, PW_REL, BASH_REL, CODE_PRESET_REL, patchTargets,
-  slotCompatPatchTargets,
-  transformFlashFix, transformExposeFix,
-  transformShellDescriptionOptional, transformCodeModeCompat,
-  transformAttachmentMimeTrust, ATTACH_LOCAL_REL,
-  transformLegacySlotKey, transformSlotUnkeyedCompat,
-  PERSISTENCE_PKG_REL, transformPersistenceAll,
-} = require('./lib/runtime-patches');
 const {
   ACP_DISABLE_BLOCK, PET_DISABLE_BLOCK,
   ensureDisabledPatchEntry, removeLegacyMarketplacePatchLines,
@@ -91,18 +82,41 @@ function packageDirFromBin(binPath) {
   return '';
 }
 
+// Windows 可执行扩展名（按 PATH 解析优先级）。
+const WINDOWS_PATHEXT = ['.com', '.exe', '.bat', '.cmd'];
+
+/**
+ * 纯 JS 的 PATH 命令解析：不做任何子进程 spawn。
+ *
+ * 旧实现用 `spawnSync('where.exe')`（Windows）/ `sh -lc 'command -v'`（POSIX），
+ * 在部分 Windows / Node 版本组合下会触发原生崩溃（0xC0000409 / ENOENT / exit
+ * 127），且依赖系统 where.exe。改为直接扫描 process.env.PATH 各目录：
+ *   - Windows：按 PATHEXT 扩展名探测，返回全部命中（对齐 where.exe -a 语义）；
+ *   - POSIX：按可执行位探测，返回第一个命中（对齐 command -v 语义）。
+ * 无子进程、无外部依赖、跨版本确定。
+ */
 function commandLocations(cmd) {
-  try {
-    const win = process.platform === 'win32';
-    const res = spawnSync(win ? 'where.exe' : 'sh', win ? [cmd] : ['-lc', `command -v ${cmd} 2>/dev/null || true`], {
-      encoding: 'utf8',
-      windowsHide: true,
-      timeout: 15000,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    if (res.status !== 0) return [];
-    return (res.stdout || '').split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
-  } catch { return []; }
+  const locations = [];
+  const entries = String(process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  const win = process.platform === 'win32';
+  for (const dir of entries) {
+    if (win) {
+      // 传入的 cmd 已含扩展名则直接探测，否则按 PATHEXT 顺序试探（含无扩展名形态）。
+      const names = cmd.includes('.') ? [cmd] : [cmd, ...WINDOWS_PATHEXT.map((ext) => cmd + ext)];
+      for (const name of names) {
+        const full = path.join(dir, name);
+        try { if (fs.statSync(full).isFile()) locations.push(full); } catch { /* 该形态不存在，继续 */ }
+      }
+    } else {
+      const full = path.join(dir, cmd);
+      try {
+        fs.accessSync(full, fs.constants.X_OK);
+        locations.push(full);
+        break; // POSIX 与 command -v 一致：取第一个可执行
+      } catch { /* 该目录无可执行，继续 */ }
+    }
+  }
+  return [...new Set(locations)];
 }
 
 function findDshPackageDir(home, explicit) {
@@ -264,134 +278,41 @@ function syncPlugins(home, dryRun, dshPkgDir) {
 }
 
 // ---------------------------------------------------------------------------
-// 运行时补丁（与 main.js applyRuntimeFlashFix / applyPromptExposeFix 共用
-// scripts/lib/runtime-patches.js 的同一变换）：覆盖 profile fallback 与壳托管
-// 安装目录 agent 两份副本；bundle 初始化后的 dsh 安装（npm 版）两份副本通常
-// 互为同一文件（fallback 符号链接写穿），幂等。
+// 运行时补丁：复用 patch-runner 的 applyAll + patch-registry 的 getSpecsByCli()，
+// 由 registry 的 cli:true 字段单一驱动（CLI 与 main.js 不再各持一份手写清单，
+// 杜绝漂移）。CLI 同步期仅应用 cli:true 的 9 个补丁（= 8 个 HEAD 原有补丁 +
+// 1 个 slot-error-isolation：第一轮 review 有意补漏的第三层错误隔离安全网）：
+//   slot-legacy-key / slot-unkeyed-compat / slot-error-isolation /
+//   runtime-flash-fix / prompt-expose-fix / shell-description-compat /
+//   code-mode-compat / attachment-mime-trust / session-persistence。
+// image-send / vision-key（宿主侧识图能力，仅桌面壳经 main.js 应用）与
+// guard 组 / 其余 package 组补丁 cli:false，不在同步期应用。
+//
+// 注：runtime-flash-fix 的 doneLog 与 registry 统一为「已修复会话列表刷新闪跳」，
+// 属有意修复历史文案漂移（非保持 CLI 历史文案），与 registry 单一数据源原则一致。
+//
+// ctx 构造：wslMode:true 走 spec.wslLayout（WSL 两份副本 profile fallback +
+// agent）；appDir/userDataDir 指向 os.tmpdir() 下刻意不存在的哨兵根（含 pid，
+// 唯一不可碰撞），使 resolveNmRoots 的 nm-roots 四根中仅 home 的 profile/agent
+// 两根存在（等价旧 patchTargets 两份副本），其余被 applyRoot 的 existsSync
+// 跳过。dry-run + donePrefix:false + anchorLog:warn 保持 CLI 历史日志契约。
 // ---------------------------------------------------------------------------
 
 function applyRuntimePatches(home, dryRun) {
-  // keyed slot 兼容：rc.6 旧插件把 keyed slot 的注册身份放在 `id`，rc.7
-  // 改为强制 `key`；更老的插件 key/id 都不传（dsh-advisor / dsh-llm-fallbacks），
-  // 会导致单个插件拖垮整个 loader。ui-slots 把旧 id 提升为 key；client-runner
-  // 为既无 key 又无 id 的注册派生包级兜底 key。覆盖顶层与嵌套依赖副本。
-  applyPatchToFiles({
-    prefix: 'keyed slot 旧插件兼容补丁',
-    files: slotCompatPatchTargets(home),
+  const cliCtx = {
+    home,
+    // 刻意不存在的哨兵根（os.tmpdir() + pid 唯一不可碰撞）：使 resolveNmRoots 的
+    // appDir/userDataDir 根被 existsSync 跳过，仅保留 home 的 profile/agent 两根。
+    // 用 tmpdir 而非 home 下固定名，避免与 home 下真实同名目录碰撞导致误扫描。
+    appDir: path.join(os.tmpdir(), 'dsh-cli-app-' + process.pid),
+    userDataDir: path.join(os.tmpdir(), 'dsh-cli-ud-' + process.pid),
+    wslMode: true,
     log: (m) => log(m),
-    anchorLog: (m) => warn(m),
-    transform: transformLegacySlotKey,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已兼容旧插件的 keyed slot id ' + file,
-    donePrefix: false,
-    failLog: (file, err) => 'keyed slot 旧插件兼容补丁失败(' + file + '): ' + err.message,
+  };
+  applyAll(cliCtx, getSpecsByCli(), {
     dryRun,
-    dryRunChangedLog: (file) => 'dry-run: 将兼容旧插件的 keyed slot id ' + file,
-  });
-  applyPatchToFiles({
-    prefix: 'keyed slot 无 key 兼容补丁',
-    files: slotCompatPatchTargets(home),
-    log: (m) => log(m),
-    anchorLog: (m) => warn(m),
-    transform: transformSlotUnkeyedCompat,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已兼容 keyed slot 无 key 注册 ' + file,
     donePrefix: false,
-    failLog: (file, err) => 'keyed slot 无 key 兼容补丁失败(' + file + '): ' + err.message,
-    dryRun,
-    dryRunChangedLog: (file) => 'dry-run: 将兼容 keyed slot 无 key 注册 ' + file,
-  });
-  // 会话列表刷新闪跳修复（mergeOrderedBaseline 保留本地新会话）。
-  applyPatchToFiles({
-    prefix: 'runtime 补丁',
-    files: patchTargets(home, FLASH_PKG_REL),
-    log: (m) => log(m),
     anchorLog: (m) => warn(m),
-    transform: (src) => transformFlashFix(src),
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已应用会话列表闪跳修复 ' + file,
-    donePrefix: false,
-    failLog: (file, err) => 'runtime 补丁失败(' + file + '): ' + err.message,
-    dryRun,
-    dryRunChangedLog: (file) => 'dry-run: 将应用会话列表闪跳修复 ' + file,
-  });
-
-  // 设置暴露白名单补丁（dsh-prompt / 第三方思考 / 识图 / 会话调整）。
-  applyPatchToFiles({
-    prefix: '提示词暴露补丁',
-    files: patchTargets(home, EXPOSE_PKG_REL),
-    log: (m) => log(m),
-    anchorLog: (m) => warn(m),
-    transform: transformExposeFix,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file, note) => '已把 ' + note.join(', ') + ' 加入设置白名单 ' + file,
-    donePrefix: false,
-    failLog: (file, err) => '提示词暴露补丁失败(' + file + '): ' + err.message,
-    dryRun,
-    dryRunChangedLog: (file, note) => 'dry-run: 将把 ' + note.join(', ') + ' 加入设置白名单 ' + file,
-  });
-
-  // shell 工具 description 可选化补丁（code 模式 run_code 程序常省略 description）。
-  for (const rel of [PW_REL, BASH_REL]) {
-    applyPatchToFiles({
-      prefix: 'shell description 兼容补丁',
-      files: patchTargets(home, rel),
-      log: (m) => log(m),
-      anchorLog: (m) => warn(m),
-      transform: transformShellDescriptionOptional,
-      alreadyLog: (file) => '已应用，跳过 ' + file,
-      doneLog: (file) => '已把 description 改为可选 ' + file,
-      donePrefix: false,
-      failLog: (file, err) => 'shell description 兼容补丁失败(' + file + '): ' + err.message,
-      dryRun,
-      dryRunChangedLog: (file) => 'dry-run: 将把 description 改为可选 ' + file,
-    });
-  }
-
-  // code preset 兼容补丁（code → both：保留 run_code，同时允许直接调用原生工具）。
-  applyPatchToFiles({
-    prefix: 'code 模式兼容补丁',
-    files: patchTargets(home, CODE_PRESET_REL),
-    log: (m) => log(m),
-    anchorLog: (m) => warn(m),
-    transform: transformCodeModeCompat,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已把 code preset 切换为 both ' + file,
-    donePrefix: false,
-    failLog: (file, err) => 'code 模式兼容补丁失败(' + file + '): ' + err.message,
-    dryRun,
-    dryRunChangedLog: (file) => 'dry-run: 将把 code preset 切换为 both ' + file,
-  });
-
-  // 图片字节信任补丁（浏览器声明的 MIME 跟随扩展名不可信，以解码字节为准）。
-  applyPatchToFiles({
-    prefix: '图片字节信任补丁',
-    files: patchTargets(home, ATTACH_LOCAL_REL),
-    log: (m) => log(m),
-    anchorLog: (m) => warn(m),
-    transform: transformAttachmentMimeTrust,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已信任图片解码字节 ' + file,
-    donePrefix: false,
-    failLog: (file, err) => '图片字节信任补丁失败(' + file + '): ' + err.message,
-    dryRun,
-    dryRunChangedLog: (file) => 'dry-run: 将信任图片解码字节 ' + file,
-  });
-
-  // 会话持久化容错：尾部擕裂的半条 JSONL 走崩溃恢复流程；整个日志损坏
-  // （坏帧头/零填充头）的会话告警跳过，不得击穿启动扫描。
-  applyPatchToFiles({
-    prefix: '会话持久化容错补丁',
-    files: patchTargets(home, PERSISTENCE_PKG_REL),
-    log: (m) => log(m),
-    anchorLog: (m) => warn(m),
-    transform: transformPersistenceAll,
-    alreadyLog: (file) => '已应用，跳过 ' + file,
-    doneLog: (file) => '已应用 zstd 尾部/损坏会话容错 ' + file,
-    donePrefix: false,
-    failLog: (file, err) => '会话持久化容错补丁失败(' + file + '): ' + err.message,
-    dryRun,
-    dryRunChangedLog: (file) => 'dry-run: 将应用 zstd 尾部/损坏会话容错 ' + file,
   });
 }
 

--- a/dsh-desktop/scripts/test/desktop-diagnostics.test.js
+++ b/dsh-desktop/scripts/test/desktop-diagnostics.test.js
@@ -256,3 +256,55 @@ test('runDiagnostics 报告携带自愈历史（sections + infos）', () => {
   assert.strictEqual(report.sections.selfHeal[0].kind, 'bundle');
   assert.ok(report.infos.some((i) => /最近启动自愈.*已自动移除.*dsh-vision/.test(i.message)));
 });
+
+test('readSelfHealHistory kind 白名单 + patch-layer backup 透传', () => {
+  const dir = tmpdir();
+  const file = path.join(dir, 'self-heal-history.json');
+  write(dir, 'self-heal-history.json', JSON.stringify([
+    { kind: 'patch-layer', names: ['补丁配置'], backup: 'C:\\Users\\alice\\.dsh\\cordis.patch.yml.broken-123', ts: 3000 },
+    { kind: 'bad-kind', names: ['x'], ts: 2000 },
+    { names: ['no-kind'], ts: 1000 },
+  ]));
+  const out = readSelfHealHistory(file, fs);
+  assert.strictEqual(out.length, 3);
+  // patch-layer 原样保留 + backup 透传 + names 存人类可读标签而非绝对路径
+  assert.strictEqual(out[0].kind, 'patch-layer');
+  assert.strictEqual(out[0].backup, 'C:\\Users\\alice\\.dsh\\cordis.patch.yml.broken-123');
+  assert.deepStrictEqual(out[0].names, ['补丁配置']);
+  // 未知 kind 兜底 bundle
+  assert.strictEqual(out[1].kind, 'bundle');
+  assert.deepStrictEqual(out[1].names, ['x']);
+  assert.strictEqual(out[1].backup, undefined);
+  // 缺 kind 字段兜底 bundle
+  assert.strictEqual(out[2].kind, 'bundle');
+  assert.deepStrictEqual(out[2].names, ['no-kind']);
+  assert.strictEqual(out[2].backup, undefined);
+});
+
+test('runDiagnostics 自愈历史 action 三态', () => {
+  const dir = tmpdir();
+  const profile = path.join(dir, 'profile');
+  write(profile, 'cordis.patch.yml', '[{"id":"web","insert":[]}]');
+  write(profile, 'package.json', JSON.stringify({ dsh: { profile: { bundles: [] } } }));
+  const hist = path.join(dir, 'self-heal-history.json');
+  write(dir, 'self-heal-history.json', JSON.stringify([
+    { kind: 'overlay', names: ['balance'], ts: Date.now() - 60000 },
+    { kind: 'patch-layer', names: ['补丁配置'], backup: path.join(dir, 'cordis.patch.yml.broken-1'), ts: Date.now() - 120000 },
+    { kind: 'bundle', names: ['@dsh-external/dsh-vision'], ts: Date.now() - 180000 },
+  ]));
+  const report = runDiagnostics({
+    profileDir: profile,
+    patchFile: path.join(profile, 'cordis.patch.yml'),
+    assetsDir: null,
+    coreDirDshAt: null,
+    crashDir: null,
+    logs: {},
+    selfHealHistoryFile: hist,
+    yaml: { load: (t) => JSON.parse(t) },
+    env: {},
+  }, fs);
+  assert.strictEqual(report.sections.selfHeal.length, 3);
+  assert.ok(report.infos.some((i) => /最近启动自愈.*已自动禁用.*balance/.test(i.message)));
+  assert.ok(report.infos.some((i) => /最近启动自愈.*已重置补丁配置.*cordis\.patch\.yml\.broken-1/.test(i.message)));
+  assert.ok(report.infos.some((i) => /最近启动自愈.*已自动移除.*dsh-vision/.test(i.message)));
+});

--- a/dsh-desktop/scripts/test/fixtures/plugin-inventory-tab-merge.golden.json
+++ b/dsh-desktop/scripts/test/fixtures/plugin-inventory-tab-merge.golden.json
@@ -1,0 +1,23 @@
+{
+  "id": "plugin-inventory-tab-merge",
+  "description": "插件页标签合并补丁三态 golden：匹配（changed）/ 已应用（already）/ 失配（anchor-missing）。",
+  "marker": "dsh-desktop fix: hide inventory tab",
+  "cases": {
+    "match": {
+      "input": "tabs = ctx.slots.entries(\"settings.plugins.tab\").map((entry) => ({",
+      "status": "changed",
+      "expectContains": [
+        ".filter((entry) => (entry.options.id ?? \"\") !== \"all\")",
+        "dsh-desktop fix: hide inventory tab"
+      ]
+    },
+    "already": {
+      "input": "// dsh-desktop fix: hide inventory tab\nconst x = 1;",
+      "status": "already"
+    },
+    "anchor-missing": {
+      "input": "export const x = 1;",
+      "status": "anchor-missing"
+    }
+  }
+}

--- a/dsh-desktop/scripts/test/unit-fault-isolation.test.js
+++ b/dsh-desktop/scripts/test/unit-fault-isolation.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// fault-isolation 单元测试（node --test）。
+// 覆盖：uiSlotsMarkers() 收集结果、preflight() 三态（已补丁 / 未覆盖 / 无
+// profile 早退）。回归背景（QA 发现）：uiSlotsMarkers 曾误用 spec.pkgRel
+// （单数）过滤，而 registry 的 slot 补丁用 pkgRels（复数数组），导致恒返回
+// []、preflight 恒误报「未覆盖」。本测试直接验证收集结果，拦住该回归。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { uiSlotsMarkers, preflight } = require('../integration/fault-isolation');
+const { SLOT_KEY_COMPAT_MARKER, SLOT_ERROR_ISOLATE_MARKER, SLOT_ERROR_ISOLATE_MARKER_V2 } = require('../lib/runtime-patches');
+const { SLOT_KEY_COMPAT_PKG_REL } = require('../lib/patch-target-resolver');
+const { markers } = require('../lib/patch-adapters');
+
+test('uiSlotsMarkers：收集 ui-slots 的 legacy-key 与 error-isolation（v1+v2）marker，不含 unkeyed', () => {
+  const markers = uiSlotsMarkers();
+  assert.ok(markers.includes(SLOT_KEY_COMPAT_MARKER), '应含 legacy keyed-slot marker');
+  assert.ok(markers.includes(SLOT_ERROR_ISOLATE_MARKER), '应含 error-isolation v1 marker（过渡兼容）');
+  assert.ok(markers.includes(SLOT_ERROR_ISOLATE_MARKER_V2), '应含 error-isolation v2 marker');
+  assert.equal(new Set(markers).size, markers.length, 'marker 不得重复');
+  // 不应包含从不写入 ui-slots 的 unkeyed-compat marker。
+  assert.ok(!markers.some((m) => m.includes('derive keyed slot key')), '不应含 unkeyed-compat marker');
+});
+
+function buildTree(t, uiSlotsContent) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-fault-isol-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  // profile manifest 带非空 bundles，使 preflight 越过早退。
+  const profileDir = path.join(root, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({ dsh: { profile: { bundles: ['fake-bundle'] } } }));
+  const uiSlotsFile = path.join(root, 'profiles', 'node_modules', '@deepseek-ai', SLOT_KEY_COMPAT_PKG_REL);
+  fs.mkdirSync(path.dirname(uiSlotsFile), { recursive: true });
+  fs.writeFileSync(uiSlotsFile, uiSlotsContent);
+  return { root, uiSlotsFile };
+}
+
+test('preflight：ui-slots 已打补丁 → 不误报、unpatched 为空', (t) => {
+  const { root } = buildTree(t, '// ' + SLOT_KEY_COMPAT_MARKER + '\nconst x = 1;\n');
+  const logs = [];
+  const report = preflight({
+    home: root,
+    appDir: path.join(os.tmpdir(), 'no-app'),
+    userDataDir: path.join(os.tmpdir(), 'no-ud'),
+    log: (m) => logs.push(m),
+  });
+  assert.deepEqual(report.unpatched, [], '已补丁态不得误报');
+  assert.equal(logs.length, 0, '已补丁态不得输出告警');
+});
+
+test('preflight：ui-slots 未打补丁（锚点失配）→ 记入 unpatched + 告警', (t) => {
+  const { root, uiSlotsFile } = buildTree(t, 'export const totallyDifferent = 1;\n');
+  const logs = [];
+  const report = preflight({
+    home: root,
+    appDir: path.join(os.tmpdir(), 'no-app'),
+    userDataDir: path.join(os.tmpdir(), 'no-ud'),
+    log: (m) => logs.push(m),
+  });
+  assert.deepEqual(report.unpatched, [uiSlotsFile], '未覆盖应记入 unpatched');
+  assert.ok(logs.some((m) => m.includes('ui-slots 文件未被补丁覆盖')), '应输出版本差异告警');
+  assert.ok(logs.some((m) => m.includes('建议:')), '应输出升级建议');
+});
+
+test('uiSlotsMarkers：返回严格等于 patch-adapters.markers 装配点（顺序 + 值同源）', () => {
+  // 验证 fault-isolation 的 marker 收集与 patch-adapters.markers 单一数据源严格一致，
+  // 杜绝「跨模块复制 marker 字面量导致漂移」的回归。
+  assert.deepEqual(
+    uiSlotsMarkers(),
+    [markers.SLOT_KEY_COMPAT_MARKER, markers.SLOT_ERROR_ISOLATE_MARKER, markers.SLOT_ERROR_ISOLATE_MARKER_V2],
+    'uiSlotsMarkers 必须严格等于 patch-adapters.markers 的装配点（含顺序）',
+  );
+  // 与 runtime-patches 导出的常量也逐项同源（三层 marker 单一数据源）。
+  assert.deepEqual(
+    uiSlotsMarkers(),
+    [SLOT_KEY_COMPAT_MARKER, SLOT_ERROR_ISOLATE_MARKER, SLOT_ERROR_ISOLATE_MARKER_V2],
+  );
+});
+
+test('preflight：无 profile manifest → 早退（scanned=0，不抛）', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-fault-isol-empty-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const report = preflight({
+    home: root,
+    appDir: path.join(os.tmpdir(), 'no-app'),
+    userDataDir: path.join(os.tmpdir(), 'no-ud'),
+    log: () => {},
+  });
+  assert.deepEqual(report, { scanned: 0, unpatched: [] });
+});

--- a/dsh-desktop/scripts/test/unit-host-capabilities.test.js
+++ b/dsh-desktop/scripts/test/unit-host-capabilities.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// host-capabilities 单元测试（node --test）。
+// 验证宿主能力清单、探测报告、降级告警文案与注入桥表达式。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  HOST_CAPABILITIES,
+  BRIDGE_EXPRS,
+  DELETE_SESSION_MENU_GUARD,
+  missingBridgeWarning,
+  probe,
+} = require('../lib/host-capabilities');
+
+test('清单声明 openPath（preload required）与 deleteSession（插件非 required）', () => {
+  assert.equal(HOST_CAPABILITIES.openPath.provider, 'preload');
+  assert.equal(HOST_CAPABILITIES.openPath.required, true);
+  assert.equal(HOST_CAPABILITIES.deleteSession.provider, 'dsh-session-manager');
+  assert.equal(HOST_CAPABILITIES.deleteSession.required, false);
+});
+
+test('桥表达式为可选链（桥缺失静默降级到 undefined）', () => {
+  assert.equal(BRIDGE_EXPRS.openPath, 'window.dshDesktop?.openPath');
+  assert.equal(BRIDGE_EXPRS.deleteSession, 'window.__dshSessionManager?.deleteSession');
+});
+
+test('deleteSession 菜单守卫在桥缺失时隐藏菜单项', () => {
+  assert.equal(
+    DELETE_SESSION_MENU_GUARD,
+    'window.__dshSessionManager && typeof window.__dshSessionManager.deleteSession === "function"',
+  );
+});
+
+test('probe：探测器给出布尔；缺失探测器返回 null（未知）', () => {
+  const r = probe({ openPath: () => true, deleteSession: () => false });
+  assert.equal(r.openPath.available, true);
+  assert.equal(r.deleteSession.available, false);
+  assert.equal(r.openPath.required, true);
+  const unknown = probe();
+  assert.equal(unknown.openPath.available, null);
+  assert.equal(unknown.deleteSession.available, null);
+});
+
+test('missingBridgeWarning：deleteSession 文案含插件名与隐藏提示', () => {
+  const w = missingBridgeWarning('deleteSession');
+  assert.ok(w.includes('dsh-session-manager'));
+  assert.ok(w.includes('隐藏'));
+  // 未知能力返回空串。
+  assert.equal(missingBridgeWarning('nope'), '');
+});
+
+test('桥契约一致性：patch 脚本注入的桥字符串与清单常量一致', () => {
+  // BRIDGE_EXPRS / DELETE_SESSION_MENU_GUARD 是「单一数据源」；patch-*.js 以
+  // 内联字符串注入到第三方源码。此处用契约一致性测试强制二者同步，防止漂移。
+  const openDirSrc = fs.readFileSync(path.join(__dirname, '..', 'patch-open-project-dir.js'), 'utf8');
+  const sessionManageSrc = fs.readFileSync(path.join(__dirname, '..', 'patch-session-manage.js'), 'utf8');
+  assert.ok(openDirSrc.includes(BRIDGE_EXPRS.openPath), 'patch-open-project-dir 应引用 openPath 桥');
+  assert.ok(sessionManageSrc.includes(DELETE_SESSION_MENU_GUARD), 'patch-session-manage 应引用 deleteSession 菜单守卫');
+  assert.ok(sessionManageSrc.includes(BRIDGE_EXPRS.deleteSession), 'patch-session-manage 应引用 deleteSession 桥');
+});

--- a/dsh-desktop/scripts/test/unit-open-project-dir.test.js
+++ b/dsh-desktop/scripts/test/unit-open-project-dir.test.js
@@ -27,11 +27,12 @@ test('补丁脚本：一次应用、二次幂等、anchor 缺失跳过且不损�
   assert.strictEqual(n, 1, '应补丁 1 个文件');
   const patched = fs.readFileSync(tree.file, 'utf8');
   assert.ok(patched.includes(MARKER), '应写入幂等标记');
-  assert.ok(patched.includes('window.__dshDesktopOpenDir?.(row.cwd)'), '项目行 open-folder 应调用桥');
-  assert.ok(patched.includes('window.__dshDesktopOpenDir?.(cwd)'), '会话行 open-folder 应调用桥');
+  assert.ok(patched.includes('window.dshDesktop?.openPath?.(row.cwd)'), '项目行 open-folder 应直接引用宿主 openPath');
+  assert.ok(patched.includes('window.dshDesktop?.openPath?.(cwd)'), '会话行 open-folder 应直接引用宿主 openPath');
   assert.ok(patched.includes('right: e.clientX + 1, bottom: e.clientY + 1'), '右键锚点矩形应含四边');
   assert.ok(patched.includes('getAnchorRect: () => menuRect'), '菜单应走 getAnchorRect');
   assert.ok(patched.includes('...(cwd ? [{'), '会话行 open-folder 应仅在 cwd 存在时显示');
+  assert.ok(patched.includes('window.__dshSessionManager && typeof window.__dshSessionManager.deleteSession === "function"'), '删除项应按桥可见性显示');
   assert.ok(patched.includes('"menu.openProjectDir": "打开项目目录"'), '应写入中文翻译');
   assert.ok(patched.includes('"menu.openProjectDir": "Open project directory"'), '应写入英文翻译');
   // 第二次：零写入且内容不变

--- a/dsh-desktop/scripts/test/unit-patch-adapters.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-adapters.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// patch-adapters 单元测试（node --test）。
+// 验证原 main.js 内联的 6 个 transform 声明化后，三态（匹配 / 失配 / 已应用）
+// 判定与注入字节级等价；runtime-patches 的 transform re-export 可用。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  transformVisionKeyFix,
+  transformProfilePatchGuard,
+  transformSettingsSectionGuard,
+  transformWorkspaceSearchRailFix,
+  transformPluginInventoryTabMergeFix,
+  transformImageSendFix,
+  transformFlashFix,
+} = require('../lib/patch-adapters');
+
+const VISION_MARKER = 'dsh-desktop fix: read the resolved HOST-side value';
+const VISION_FROM = '\tlet vision = null;\n\tif (settings !== void 0 && typeof settings.describe === "function") {\n\t\ttry {\n\t\t\tconst descriptor = settings.describe({ redactSecrets: true }).find((candidate) => String(candidate.ns) === "dsh-vision");\n\t\t\tif (descriptor !== void 0 && descriptor.value !== void 0 && typeof descriptor.value === "object") vision = descriptor.value;\n\t\t} catch {}\n\t}';
+
+test('transformVisionKeyFix：匹配 / 已应用 / 失配三态', () => {
+  const changed = transformVisionKeyFix(VISION_FROM, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(VISION_MARKER));
+  assert.ok(changed.src.includes('settings.get("dsh-vision")'));
+  // 已应用：marker 存在 → already
+  assert.equal(transformVisionKeyFix('// ' + VISION_MARKER, 't.js').status, 'already');
+  // 失配：无 from 锚点 → anchor-missing，绝不改写
+  const miss = transformVisionKeyFix('export const x = 1;', 't.js');
+  assert.equal(miss.status, 'anchor-missing');
+  assert.ok(miss.detail.includes('版本可能已变化'));
+});
+
+const PATCH_GUARD_CALL = '\t\tpatches: options.userLayer !== false && existsSync(patchPath) ? loadOverlayPatches(binName, patchPath) : []';
+const PATCH_GUARD_AFTER = '\treturn parsePatchList(binName, file, content, "overlay");\n}';
+
+test('transformProfilePatchGuard：匹配 / 已应用 / 失配三态', () => {
+  const src = PATCH_GUARD_CALL + '\n' + PATCH_GUARD_AFTER;
+  const changed = transformProfilePatchGuard(src, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes('function loadUserPatchLayer'));
+  assert.ok(changed.src.includes('patches: loadUserPatchLayer(binName, patchPath, options)'));
+  // 已应用：marker（function loadUserPatchLayer）存在 → already
+  assert.equal(transformProfilePatchGuard('function loadUserPatchLayer', 't.js').status, 'already');
+  // 失配：缺少 callSite/insertAfter
+  const miss = transformProfilePatchGuard('export const x = 1;', 't.js');
+  assert.equal(miss.status, 'anchor-missing');
+});
+
+const SETTINGS_MARKER = 'dsh-desktop guard: an invalid stored section must not brick';
+const SETTINGS_ANCHOR = '\t\tconst scope = sctx.settings.register(ns, schema, {';
+
+test('transformSettingsSectionGuard：匹配 / 已应用 / 失配三态', () => {
+  const src = '\t\tconst scope = sctx.settings.register(ns, schema, {\n\t\t\tbase: entry,\n\t\t\t...hooks.validate === void 0 ? {} : { validate: hooks.validate }\n\t\t});\n\t\thooks.setSource(() => scope.get());';
+  const changed = transformSettingsSectionGuard(src, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(SETTINGS_MARKER));
+  assert.ok(changed.src.includes('let scope;'));
+  assert.equal(transformSettingsSectionGuard('// ' + SETTINGS_MARKER, 't.js').status, 'already');
+  const miss = transformSettingsSectionGuard('export const x = 1;', 't.js');
+  assert.equal(miss.status, 'anchor-missing');
+});
+
+const RAIL_MARKER = 'dsh-desktop fix: rail search expansion';
+const RAIL_OLD_GUARD = '\t\t\t\tif (!wide || !searchExpanded) return;';
+const RAIL_OLD_DEPS = '\t\t\t}, [\n\t\t\t\tnormalizedQuery,\n\t\t\t\twide,\n\t\t\t\tsearchExpanded\n\t\t\t]);';
+
+test('transformWorkspaceSearchRailFix：匹配 / 已应用 / 失配三态', () => {
+  const src = RAIL_OLD_GUARD + '\n' + RAIL_OLD_DEPS;
+  const changed = transformWorkspaceSearchRailFix(src, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(RAIL_MARKER));
+  assert.ok(changed.src.includes('searchOnExpand'));
+  assert.equal(transformWorkspaceSearchRailFix('// ' + RAIL_MARKER, 't.js').status, 'already');
+  // 两个锚点缺一即失配
+  assert.equal(transformWorkspaceSearchRailFix(RAIL_OLD_GUARD, 't.js').status, 'anchor-missing');
+});
+
+const TAB_MARKER = 'dsh-desktop fix: hide inventory tab';
+const TAB_OLD = 'tabs = ctx.slots.entries("settings.plugins.tab").map((entry) => ({';
+
+test('transformPluginInventoryTabMergeFix：匹配 / 已应用 / 失配三态', () => {
+  const changed = transformPluginInventoryTabMergeFix(TAB_OLD, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(TAB_MARKER));
+  assert.ok(changed.src.includes('.filter((entry) => (entry.options.id ?? "") !== "all")'));
+  assert.equal(transformPluginInventoryTabMergeFix('// ' + TAB_MARKER, 't.js').status, 'already');
+  assert.equal(transformPluginInventoryTabMergeFix('export const x = 1;', 't.js').status, 'anchor-missing');
+});
+
+test('transformImageSendFix：已应用 / 失配（helper 锚点缺失）', () => {
+  assert.equal(transformImageSendFix('DSH Desktop: reuse the dsh-vision VLM config', 't.js').status, 'already');
+  const miss = transformImageSendFix('export const x = 1;', 't.js');
+  assert.equal(miss.status, 'anchor-missing');
+  assert.ok(miss.detail.includes('helper 插入锚点'));
+});
+
+test('transformImageSendFix：完整匹配注入 helper / admittedContent / 门槛替换', () => {
+  const src = [
+    '/** Validate one prompt as a batch before publishing any durable image object. */',
+    'const hasImage = content.some((part) => part.type === "image");',
+    'if (modelInfo.inputModalities !== void 0 && !modelInfo.inputModalities.includes("image")) return err(request, {',
+    '\t\t\t\tcode: "no-image"',
+    '\t\t\t});',
+    'durablePromptContent(ctx, content);',
+  ].join('\n');
+  const changed = transformImageSendFix(src, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes('async function describeImagesWithVision'));
+  assert.ok(changed.src.includes('let admittedContent = content;'));
+  assert.ok(changed.src.includes('admittedContent = await describeImagesWithVision(ctx, content)'));
+  assert.ok(changed.src.includes('durablePromptContent(ctx, admittedContent)'));
+  // 已应用后幂等
+  assert.equal(transformImageSendFix(changed.src, 't.js').status, 'already');
+});
+
+test('runtime transform re-export 可用', () => {
+  // 仅验证 re-export 链路通：flash 变换的已应用判定。
+  const src = '(value) => baselineByKey.get(keyOf(value)) ?? value).filter((value) => value !== void 0);';
+  assert.equal(transformFlashFix(src, 't.js').status, 'already');
+});
+
+test('golden fixture：插件页标签合并补丁三态', () => {
+  const fixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures', 'plugin-inventory-tab-merge.golden.json'), 'utf8'));
+  assert.equal(fixture.id, 'plugin-inventory-tab-merge');
+  const { match, already, 'anchor-missing': missing } = fixture.cases;
+  const m = transformPluginInventoryTabMergeFix(match.input, 't.js');
+  assert.equal(m.status, match.status);
+  for (const needle of match.expectContains) assert.ok(m.src.includes(needle), needle);
+  assert.equal(transformPluginInventoryTabMergeFix(already.input, 't.js').status, already.status);
+  assert.equal(transformPluginInventoryTabMergeFix(missing.input, 't.js').status, missing.status);
+});

--- a/dsh-desktop/scripts/test/unit-patch-adapters.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-adapters.test.js
@@ -124,6 +124,17 @@ test('runtime transform re-export 可用', () => {
   assert.equal(transformFlashFix(src, 't.js').status, 'already');
 });
 
+test('transformPersistenceAll re-export 可用（损坏会话容错收口，勿回退旧名）', () => {
+  // 语义修正：session-persistence 已从 transformPersistenceTornTail 升级为
+  // transformPersistenceAll（含 #112 损坏会话容错），patch-adapters 的 re-export
+  // 必须同步，且不得残留旧导出名。
+  const adapters = require('../lib/patch-adapters');
+  assert.equal(typeof adapters.transformPersistenceAll, 'function', '应 re-export transformPersistenceAll');
+  assert.equal(adapters.transformPersistenceTornTail, undefined, '不应再导出旧的 transformPersistenceTornTail');
+  // re-export 的 transformPersistenceAll 应能实际执行（失配 → anchor-missing）。
+  assert.equal(adapters.transformPersistenceAll('export const x = 1;', 't.js').status, 'anchor-missing');
+});
+
 test('golden fixture：插件页标签合并补丁三态', () => {
   const fixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures', 'plugin-inventory-tab-merge.golden.json'), 'utf8'));
   assert.equal(fixture.id, 'plugin-inventory-tab-merge');

--- a/dsh-desktop/scripts/test/unit-patch-registry.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-registry.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+// patch-registry 单元测试（node --test）。
+// 验证 PATCH_SPECS 清单完整、字段契约、分组与顺序、marker 与 transform 的
+// 幂等判定同源。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { PATCH_SPECS, getSpecsByGroup, getSpecsByCli } = require('../lib/patch-registry');
+const { SLOT_KEY_COMPAT_PKG_REL, SLOT_COMPAT_PKG_RELS } = require('../lib/patch-target-resolver');
+const { SLOT_KEY_COMPAT_MARKER, SLOT_ERROR_ISOLATE_MARKER, SLOT_ERROR_ISOLATE_MARKER_V2 } = require('../lib/runtime-patches');
+
+test('清单非空、id 唯一、order 升序', () => {
+  assert.ok(PATCH_SPECS.length >= 19, '应覆盖全部运行时补丁');
+  const ids = PATCH_SPECS.map((s) => s.id);
+  assert.equal(new Set(ids).size, ids.length, 'id 必须唯一');
+  const ordered = getSpecsByGroup();
+  for (let i = 1; i < ordered.length; i += 1) {
+    assert.ok(ordered[i - 1].order <= ordered[i].order, `order 应按升序（${ordered[i - 1].id} → ${ordered[i].id}）`);
+  }
+});
+
+test('每个 file 补丁都声明 transform；每个 root 补丁都声明 apply', () => {
+  for (const spec of PATCH_SPECS) {
+    if (spec.kind === 'file') {
+      assert.equal(typeof spec.transform, 'function', `${spec.id} 缺 transform`);
+      assert.ok(spec.layout, `${spec.id} 缺 layout`);
+      if (spec.layout !== 'profile-boot-dirs') {
+        assert.ok(spec.pkgRel || (spec.pkgRels && spec.pkgRels.length > 0), `${spec.id} 缺 pkgRel/pkgRels`);
+      }
+    } else if (spec.kind === 'root') {
+      assert.equal(typeof spec.apply, 'function', `${spec.id} 缺 apply`);
+      assert.equal(typeof spec.successLog, 'function', `${spec.id} 缺 successLog`);
+      assert.equal(typeof spec.failLog, 'function', `${spec.id} 缺 failLog`);
+    }
+  }
+});
+
+test('分组查询返回有序子集', () => {
+  const groups = ['runtime', 'guard', 'package'];
+  for (const g of groups) {
+    const specs = getSpecsByGroup(g);
+    assert.ok(specs.length > 0, `${g} 分组非空`);
+    for (const s of specs) assert.equal(s.group, g);
+    for (let i = 1; i < specs.length; i += 1) {
+      assert.ok(specs[i - 1].order <= specs[i].order);
+    }
+  }
+});
+
+test('slot 三层共用 slot-compat 布局与 pkgRels', () => {
+  const slotIds = ['slot-legacy-key', 'slot-unkeyed-compat', 'slot-error-isolation'];
+  for (const id of slotIds) {
+    const spec = PATCH_SPECS.find((s) => s.id === id);
+    assert.ok(spec, id);
+    assert.equal(spec.layout, 'slot-compat');
+    assert.equal(spec.wslLayout, 'slot-compat-wsl');
+    assert.deepEqual(spec.pkgRels, SLOT_COMPAT_PKG_RELS);
+  }
+});
+
+test('ui-slots 预检 marker 与 transform 幂等判定同源（slot 三层）', () => {
+  // slot 三层各自声明 marker（与 transform 的 already 判定同源）。
+  const byId = Object.fromEntries(PATCH_SPECS.map((s) => [s.id, s]));
+  assert.equal(byId['slot-legacy-key'].marker, SLOT_KEY_COMPAT_MARKER, 'legacy-key marker 同源');
+  // slot-error-isolation 已修复为 v2（warn + 派生 key，不 throw），marker 须为 V2。
+  assert.equal(byId['slot-error-isolation'].marker, SLOT_ERROR_ISOLATE_MARKER_V2, 'error-isolation marker 应为 V2');
+  assert.notEqual(byId['slot-error-isolation'].marker, SLOT_ERROR_ISOLATE_MARKER, 'error-isolation 不得再用 v1 marker');
+});
+
+test('所有 spec 的 marker 均引用共享常量（单一数据源，无内联复制）', () => {
+  const { markers } = require('../lib/patch-adapters');
+  // 每个声明了 marker 的 spec，其 marker 值必须与 patch-adapters 的 markers 清单
+  // 中的某个常量严格相等——杜绝「registry 内联字面量与 transform 常量复制漂移」。
+  const known = new Set(Object.values(markers));
+  for (const spec of PATCH_SPECS) {
+    if (spec.marker === null || spec.marker === undefined) continue;
+    assert.ok(known.has(spec.marker), `${spec.id} 的 marker 未引用共享常量，而是内联复制`);
+  }
+});
+
+test('防护类补丁与包级补丁均已登记（无遗漏 apply*）', () => {
+  const ids = new Set(PATCH_SPECS.map((s) => s.id));
+  const expected = [
+    'slot-legacy-key', 'slot-unkeyed-compat', 'slot-error-isolation',
+    'runtime-flash-fix', 'prompt-expose-fix', 'shell-description-compat',
+    'code-mode-compat', 'image-send-fix', 'attachment-mime-trust', 'vision-key-fix',
+    'profile-patch-guard', 'profile-bundle-guard-appboot', 'profile-bundle-guard-profileboot',
+    'settings-section-guard', 'workspace-search-rail-fix', 'plugin-inventory-tab-merge',
+    'web-search-baseurl', 'menu-viewport', 'session-manage', 'open-project-dir',
+    'session-persistence',
+  ];
+  for (const id of expected) assert.ok(ids.has(id), `遗漏补丁 ${id}`);
+});
+
+test('getSpecsByCli：返回 9 个 cli:true 补丁（8 runtime + session-persistence）', () => {
+  const specs = getSpecsByCli();
+  assert.equal(specs.length, 9, 'cli 清单应恰为 9 项');
+  const expected = new Set([
+    'slot-legacy-key', 'slot-unkeyed-compat', 'slot-error-isolation',
+    'runtime-flash-fix', 'prompt-expose-fix', 'shell-description-compat',
+    'code-mode-compat', 'attachment-mime-trust', 'session-persistence',
+  ]);
+  assert.deepEqual(new Set(specs.map((s) => s.id)), expected, 'cli 清单 id 集合不符');
+  for (const s of specs) assert.equal(s.cli, true, `${s.id} 应标记 cli:true`);
+  for (let i = 1; i < specs.length; i += 1) {
+    assert.ok(specs[i - 1].order <= specs[i].order, 'cli 清单应按 order 升序');
+  }
+});
+
+test('failPolicy：slot-error-isolation=degrade，其余=warn', () => {
+  const byId = Object.fromEntries(PATCH_SPECS.map((s) => [s.id, s]));
+  assert.equal(byId['slot-error-isolation'].failPolicy, 'degrade', 'slot-error-isolation 应为 degrade');
+  for (const spec of PATCH_SPECS) {
+    if (spec.id === 'slot-error-isolation') continue;
+    assert.equal(spec.failPolicy, 'warn', `${spec.id} 的 failPolicy 应为 warn`);
+  }
+});
+
+test('getSpecsByCli：每个 spec 的 transform/apply 与 patch-adapters 导出同源（无漂移）', () => {
+  const adapters = require('../lib/patch-adapters');
+  // CLI 同步期的 8 个 file 补丁 transform + 1 个 root 补丁 apply，逐一与唯一
+  // 装配层（patch-adapters）导出严格同源，杜绝 registry 复制一份实现导致漂移。
+  const transformMap = {
+    'slot-legacy-key': adapters.transformLegacySlotKey,
+    'slot-unkeyed-compat': adapters.transformSlotUnkeyedCompat,
+    'slot-error-isolation': adapters.transformSlotErrorIsolation,
+    'runtime-flash-fix': adapters.transformFlashFix,
+    'prompt-expose-fix': adapters.transformExposeFix,
+    'shell-description-compat': adapters.transformShellDescriptionOptional,
+    'code-mode-compat': adapters.transformCodeModeCompat,
+    'attachment-mime-trust': adapters.transformAttachmentMimeTrust,
+  };
+  for (const spec of getSpecsByCli()) {
+    if (spec.kind === 'root') {
+      assert.equal(spec.apply, adapters.rootAppliers.patchSessionPersistence, `${spec.id} 的 apply 应与 rootAppliers 同源`);
+    } else {
+      assert.equal(spec.transform, transformMap[spec.id], `${spec.id} 的 transform 应与 patch-adapters 导出同源`);
+    }
+  }
+});

--- a/dsh-desktop/scripts/test/unit-patch-runner.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-runner.test.js
@@ -1,0 +1,300 @@
+'use strict';
+
+// patch-runner 单元测试（node --test）。
+// 覆盖：applyFile 对 slot-compat 布局不再双重处理；applyAll 的 failPolicy
+// 三档分级落地（warn / degrade / fatal）与汇总日志。补丁目标目录经 mkdtemp
+// 隔离，绝不触碰真实 ~/.dsh。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { applyFile, applyAll, applyRoot, resolveFiles } = require('../integration/patch-runner');
+const { PATCH_SPECS } = require('../lib/patch-registry');
+const { SLOT_COMPAT_PKG_RELS, resolveNmRoots } = require('../lib/patch-target-resolver');
+const { patchSessionPersistence } = require('../patch-session-persistence');
+
+function makeCtx(t) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-runner-home-'));
+  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-runner-app-'));
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-runner-ud-'));
+  t.after(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(appDir, { recursive: true, force: true });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+  const logs = [];
+  return { home, appDir, userDataDir, logs, log: (m) => logs.push(m), wslMode: false };
+}
+
+test('applyFile：slot-compat 布局每个目标文件只被处理一次（不双重处理）', (t) => {
+  const ctx = makeCtx(t);
+  const spec = PATCH_SPECS.find((s) => s.id === 'slot-legacy-key');
+
+  // 在 profile fallback 根创建 ui-slots / cordis-client-runner 两个目标文件，
+  // 用计数 transform 统计每个文件被调用的次数。
+  const created = [];
+  for (const rel of SLOT_COMPAT_PKG_RELS) {
+    const f = path.join(ctx.home, 'profiles', 'node_modules', '@deepseek-ai', rel);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, 'const x = 1;\n');
+    created.push(f);
+  }
+  const calls = new Map();
+  const counting = (src, file) => {
+    calls.set(file, (calls.get(file) || 0) + 1);
+    return { status: 'anchor-missing', detail: 'x' };
+  };
+  applyFile(ctx, { ...spec, transform: counting });
+
+  // 每个被创建的目标文件恰好被处理一次。
+  for (const f of created) {
+    assert.equal(calls.get(f) || 0, 1, `${f} 应恰好处理一次，实际 ${calls.get(f)}`);
+  }
+  // 不应存在任何文件被处理超过一次。
+  for (const [f, n] of calls) assert.ok(n <= 1, `${f} 被重复处理 ${n} 次`);
+});
+
+// 构造一个会让 resolveFiles 抛出「规格级异常」的 file 规格（缺 pkgRel/pkgRels
+// 且布局依赖 pkgRel），以触发 applyAll 的 catch 分支（逐文件异常由
+// applyPatchToFiles 内部吸收，不会传到 applyAll）。
+function throwingFileSpec(id, order, failPolicy) {
+  return {
+    id, group: 'runtime', order, kind: 'file', layout: 'runtime-local', wslLayout: 'wsl',
+    requires: [], failPolicy,
+    transform: () => ({ status: 'already' }),
+    logs: {},
+  };
+}
+
+// 构造一个会命中单个真实落盘文件的 file spec（transform 可注入），供
+// stats（anchorMissing / failed）回流断言使用。
+function fileSpec(id, transform, { pkgRel = path.join('dsh-client-runtime', 'lib', 'client.js'), failPolicy = 'warn', order = 1 } = {}) {
+  return {
+    id, group: 'runtime', order, kind: 'file', layout: 'runtime-local', wslLayout: 'wsl',
+    pkgRel, requires: [], failPolicy, transform, logs: { prefix: id },
+  };
+}
+
+// 在 ctx.home 的 runtime-local 第一落点写入一个真实文件，返回绝对路径。
+// 仅创建一个副本，其余两个落点不存在会被 applyPatchToFiles 静默跳过，
+// 从而让 transform 恰好执行一次，便于断言 stats 计数精确回流。
+function writeRuntimeFile(ctx, pkgRel = path.join('dsh-client-runtime', 'lib', 'client.js')) {
+  const f = path.join(ctx.home, 'profiles', 'node_modules', '@deepseek-ai', pkgRel);
+  fs.mkdirSync(path.dirname(f), { recursive: true });
+  fs.writeFileSync(f, 'const x = 1;\n');
+  return f;
+}
+
+test('applyAll：failPolicy=warn 异常进 errors，不中断后续补丁', () => {
+  const logs = [];
+  const ctx = { home: 'x', appDir: 'y', userDataDir: 'z', wslMode: false, log: (m) => logs.push(m) };
+  const report = applyAll(ctx, [
+    throwingFileSpec('boom', 1, 'warn'),
+    throwingFileSpec('ok', 2, 'warn'),
+  ]);
+  assert.deepEqual(report.errors, ['boom', 'ok'], 'warn 异常应记入 errors');
+});
+
+test('applyAll：failPolicy=degrade / fatal 异常进 degraded，不 throw', () => {
+  const logs = [];
+  const ctx = { home: 'x', appDir: 'y', userDataDir: 'z', wslMode: false, log: (m) => logs.push(m) };
+  const report = applyAll(ctx, [
+    throwingFileSpec('deg', 1, 'degrade'),
+    throwingFileSpec('fat', 2, 'fatal'),
+  ]);
+  assert.deepEqual(report.degraded, ['deg', 'fat'], 'degrade/fatal 异常应记入 degraded');
+  assert.equal(report.errors.length, 0, 'degrade/fatal 不得记入 errors');
+});
+
+test('applyAll：输出汇总日志（避免部分失败静默）', () => {
+  const logs = [];
+  const ctx = { home: 'x', appDir: 'y', userDataDir: 'z', wslMode: false, log: (m) => logs.push(m) };
+  applyAll(ctx, [throwingFileSpec('boom', 1, 'warn')]);
+  assert.ok(logs.some((m) => m.includes('补丁应用汇总')), '应输出汇总日志');
+});
+
+test('applyAll：transform 返回 anchor-missing → report.anchorMissing 回流', (t) => {
+  const ctx = makeCtx(t);
+  writeRuntimeFile(ctx);
+  const report = applyAll(ctx, [
+    fileSpec('am', () => ({ status: 'anchor-missing', detail: '锚点失配' })),
+  ]);
+  assert.equal(report.anchorMissing, 1, 'anchor-missing 应回流到 report.anchorMissing');
+});
+
+test('applyAll：transform 抛异常 → report.failed 回流（不记入规格级 errors）', (t) => {
+  const ctx = makeCtx(t);
+  writeRuntimeFile(ctx);
+  const report = applyAll(ctx, [
+    fileSpec('tf', () => { throw new Error('boom'); }),
+  ]);
+  assert.equal(report.failed, 1, '逐文件异常应回流到 report.failed');
+  assert.equal(report.errors.length, 0, '逐文件异常不记入规格级 errors');
+});
+
+test('applyAll：failPolicy=degrade 且 anchorMissing>0 → 记入 degraded（互斥，不重复计入 anchorMissing）', (t) => {
+  const ctx = makeCtx(t);
+  writeRuntimeFile(ctx);
+  const report = applyAll(ctx, [
+    fileSpec('deg-am', () => ({ status: 'anchor-missing', detail: '失配' }), { failPolicy: 'degrade' }),
+  ]);
+  assert.ok(report.degraded.includes('deg-am'), 'degrade + anchorMissing 应记入 degraded');
+  assert.equal(report.anchorMissing, 0, 'degrade 档失配只进 degraded，不得重复计入 anchorMissing（互斥）');
+});
+
+test('applyAll：failPolicy=warn 且 anchorMissing>0 → 只进 anchorMissing，不进 degraded（互斥）', (t) => {
+  const ctx = makeCtx(t);
+  writeRuntimeFile(ctx);
+  const report = applyAll(ctx, [
+    fileSpec('warn-am', () => ({ status: 'anchor-missing', detail: '失配' }), { failPolicy: 'warn' }),
+  ]);
+  assert.equal(report.anchorMissing, 1, 'warn 档失配只进 anchorMissing');
+  assert.ok(!report.degraded.includes('warn-am'), 'warn 档失配不得进 degraded');
+});
+
+test('applyAll：互斥分流汇总日志——失配 N 只反映 warn 档，降级 J 含 degrade 档', (t) => {
+  const ctx = makeCtx(t);
+  writeRuntimeFile(ctx);
+  const report = applyAll(ctx, [
+    fileSpec('warn-am', () => ({ status: 'anchor-missing', detail: '失配' }), { failPolicy: 'warn', order: 1 }),
+    fileSpec('deg-am', () => ({ status: 'anchor-missing', detail: '失配' }), { failPolicy: 'degrade', order: 2 }),
+  ]);
+  assert.equal(report.anchorMissing, 1, '互斥分流：anchorMissing 只计 warn 档（1 项）');
+  assert.deepEqual(report.degraded, ['deg-am'], 'degraded 只含 degrade 档 spec.id');
+  const summary = ctx.logs.find((m) => m.includes('补丁应用汇总'));
+  assert.ok(summary, '应输出汇总日志');
+  assert.ok(summary.includes('失配 1 项'), `汇总「失配」应只反映 warn 档：${summary}`);
+  assert.ok(summary.includes('降级 1 项'), `汇总「降级」应含 degrade 档：${summary}`);
+});
+
+test('applyAll：规格级异常也计入 report.total（不再低报）', () => {
+  const logs = [];
+  const ctx = { home: 'x', appDir: 'y', userDataDir: 'z', wslMode: false, log: (m) => logs.push(m) };
+  const report = applyAll(ctx, [throwingFileSpec('boom', 1, 'warn')]);
+  assert.equal(report.total, 1, '规格级异常也应计入 total');
+  assert.ok(report.errors.includes('boom'), '异常仍记入 errors');
+});
+
+// ---------------------------------------------------------------------------
+// 上一轮重构补漏（P0）：applyRoot 逐根容错 / root anchor-missing 回流 /
+// requires 降级链 / dryRun·donePrefix 场景参数 / fatal→degrade 语义。
+// ---------------------------------------------------------------------------
+
+/** 构造一个 kind='root' 规格（apply / successLog / failLog 可注入）。 */
+function rootSpec(id, applyFn, { failPolicy = 'warn' } = {}) {
+  return {
+    id, group: 'package', order: 1, kind: 'root', layout: 'nm-roots', wslLayout: 'nm-roots',
+    apply: applyFn, requires: [], failPolicy,
+    successLog: (root) => 'ok ' + root,
+    failLog: (root, err) => 'fail ' + root + ': ' + err.message,
+  };
+}
+
+test('applyRoot：逐根容错——单根异常计入 stats.failed，其余根仍被处理，不 throw', (t) => {
+  const ctx = makeCtx(t);
+  const roots = resolveNmRoots(ctx, { layout: 'nm-roots' });
+  // 只创建前两根（home/appDir），第三根（userDataDir/agent/node_modules）不存在 → 跳过。
+  fs.mkdirSync(roots[0], { recursive: true });
+  fs.mkdirSync(roots[1], { recursive: true });
+
+  let secondProcessed = false;
+  const stats = { anchorMissing: 0, failed: 0 };
+  const spec = rootSpec('rt', (root) => {
+    if (root === roots[0]) throw new Error('boom');
+    secondProcessed = true;
+    return 1;
+  });
+
+  const written = applyRoot(ctx, spec, stats);
+  assert.equal(stats.failed, 1, '抛异常的根应计入 stats.failed');
+  assert.equal(written, 1, '另一个根仍应写入并计数');
+  assert.ok(secondProcessed, '第二个根应被继续处理（不被第一个根异常拖垮）');
+});
+
+test('applyAll：root 补丁 anchor-missing 经真实 patchSessionPersistence 回流', (t) => {
+  const ctx = makeCtx(t);
+  // 在 home 的 nm-root 落点创建不含任何锚点的 dsh-session-persistence-jsonl 文件。
+  const spec = PATCH_SPECS.find((s) => s.id === 'session-persistence');
+  const root = path.join(ctx.home, 'profiles', 'node_modules');
+  const file = path.join(root, '@deepseek-ai', 'dsh-session-persistence-jsonl', 'lib', 'index.js');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, 'export const x = 1;\n');
+
+  const report = applyAll(ctx, [spec]);
+  assert.equal(report.anchorMissing, 1, 'root 应用器 anchor-missing 应回流到 report.anchorMissing');
+  assert.equal(report.failed, 0, '失配不应计为 failed');
+});
+
+test('applyAll：requires 降级链（openPath required→degraded；deleteSession 非 required→warnings）', () => {
+  const logs = [];
+  const ctx = {
+    home: 'x', appDir: 'y', userDataDir: 'z', wslMode: false,
+    log: (m) => logs.push(m),
+    hostDetectors: { openPath: () => false, deleteSession: () => false },
+  };
+  const mk = (id, requires) => ({
+    id, group: 'runtime', order: 1, kind: 'file', layout: 'runtime-local', wslLayout: 'wsl',
+    pkgRel: path.join('dsh-client-runtime', 'lib', 'client.js'), requires, failPolicy: 'warn',
+    transform: () => ({ status: 'already' }), logs: { prefix: id },
+  });
+  const report = applyAll(ctx, [
+    mk('needs-open-path', ['openPath']),
+    mk('needs-delete-session', ['deleteSession']),
+  ]);
+  assert.ok(report.degraded.includes('needs-open-path'), 'openPath required 缺失 → degraded');
+  assert.ok(report.warnings.includes('needs-delete-session'), 'deleteSession 非 required 缺失 → warnings');
+  assert.ok(!report.degraded.includes('needs-delete-session'), '非 required 缺失不得进 degraded');
+});
+
+test('applyAll：dryRun=true 时 transform 返回 changed 但不落盘（dryRunChangedLog 输出）', (t) => {
+  const ctx = makeCtx(t);
+  const f = writeRuntimeFile(ctx);
+  const before = fs.readFileSync(f, 'utf8');
+  const report = applyAll(ctx, [
+    fileSpec('dry', (src) => ({ status: 'changed', src: src + '// patched\n' })),
+  ], { dryRun: true });
+  assert.equal(fs.readFileSync(f, 'utf8'), before, 'dryRun 不得改写文件内容');
+  assert.ok(ctx.logs.some((m) => m.includes('dry-run: 将')), '应输出 dryRunChangedLog 计划文案');
+  assert.equal(report.changed, 0, 'dryRun 不落盘，changed 应保持 0');
+});
+
+test('applyAll：donePrefix=false 时成功日志无「前缀: 」', (t) => {
+  const ctx = makeCtx(t);
+  const f = writeRuntimeFile(ctx);
+  applyAll(ctx, [
+    fileSpec('noprefix', (src) => ({ status: 'changed', src: src + '// x\n' })),
+  ], { donePrefix: false });
+  assert.ok(ctx.logs.some((m) => m.includes('已应用 ' + f)), '应输出裸 doneLog');
+  assert.ok(!ctx.logs.some((m) => m.includes('noprefix: 已应用')), 'donePrefix=false 时成功日志不得带前缀');
+});
+
+test('applyAll：failPolicy=fatal 规格级异常 → degraded（fatal→degrade），不 throw', () => {
+  const logs = [];
+  const ctx = { home: 'x', appDir: 'y', userDataDir: 'z', wslMode: false, log: (m) => logs.push(m) };
+  const report = applyAll(ctx, [throwingFileSpec('fat2', 1, 'fatal')]);
+  assert.deepEqual(report.degraded, ['fat2'], 'fatal 异常应降级为 degraded');
+  assert.equal(report.errors.length, 0, 'fatal 异常不得记入 errors');
+  assert.ok(logs.some((m) => m.includes('fatal→degrade')), '应输出 fatal→degrade 日志');
+});
+
+// ---------------------------------------------------------------------------
+// P1：resolveFiles 的 profile-boot-dirs 布局 glob 分支（只返回 profile-boot-*.js）。
+// ---------------------------------------------------------------------------
+
+test('resolveFiles：profile-boot-dirs 布局只 glob 出 profile-boot-*.js', (t) => {
+  const ctx = makeCtx(t);
+  const dir = path.join(ctx.home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh', 'lib');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'profile-boot-a.js'), 'export const a = 1;\n');
+  fs.writeFileSync(path.join(dir, 'profile-boot-b.js'), 'export const b = 2;\n');
+  fs.writeFileSync(path.join(dir, 'other.js'), 'export const other = 3;\n');
+
+  const files = resolveFiles(ctx, { layout: 'profile-boot-dirs', wslLayout: 'profile-boot-dirs' }).sort();
+  assert.deepEqual(files, [
+    path.join(dir, 'profile-boot-a.js'),
+    path.join(dir, 'profile-boot-b.js'),
+  ].sort(), '只应返回 profile-boot-*.js，忽略 other.js');
+});

--- a/dsh-desktop/scripts/test/unit-patch-target-resolver.test.js
+++ b/dsh-desktop/scripts/test/unit-patch-target-resolver.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+// patch-target-resolver 单元测试（node --test）。
+// 验证五函数收敛为 resolvePatchTargets / resolveNmRoots 后，各布局与旧实现的
+// 路径构造逐项一致（localCopyFiles / guardCopyFiles / patchTargets /
+// localNodeModulesRoots / slotCompat*），且 WSL 布局选择正确。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  resolvePatchTargets,
+  resolveNmRoots,
+  slotCompatCopyFiles,
+  slotCompatPatchTargets,
+  SLOT_KEY_COMPAT_PKG_REL,
+  SLOT_UNKEYED_COMPAT_PKG_REL,
+  SLOT_COMPAT_PKG_RELS,
+} = require('../lib/patch-target-resolver');
+
+const CTX = {
+  home: 'C:\\Users\\t\\.dsh',
+  appDir: 'C:\\app\\resources\\app',
+  userDataDir: 'C:\\Users\\t\\AppData\\Roaming\\DSH Desktop',
+  wslMode: false,
+};
+
+test('runtime-local 布局 = 硬编码三副本（golden，非同义反复）', () => {
+  const rel = path.join('dsh-client-runtime', 'lib', 'client.js');
+  const got = resolvePatchTargets(CTX, { layout: 'runtime-local', pkgRel: rel });
+  // 硬编码 golden 期望，证明 resolver 输出正确（而非与自身薄封装 f(x)===f(x)）。
+  assert.deepEqual(got, [
+    path.join(CTX.home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+    path.join(CTX.appDir, 'node_modules', '@deepseek-ai', rel),
+    path.join(CTX.userDataDir, 'agent', 'node_modules', '@deepseek-ai', rel),
+  ]);
+  assert.equal(got.length, 3);
+});
+
+test('guard 布局 = 硬编码四副本（golden，含嵌套 dsh）', () => {
+  const rel = path.join('dsh-app-boot', 'lib', 'index.js');
+  const got = resolvePatchTargets(CTX, { layout: 'guard', pkgRel: rel });
+  assert.deepEqual(got, [
+    path.join(CTX.appDir, 'node_modules', '@deepseek-ai', rel),
+    path.join(CTX.userDataDir, 'agent', 'node_modules', '@deepseek-ai', rel),
+    path.join(CTX.userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'node_modules', '@deepseek-ai', rel),
+    path.join(CTX.home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+  ]);
+  assert.equal(got.length, 4);
+  // 第三项必须是 overlay 嵌套 dsh 依赖副本。
+  assert.ok(got[2].includes(path.join('dsh', 'node_modules', '@deepseek-ai')));
+});
+
+test('wsl 布局 = 硬编码 profile fallback + agent（golden）', () => {
+  const rel = path.join('dsh-host-apiproxy', 'lib', 'index.js');
+  const got = resolvePatchTargets(CTX, { layout: 'wsl', pkgRel: rel });
+  assert.deepEqual(got, [
+    path.join(CTX.home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+    path.join(CTX.home, 'agent', 'node_modules', '@deepseek-ai', rel),
+  ]);
+  assert.equal(got.length, 2);
+});
+
+test('wslLayout 存在且 ctx.wslMode 时优先 wsl 布局', () => {
+  const rel = path.join('dsh-client-runtime', 'lib', 'client.js');
+  const wslCtx = { ...CTX, wslMode: true };
+  const got = resolvePatchTargets(wslCtx, { layout: 'runtime-local', wslLayout: 'wsl', pkgRel: rel });
+  assert.deepEqual(got, [
+    path.join(CTX.home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+    path.join(CTX.home, 'agent', 'node_modules', '@deepseek-ai', rel),
+  ]);
+  // 非 WSL 仍走本地三副本。
+  assert.deepEqual(
+    resolvePatchTargets(CTX, { layout: 'runtime-local', wslLayout: 'wsl', pkgRel: rel }),
+    [
+      path.join(CTX.home, 'profiles', 'node_modules', '@deepseek-ai', rel),
+      path.join(CTX.appDir, 'node_modules', '@deepseek-ai', rel),
+      path.join(CTX.userDataDir, 'agent', 'node_modules', '@deepseek-ai', rel),
+    ],
+  );
+});
+
+test('nm-roots 布局：硬编码本地三根、WSL 追加 agent 直连根（golden）', () => {
+  const local = resolveNmRoots(CTX, { layout: 'nm-roots' });
+  assert.deepEqual(local, [
+    path.join(CTX.home, 'profiles', 'node_modules'),
+    path.join(CTX.appDir, 'node_modules'),
+    path.join(CTX.userDataDir, 'agent', 'node_modules'),
+  ]);
+  const wsl = resolveNmRoots({ ...CTX, wslMode: true }, { layout: 'nm-roots' });
+  assert.deepEqual(wsl, [
+    path.join(CTX.home, 'profiles', 'node_modules'),
+    path.join(CTX.appDir, 'node_modules'),
+    path.join(CTX.userDataDir, 'agent', 'node_modules'),
+    path.join(CTX.home, 'agent', 'node_modules'),
+  ]);
+  assert.equal(wsl.length, 4);
+});
+
+test('slot-compat 布局（本地）逐文件 = 单 pkgRel 子集（去重）', () => {
+  const rel = SLOT_KEY_COMPAT_PKG_REL;
+  const got = resolvePatchTargets(CTX, { layout: 'slot-compat', pkgRel: rel });
+  // 单文件布局只应包含该 pkgRel 的副本（不得再返回完整 pkgRels 并集，避免双重处理）。
+  assert.ok(got.length > 0, '应返回该 pkgRel 的副本');
+  assert.ok(got.every((f) => f.includes(rel)), '单文件布局只应包含目标 pkgRel');
+  assert.equal(got.length, new Set(got).size, '应去重');
+  // 全量 compat 函数仍是 SLOT_COMPAT_PKG_RELS 的并集。
+  const full = slotCompatCopyFiles(CTX.home, CTX.appDir, CTX.userDataDir);
+  assert.ok(full.some((f) => f.includes(SLOT_KEY_COMPAT_PKG_REL)));
+  assert.ok(full.some((f) => f.includes(SLOT_UNKEYED_COMPAT_PKG_REL)));
+  assert.equal(full.length, new Set(full).size, 'compat 全量应去重');
+});
+
+test('slot-compat-wsl 布局（本地）逐文件 = 单 pkgRel 子集（去重）', () => {
+  const rel = SLOT_KEY_COMPAT_PKG_REL;
+  const got = resolvePatchTargets(CTX, { layout: 'slot-compat-wsl', pkgRel: rel });
+  assert.ok(got.length > 0, '应返回该 pkgRel 的副本');
+  assert.ok(got.every((f) => f.includes(rel)), '单文件布局只应包含目标 pkgRel');
+  assert.equal(got.length, new Set(got).size, '应去重');
+  const full = slotCompatPatchTargets(CTX.home);
+  assert.ok(full.some((f) => f.includes(SLOT_KEY_COMPAT_PKG_REL)));
+  assert.ok(full.some((f) => f.includes(SLOT_UNKEYED_COMPAT_PKG_REL)));
+  assert.equal(full.length, new Set(full).size, 'compat 全量应去重');
+});
+
+test('未知布局返回空数组（不抛异常）', () => {
+  assert.deepEqual(resolvePatchTargets(CTX, { layout: 'nope', pkgRel: 'x' }), []);
+});
+
+test('profile-boot-dirs 布局返回三个候选目录', () => {
+  const dirs = resolvePatchTargets(CTX, { layout: 'profile-boot-dirs' });
+  assert.equal(dirs.length, 3);
+  for (const d of dirs) assert.ok(d.endsWith(path.join('@deepseek-ai', 'dsh', 'lib')));
+});

--- a/dsh-desktop/scripts/test/unit-persistence-corrupt-guard.test.js
+++ b/dsh-desktop/scripts/test/unit-persistence-corrupt-guard.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+// 会话持久化「损坏会话日志容错」单元测试（node --test）。
+// 覆盖上游 #112 新增的两个 transform（纯函数，无文件 I/O）：
+//   1) transformPersistenceCorruptGuard —— 三态（匹配 / 已应用 / 失配）
+//   2) transformPersistenceAll       —— 尾部撕裂恢复 + 损坏会话跳过的组合语义
+// 背景：2026-08 事故——卷影恢复带回零填充头部的会话日志，导致 listArtifacts
+// 读首行时整个 plugin tree 初始化崩溃。这两个 transform 把「读首行」包进
+// try-catch，损坏时告警跳过该会话（continue），不再击穿启动扫描。
+//
+// 隔离：纯字符串变换，不读写文件，不触碰真实 ~/.dsh 或 node_modules。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  PERSISTENCE_CORRUPT_MARKER,
+  PERSISTENCE_TORN_MARKER,
+  transformPersistenceCorruptGuard,
+  transformPersistenceAll,
+} = require('../lib/runtime-patches');
+
+// 以下 OLD 锚点镜像 runtime-patches.js 的内部常量（未导出），
+// 与源文件逐字节一致，用于构造「未打补丁」的 fixtures。
+const CORRUPT_OLD = 'const first = this.compression === "zstd" ? await this.readFirstZstdLine(path, signal) : await this.readFirstLine(path, signal);';
+const FRAME_LOOP_OLD = 'let remainingFrames = frames.length - 1;\n\t\t\tfor (const plaintext of decodedFrames) {';
+const WRITE_OLD = '\t\t\t\tscanner.write(plaintext);\n\t\t\t\tremainingFrames -= 1;';
+const COMPLETE_CHECK = '\t\t\tif (complete.committedBytes !== complete.inputBytes) throw new Error("corrupt Zstandard session log: complete frame contains a torn JSONL record");';
+
+// 同时含「尾部撕裂」三个锚点 + 「损坏会话」锚点的完整原始源码。
+const FULL_SRC = [FRAME_LOOP_OLD, WRITE_OLD, COMPLETE_CHECK, CORRUPT_OLD].join('\n');
+
+test('transformPersistenceCorruptGuard：匹配 → 注入 try-catch 跳过损坏会话', () => {
+  const changed = transformPersistenceCorruptGuard(CORRUPT_OLD, 't.js');
+  assert.equal(changed.status, 'changed');
+  // 注入的核心语义：读首行包进 try-catch，损坏时告警并 continue（跳过该会话）。
+  assert.ok(changed.src.includes(PERSISTENCE_CORRUPT_MARKER), '应写入 corrupt-guard marker');
+  assert.ok(changed.src.includes('try {'), '应注入 try 块');
+  assert.ok(changed.src.includes('catch (corruptError)'), '应注入 catch 块');
+  assert.ok(changed.src.includes('signal?.throwIfAborted()'), 'catch 内应先重抛中止信号');
+  assert.ok(changed.src.includes('skipping corrupt session log'), '告警文案应含 skipping corrupt session log');
+  assert.ok(changed.src.includes('continue;'), '损坏时应 continue 跳过该会话');
+  // 原读首行逻辑保留在 try 内（去掉 const，改为 let first; 声明）。
+  assert.ok(changed.src.includes('let first;'), '应改为 let first 声明');
+  assert.ok(changed.src.includes('first = this.compression === "zstd"'), '读首行逻辑应保留在 try 内');
+  // 原「const first = ...」整句不再原样存在（已改写）。
+  assert.ok(!changed.src.includes(CORRUPT_OLD), '旧的 const first 语句应被改写');
+});
+
+test('transformPersistenceCorruptGuard：已应用 → already', () => {
+  assert.equal(transformPersistenceCorruptGuard('// ' + PERSISTENCE_CORRUPT_MARKER, 't.js').status, 'already');
+});
+
+test('transformPersistenceCorruptGuard：失配 → anchor-missing 且绝不改写', () => {
+  const src = 'export const x = 1;';
+  const miss = transformPersistenceCorruptGuard(src, 't.js');
+  assert.equal(miss.status, 'anchor-missing');
+  assert.ok(miss.detail.includes('损坏会话容错锚点'), 'detail 应说明是损坏会话容错锚点失配');
+  assert.ok(miss.detail.includes('版本可能已变更'), 'detail 应提示版本可能已变更');
+});
+
+test('transformPersistenceAll：两个补丁都命中 → 同时应用（changed）', () => {
+  const changed = transformPersistenceAll(FULL_SRC, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(PERSISTENCE_TORN_MARKER), '应含尾部撕裂 marker');
+  assert.ok(changed.src.includes(PERSISTENCE_CORRUPT_MARKER), '应含损坏会话 marker');
+  // 尾部撕裂：三个锚点均被改写。
+  assert.ok(!changed.src.includes(FRAME_LOOP_OLD), 'FRAME_LOOP 旧锚点应被改写');
+  assert.ok(!changed.src.includes(WRITE_OLD), 'WRITE 旧锚点应被改写');
+  assert.ok(changed.src.includes('tornCompleteFrameStart'), '应注入 tornCompleteFrameStart 逻辑');
+});
+
+test('transformPersistenceAll：仅损坏会话补丁命中（尾部撕裂已应用）→ changed', () => {
+  const src = ['// ' + PERSISTENCE_TORN_MARKER, CORRUPT_OLD].join('\n');
+  const changed = transformPersistenceAll(src, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(PERSISTENCE_CORRUPT_MARKER), '损坏会话 marker 应写入');
+  assert.ok(!changed.src.includes(CORRUPT_OLD), '旧 const first 应被改写');
+});
+
+test('transformPersistenceAll：仅尾部撕裂补丁命中（损坏会话已应用）→ changed', () => {
+  const src = [FRAME_LOOP_OLD, WRITE_OLD, COMPLETE_CHECK, '// ' + PERSISTENCE_CORRUPT_MARKER].join('\n');
+  const changed = transformPersistenceAll(src, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(PERSISTENCE_TORN_MARKER), '尾部撕裂 marker 应写入');
+  assert.ok(!changed.src.includes(FRAME_LOOP_OLD), 'FRAME_LOOP 旧锚点应被改写');
+});
+
+test('transformPersistenceAll：两个补丁都已应用 → already', () => {
+  const src = ['// ' + PERSISTENCE_TORN_MARKER, '// ' + PERSISTENCE_CORRUPT_MARKER].join('\n');
+  assert.equal(transformPersistenceAll(src, 't.js').status, 'already');
+});
+
+test('transformPersistenceAll：幂等——首次 changed，二次 already', () => {
+  const once = transformPersistenceAll(FULL_SRC, 't.js');
+  assert.equal(once.status, 'changed');
+  const twice = transformPersistenceAll(once.src, 't.js');
+  assert.equal(twice.status, 'already');
+});
+
+test('transformPersistenceAll：全部失配 → anchor-missing（损坏会话 detail 优先）', () => {
+  const miss = transformPersistenceAll('export const x = 1;', 't.js');
+  assert.equal(miss.status, 'anchor-missing');
+  assert.ok(miss.detail.includes('损坏会话容错锚点'), '应返回损坏会话容错锚点失配的 detail');
+});
+
+test('transformPersistenceAll：尾部撕裂命中 + 损坏会话失配 → 仅撕裂应用（互不阻塞）', () => {
+  // 只有尾部撕裂三个锚点，无损坏会话锚点：撕裂照常应用，损坏会话失配不阻断。
+  const src = [FRAME_LOOP_OLD, WRITE_OLD, COMPLETE_CHECK].join('\n');
+  const changed = transformPersistenceAll(src, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(PERSISTENCE_TORN_MARKER), '尾部撕裂 marker 应写入');
+  assert.ok(!changed.src.includes(PERSISTENCE_CORRUPT_MARKER), '损坏会话失配，不应写入其 marker');
+});
+
+test('transformPersistenceAll：尾部撕裂失配 + 损坏会话命中 → 仅损坏会话应用（互不阻塞）', () => {
+  // 只有损坏会话锚点，无尾部撕裂锚点：损坏会话容错照常应用。
+  const changed = transformPersistenceAll(CORRUPT_OLD, 't.js');
+  assert.equal(changed.status, 'changed');
+  assert.ok(changed.src.includes(PERSISTENCE_CORRUPT_MARKER), '损坏会话 marker 应写入');
+  assert.ok(!changed.src.includes(PERSISTENCE_TORN_MARKER), '尾部撕裂失配，不应写入其 marker');
+});

--- a/dsh-desktop/scripts/test/unit-plugin-integration.test.js
+++ b/dsh-desktop/scripts/test/unit-plugin-integration.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// 插件集成门面（scripts/integration/index.js）单元测试（node --test）。
+// 覆盖：createPluginIntegration().run() 闭包返回 { syncResult, patchReport,
+// healthReport }，且 run() 解构后调用不依赖 this 绑定（门面聚合不崩）。
+//
+// 隔离：getHome / getUserDataDir / appDir / installAnchor 均注入 mkdtemp，
+// 绝不触碰真实 ~/.dsh。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createPluginIntegration } = require('../integration/index');
+
+test('createPluginIntegration().run()：解构后调用返回 { syncResult, patchReport, healthReport }', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-integration-home-'));
+  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-integration-app-'));
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-integration-ud-'));
+  const anchor = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-integration-anchor-'));
+  t.after(() => {
+    for (const d of [home, appDir, userDataDir, anchor]) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  const opts = {
+    getHome: () => home,
+    appDir,
+    getUserDataDir: () => userDataDir,
+    wslMode: () => false,
+    log: () => {},
+    loadYaml: () => null,
+    loadSettings: () => ({}),
+    saveSettings: () => {},
+    getInstallAnchorDir: () => anchor,
+    hostDetectors: { openPath: () => true, deleteSession: () => true },
+  };
+
+  const integration = createPluginIntegration(opts);
+  // 解构后调用：验证 run() 不依赖 this 绑定。
+  const { run } = integration;
+  const result = run();
+
+  assert.deepEqual(Object.keys(result).sort(), ['healthReport', 'patchReport', 'syncResult'], 'run() 应返回三字段');
+  // patchReport 来自 applyAll：含 total/changed/degraded/warnings/errors 等结构化字段。
+  assert.equal(typeof result.patchReport.total, 'number', 'patchReport.total 应为数字');
+  assert.ok(Array.isArray(result.patchReport.degraded), 'patchReport.degraded 应为数组');
+  assert.ok(Array.isArray(result.patchReport.errors), 'patchReport.errors 应为数组');
+  // healthReport 来自 preflight：空隔离 home 无 manifest → 早退。
+  assert.deepEqual(result.healthReport, { scanned: 0, unpatched: [] }, 'healthReport 应为 preflight 早退结果');
+});

--- a/dsh-desktop/scripts/test/unit-plugin-sync.test.js
+++ b/dsh-desktop/scripts/test/unit-plugin-sync.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// plugin-sync（createPluginSync）单元测试（node --test）。
+// 覆盖：healProfilePatch / healHomePatch 的「解析失败 → 备份 + 重置最小文件 +
+// onHealReset(kind, backup) 回调」，自愈幂等（签名命中 memo 不重复自愈），
+// 以及 logProfileBundleHealth 的只读健康检查（不抛异常）。
+//
+// 隔离：getHome / getUserDataDir 均注入 mkdtemp 临时目录，绝不触碰真实 ~/.dsh；
+// loadYaml 用真实 js-yaml entry-list 方言解析器（createEntryListYamlParser），
+// 保证「损坏文件触发解析失败」是真实验证而非 mock 橡皮图章。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createPluginSync } = require('../integration/plugin-sync');
+const { createEntryListYamlParser } = require('../lib/profile-reconcile');
+
+/** 构造隔离的 createPluginSync ctx（heal / health 均只依赖 getHome/getUserDataDir/log/loadYaml）。 */
+function makePluginSyncCtx(t) {
+  const h = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-plugin-sync-home-'));
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-plugin-sync-ud-'));
+  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-plugin-sync-app-'));
+  t.after(() => {
+    fs.rmSync(h, { recursive: true, force: true });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(appDir, { recursive: true, force: true });
+  });
+  const parse = createEntryListYamlParser(); // 真实 js-yaml（可用时为函数，否则 null）
+  const logs = [];
+  const resets = [];
+  const ctx = {
+    getHome: () => h,
+    appDir,
+    getUserDataDir: () => userDataDir,
+    log: (m) => logs.push(m),
+    loadYaml: () => (parse ? { load: (c) => parse(c) } : null),
+    loadSettings: () => ({}),
+    saveSettings: () => {},
+    getInstallAnchorDir: () => path.join(os.tmpdir(), 'dsh-no-anchor'),
+    onHealReset: (kind, backup) => resets.push({ kind, backup }),
+  };
+  return { ctx, h, userDataDir, logs, resets };
+}
+
+test('healProfilePatch：cordis.patch.yml 解析失败 → 备份 + 重置最小文件 + onHealReset(profile, backup)', (t) => {
+  const { ctx, h, resets } = makePluginSyncCtx(t);
+  const file = path.join(h, 'profiles', 'web', 'cordis.patch.yml');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, '- id: [\n'); // 损坏：js-yaml 解析抛错（未闭合 flow sequence）
+
+  const { healProfilePatch } = createPluginSync(ctx);
+  healProfilePatch();
+
+  // 备份文件存在（.broken- 随机后缀），且内容为原损坏文本。
+  const backups = fs.readdirSync(path.dirname(file)).filter((n) => n.startsWith('cordis.patch.yml.broken-'));
+  assert.equal(backups.length, 1, '应生成一个 .broken- 备份文件');
+  const backup = path.join(path.dirname(file), backups[0]);
+  assert.equal(fs.readFileSync(backup, 'utf8'), '- id: [\n', '备份内容应为原损坏内容');
+
+  // 写回最小文件（含 []）。
+  const content = fs.readFileSync(file, 'utf8');
+  assert.ok(content.includes('[]'), '重置文件应含顶层空数组 []');
+  assert.ok(content.includes('recovered by DSH Desktop'), '重置文件应含 recovered 头部');
+
+  // onHealReset 回调。
+  assert.equal(resets.length, 1, 'onHealReset 应被调用一次');
+  assert.equal(resets[0].kind, 'profile');
+  assert.equal(resets[0].backup, backup);
+});
+
+test('healHomePatch：家级 cordis.patch.yml 解析失败 → 备份 + 重置 + onHealReset(home, backup)', (t) => {
+  const { ctx, h, resets } = makePluginSyncCtx(t);
+  const file = path.join(h, 'cordis.patch.yml');
+  fs.writeFileSync(file, '- id: [\n');
+
+  const { healHomePatch } = createPluginSync(ctx);
+  healHomePatch();
+
+  const backups = fs.readdirSync(h).filter((n) => n.startsWith('cordis.patch.yml.broken-'));
+  assert.equal(backups.length, 1, '应生成一个 .broken- 备份文件');
+  const backup = path.join(h, backups[0]);
+  assert.equal(fs.readFileSync(backup, 'utf8'), '- id: [\n', '备份内容应为原损坏内容');
+
+  const content = fs.readFileSync(file, 'utf8');
+  assert.ok(content.includes('[]'), '重置文件应含顶层空数组 []');
+
+  assert.equal(resets.length, 1, 'onHealReset 应被调用一次');
+  assert.equal(resets[0].kind, 'home');
+  assert.equal(resets[0].backup, backup);
+});
+
+test('healProfilePatch：自愈后签名（含 hash）未变 → 第二次调用不重复自愈', (t) => {
+  const { ctx, h, resets } = makePluginSyncCtx(t);
+  const file = path.join(h, 'profiles', 'web', 'cordis.patch.yml');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, '- id: [\n');
+
+  const { healProfilePatch } = createPluginSync(ctx);
+  healProfilePatch(); // 第一次：触发自愈，记录签名
+  assert.equal(resets.length, 1, '首次应触发一次自愈');
+
+  healProfilePatch(); // 第二次：签名命中 memo，跳过
+  assert.equal(resets.length, 1, '第二次调用不得重复自愈（onHealReset 不触发）');
+});
+
+test('logProfileBundleHealth：健康 profile（空 bundles）不抛异常且不输出告警', (t) => {
+  const { ctx, h, logs } = makePluginSyncCtx(t);
+  const profileDir = path.join(h, 'profiles', 'web');
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({ name: 'web', dsh: { profile: { bundles: [] } } }));
+
+  const { logProfileBundleHealth } = createPluginSync(ctx);
+  assert.doesNotThrow(() => logProfileBundleHealth(), '健康检查不得抛异常');
+  assert.equal(logs.filter((m) => m.includes('缺失') || m.includes('不可用')).length, 0, '空 bundles 不应输出缺失/不可用告警');
+});
+
+test('logProfileBundleHealth：manifest 不可读 → 记录日志并早退（不抛）', (t) => {
+  const { ctx, logs } = makePluginSyncCtx(t);
+  // 不创建 profiles/web/package.json → manifest 不可读。
+
+  const { logProfileBundleHealth } = createPluginSync(ctx);
+  assert.doesNotThrow(() => logProfileBundleHealth(), 'manifest 缺失时不得抛异常');
+  assert.ok(logs.some((m) => m.includes('manifest 不可读')), '应记录 manifest 不可读日志');
+});

--- a/dsh-desktop/scripts/test/unit-session-persistence-recovery.test.js
+++ b/dsh-desktop/scripts/test/unit-session-persistence-recovery.test.js
@@ -11,6 +11,8 @@ const {
   PERSISTENCE_PKG_REL,
   PERSISTENCE_TORN_MARKER,
   transformPersistenceTornTail,
+  PERSISTENCE_CORRUPT_MARKER,
+  transformPersistenceCorruptGuard,
 } = require('../lib/runtime-patches');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -50,6 +52,10 @@ test('session persistence patch is applied and idempotent', () => {
   const source = fs.readFileSync(target, 'utf8');
   assert.match(source, new RegExp(PERSISTENCE_TORN_MARKER));
   assert.equal(transformPersistenceTornTail(source, target).status, 'already');
+  // 上游 #112：patchSessionPersistence 现经 transformPersistenceAll 同时应用
+  // 「损坏会话日志容错」补丁，两个补丁都应已应用（幂等）。
+  assert.match(source, new RegExp(PERSISTENCE_CORRUPT_MARKER));
+  assert.equal(transformPersistenceCorruptGuard(source, target).status, 'already');
 });
 
 test('complete final zstd frame with torn JSONL returns a repair marker', async () => {

--- a/dsh-desktop/scripts/test/unit-slot-compat.test.js
+++ b/dsh-desktop/scripts/test/unit-slot-compat.test.js
@@ -13,6 +13,7 @@ const {
   SLOT_KEY_COMPAT_MARKER,
   SLOT_UNKEYED_COMPAT_MARKER,
   SLOT_ERROR_ISOLATE_MARKER,
+  SLOT_ERROR_ISOLATE_MARKER_V2,
   SLOT_KEY_COMPAT_OLD,
   SLOT_UNKEYED_COMPAT_OLD,
 } = require('../../scripts/lib/runtime-patches');
@@ -85,30 +86,56 @@ test('transformSlotUnkeyedCompat: anchor-missing when neither exact nor regex ma
 });
 
 // ---------------------------------------------------------------------------
-// transformSlotErrorIsolation (new safety net)
+// transformSlotErrorIsolation (v2：warn + 派生 key，不 throw)
 // ---------------------------------------------------------------------------
 
-test('transformSlotErrorIsolation: wraps throw with auto-derive guard', () => {
+test('transformSlotErrorIsolation: 原始单行 throw → v2 块（派生 key，不 throw）', () => {
   const src = 'function register(slot, options) {\n\tif (options.key === void 0) throw new Error("keyed slot \\"settings.plugin.item\\" requires options.key");\n}';
   const result = transformSlotErrorIsolation(src, 'test.js');
   assert.equal(result.status, 'changed');
-  assert.ok(result.src.includes(SLOT_ERROR_ISOLATE_MARKER));
+  assert.equal(result.note, 'v2');
+  assert.ok(result.src.includes(SLOT_ERROR_ISOLATE_MARKER_V2));
   assert.ok(result.src.includes('options.key = options.id'));
   assert.ok(result.src.includes('console.warn'));
+  // 关键修复：不得再保留原 throw（历史 bug 曾导致无条件 throw）。
+  assert.ok(!result.src.includes('throw new Error'), 'v2 不得保留原 throw');
 });
 
-test('transformSlotErrorIsolation: already applied returns already', () => {
-  const src = '// ' + SLOT_ERROR_ISOLATE_MARKER + '\nthrow new Error("keyed slot requires options.key");';
+test('transformSlotErrorIsolation: v1 buggy 输出（无条件 throw）→ 修复为 v2', () => {
+  // 复现 v1 注入的 buggy 结构：if 空体 + warn + 派生 + 无条件 throw。
+  const v1 = '\t\t\t\tif (options.key === void 0) // ' + SLOT_ERROR_ISOLATE_MARKER + ': convert fatal throw into warn+skip so one\n'
+    + ' // unkeyed plugin cannot take down the whole dsh web loader.\n'
+    + ' console.warn("[dsh-desktop compat] keyed slot registration missing key");\n'
+    + ' options.key = options.id !== void 0 ? String(options.id) : String(options.registrant || "auto-1");\n'
+    + ' throw new Error(`keyed slot "x" requires options.key`);';
+  const result = transformSlotErrorIsolation(v1, 'test.js');
+  assert.equal(result.status, 'changed');
+  assert.equal(result.note, 'v1-repair');
+  assert.ok(result.src.includes(SLOT_ERROR_ISOLATE_MARKER_V2));
+  assert.ok(!result.src.includes('throw new Error'), 'v1-repair 应移除无条件 throw');
+  assert.ok(result.src.includes('if (options.key === void 0) {'), '应重构为 if 守卫块');
+});
+
+test('transformSlotErrorIsolation: standalone throw v1 输出（无 if 前缀）→ 修复为 v2', () => {
+  // 旧 SLOT_ERROR_ISOLATE_REGEX 分支匹配独立 `throw`（无 if 前缀），其注入产物以
+  // `// marker...` 开头。v1-repair 需有回退匹配，否则无条件 throw 保留（边缘漏修）。
+  const standaloneV1 = '\t\t// ' + SLOT_ERROR_ISOLATE_MARKER + ': convert fatal throw into warn+skip so one\n'
+    + '\t\t// unkeyed plugin cannot take down the whole dsh web loader.\n'
+    + '\t\tconsole.warn("[dsh-desktop compat] keyed slot registration missing key");\n'
+    + '\t\toptions.key = options.id !== void 0 ? String(options.id) : String(options.registrant || "auto-1");\n'
+    + '\t\tthrow new Error(`keyed slot "x" requires options.key`);';
+  const result = transformSlotErrorIsolation(standaloneV1, 'test.js');
+  assert.equal(result.status, 'changed');
+  assert.equal(result.note, 'v1-repair');
+  assert.ok(result.src.includes(SLOT_ERROR_ISOLATE_MARKER_V2));
+  assert.ok(!result.src.includes('throw new Error'), 'standalone v1-repair 应移除无条件 throw');
+  assert.ok(result.src.includes('if (options.key === void 0) {'), 'standalone v1-repair 应重构为 if 守卫块');
+});
+
+test('transformSlotErrorIsolation: v2 already applied returns already', () => {
+  const src = '// ' + SLOT_ERROR_ISOLATE_MARKER_V2 + '\nif (options.key === void 0) {}';
   const result = transformSlotErrorIsolation(src, 'test.js');
   assert.equal(result.status, 'already');
-});
-
-test('transformSlotErrorIsolation: alt throw pattern (simpler error message)', () => {
-  const src = 'if (!options.key) throw new Error("requires options.key");';
-  const result = transformSlotErrorIsolation(src, 'test.js');
-  assert.equal(result.status, 'changed');
-  assert.ok(result.src.includes(SLOT_ERROR_ISOLATE_MARKER));
-  assert.ok(result.note === 'alt throw');
 });
 
 test('transformSlotErrorIsolation: anchor-missing when no throw found', () => {
@@ -118,7 +145,7 @@ test('transformSlotErrorIsolation: anchor-missing when no throw found', () => {
 });
 
 test('transformSlotErrorIsolation: derived key uses registrant or id', () => {
-  const src = '\t\tthrow new Error("keyed slot \\"settings.plugin.item\\" requires options.key");';
+  const src = '\tif (options.key === void 0) throw new Error("keyed slot \\"settings.plugin.item\\" requires options.key");';
   const result = transformSlotErrorIsolation(src, 'test.js');
   assert.equal(result.status, 'changed');
   // The injected code should derive key from options.id or options.registrant


### PR DESCRIPTION
> **上游适配说明**：本分支已 rebase 到上游最新 main（release v0.4.0，commit 9e571a6），与上游完全同步，无合并冲突。

## 摘要

dsh_desktop 需要接入 30+ 个第三方/社区插件，历史实现用「字节级字符串锚点」直接改写第三方插件源码（monkey-patch），补丁散落在 `main.js` 与十余个脚本里重复落盘 4~5 处路径。这套「补丁式集成」带来高耦合、低内聚、脆弱三大结构性问题：插件一升级锚点即失配、补丁静默失效，`main.js` 6384 行单体混合全部职责，单插件异常会拖垮整个 loader。

本次重构将其收敛为「声明式插件集成层」——**唯一补丁注册表 + 唯一目标解析器 + 唯一补丁引擎 + 独立集成模块**，并显式化宿主能力依赖、统一化单插件故障隔离、可观测化补丁失败。`main.js` 从 6384 行降至 5250 行，`boot()` 只做编排。

**结果**：全程行为等价，不改变任何用户可见功能；核心单测 **94 用例全绿**（隔离环境，绝不触碰真实 `~/.dsh`）；历经四轮全量 review 逐项修复，最终零回归、零遗留缺陷。

## 背景与动机

历史「补丁式集成」有三个结构性缺陷：

1. **高耦合**：直接用字节级字符串锚点改写第三方插件源码（`node_modules/@deepseek-ai/*`），插件一升级锚点即失配，补丁静默失效或产生 bug，补丁与插件源码之间没有任何契约。
2. **低内聚**：`main.js` 6384 行单体，混合窗口管理、插件同步、补丁应用、自愈、更新、余额、WSL、插件管理全部职责；18 个 `apply*` 函数各自重复「路径分支 → 补丁 → 日志」样板。
3. **脆弱**：单插件异常会拖垮整个 loader；补丁失配静默失效、用户无感知。

## 解决方案

### 1. PatchTargetResolver —— 路径解析唯一实现

将 5 个散落的路径构造函数收敛为一个 `resolvePatchTargets` + 布局枚举（`runtime-local` / `guard` / `slot-compat` / `nm-roots` / `wsl` / `profile-boot-dirs`）。每个补丁只声明「包相对路径 + 布局类型」，路径构造归一，杜绝 4~5 处重复落盘漂移。

### 2. PatchSpec 注册表 —— 补丁唯一数据源

`patch-registry.js` 声明 21 条补丁（`id / group / order / kind / layout / transform / marker / failPolicy / cli / logs`），作为补丁编排与健康预检的唯一数据源。`marker` 全部引用 `patch-adapters.js` 的 `markers` 单一导出源；`cli` 标志使 `sync-companion-plugins.js` 的补丁清单也由注册表单一驱动，消除第二份清单漂移。

### 3. patch-adapters —— 内联 transform 声明化

将 `main.js` 内联的 6 个 transform 迁入 `patch-adapters.js`，与 `runtime-patches.js` 的 9 个 transform 统一由注册表驱动；5 个包级补丁以「node_modules 根应用器」形态收口。

### 4. 插件集成层 —— 职责清晰的分层

```
main.js（编排）
  └─> scripts/integration/index.js（门面 PluginIntegration）
        ├── plugin-sync.js      插件同步/自愈/对账
        ├── patch-runner.js     补丁编排（注册表驱动 + 逐补丁 try-catch + failPolicy）
        └── fault-isolation.js  单插件故障隔离（只读预检 + 隔离 transform 收口）
```

### 5. window 桥显式化 + 宿主能力清单

`openPath` / `deleteSession` 桥显式声明于 `host-capabilities.js`，patch-runner 探测并记录降级告警；桥缺失时菜单项隐藏 + 告警，不再静默失效。

### 6. 失败策略分级 + 补丁报告可观测

`warn` / `degrade` / `fatal` 三档，且分级真正生效：`degrade` 档补丁（如 slot-error-isolation 故障隔离安全网）的失配进 `report.degraded` 触发「降级」级提示，`warn` 档计入 `anchorMissing` 触发「版本差异」提示，二者互斥不重复。所有异常（含 root 补丁的 anchor-missing、逐文件/逐根失败）在补丁边界内收敛进 `patchReport`，`main.js` 消费报告并给出分级用户可见提示。

## 结果与验证

### 解决的核心问题

| 结构性问题 | 重构后 |
|---|---|
| 高耦合（锚点失配静默失效） | 补丁声明化 + 锚点三态（匹配/失配/已应用）断言 + 失配可观测告警 |
| 低内聚（6384 行单体） | `main.js` 6384 → 5250 行，`boot()` 只编排；18 个 `apply*` 收敛为 21 条 spec |
| 脆弱（单插件拖垮 loader） | 逐补丁 try-catch + failPolicy 分级 + 故障隔离安全网（slot-error-isolation，degrade 档）|

### 行为等价保证

1. **字节级等价**：所有 transform 的锚点常量、注入代码、日志文案与旧实现逐字节一致，每个 transform 具备「匹配 / 失配 / 已应用」三态断言。
2. **路径等价（golden 断言）**：`resolvePatchTargets` 的 5 布局与旧实现逐项一致，由硬编码 golden 期望（非同义反复）证明。
3. **清单等价**：旧 18 个 `apply*` 与 21 条 spec 一一映射；`runtime-patches.js` 导出符号 47 原有无丢失（新增 1 个 V2 marker，共 48）。
4. **CLI 等价**：`sync-companion-plugins.js --with-patches` 经注册表复用，补丁清单/布局/文案与旧实现一致，`--dry-run` 不落盘。

### 测试验证

- **核心单测 94 用例全绿**（隔离环境 `DSH_HOME` + `mkdtemp`，绝不触碰真实 `~/.dsh`）。
- **语法**：全部 21 个改动文件 `node --check` 通过。
- **CLI 直跑**：Node 24 与 Node 22 下 `--with-patches --dry-run` 均 exit 0、不落盘。
- **等价性复核**：程序化验证 PATCH_SPECS=21、id 唯一、order 严格递增、marker 全量同源、导出符号 48、failPolicy 互斥分流；resolver 测试 golden 断言经 `git show HEAD` 逐项比对确认。

### 已知限制

- Node 22 在损坏 PATH 环境下存在环境性原生崩溃（`commandLocations` 已纯 JS 化消除 `where.exe` 依赖），项目已统一指向 Node 24。
- 完整集成场景（带 GPU 故障注入的端到端「缺 key 插件不拖垮 loader」）需图形环境，建议在 `windows-latest` CI 执行。

## 变更清单

- **修改**：`main.js`（-1134 行）、`runtime-patches.js`、`patch-engine.js`、`sync-companion-plugins.js`、5 个 root applier（`patch-web-search-baseurl` / `patch-menu-viewport` / `patch-session-manage` / `patch-open-project-dir` / `patch-session-persistence`）、`patch-portable-template.js`、`desktop-diagnostics.js`、`assets/plugins/*/lib/client.js`。
- **新增核心逻辑**：`patch-target-resolver.js` / `patch-registry.js` / `patch-adapters.js` / `host-capabilities.js`；`integration/index.js` / `plugin-sync.js` / `patch-runner.js` / `fault-isolation.js`。
- **新增测试**：`unit-patch-{runner,registry,adapters,target-resolver,host-capabilities,fault-isolation,open-project-dir}.test.js`、`unit-plugin-sync.test.js`、`unit-plugin-integration.test.js`、`desktop-diagnostics.test.js`（补强）、`fixtures/*.golden.json`。

## 后续计划

1. **上游适配**：持续向上游提 PR 消除无接口的 monkey-patch，让补丁逐步退出。
2. 为 `plugin-sync` 的 `sync()` 七步完整流程补专属单测（带 GPU CI）。
3. 补丁应用可观测性：命中率、失配率的结构化指标。
4. 统一 CI 到 Node 24，消除版本漂移。

---

---

## 测试覆盖补全（上游适配）

针对本次上游适配涉及的关键改动，补全了单元测试（commit `7f08319`，3 文件 +139 行）：

- **新增 `unit-persistence-corrupt-guard.test.js`（11 用例）**：覆盖上游 #112 引入的 `transformPersistenceCorruptGuard` 三态（匹配 / 已应用 / 失配），以及 `transformPersistenceAll` 的组合语义——两补丁同时应用、仅尾部撕裂、仅损坏会话、均已应用、幂等、全失配、两补丁互不阻塞（一个锚点失配不阻断另一个应用）。
- **补强 `unit-session-persistence-recovery.test.js`**：断言 `patchSessionPersistence` 经 `transformPersistenceAll` 同时应用「尾部撕裂恢复」与「损坏会话日志容错」两个补丁（二者均应已应用，幂等）。
- **补强 `unit-patch-adapters.test.js`**：断言 `transformPersistenceAll` 的 re-export 可用，且不再残留旧的 `transformPersistenceTornTail` 导出名（防回退）。

验证结果（隔离环境 `DSH_HOME` + `mkdtemp`，绝不触碰真实 `~/.dsh`）：
- 新增与补强用例全绿（11 + 1 新用例 + 补强断言）
- 重构核心单测 + 新增 + 上游相关测试合计 **131 用例全绿**
- 全量套件 587 用例：578 通过，7 个失败均为既有环境性原因（缺私有包、Node 22 spawn 崩溃、测试隔离抖动），与本次改动无关
