### PR TITLE
fix: 更新后软件报错bug修复，移除插件中废弃的 web-react 依赖回落，以防止模块加载器崩溃

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-conversation-tweaks/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-conversation-tweaks/lib/client.js
@@ -28,12 +28,7 @@ window.__ModuleLoader__.load({
 				};
 			}
 		} catch { /* 模块不在页面表（rc.7 及更早内核）→ 走下一级回落 */ }
-		if (!bindSnapshotSelector) {
-			try {
-				const webReactMod = require("@deepseek-ai/dsh-client-web-react");
-				if (typeof webReactMod.bindSnapshotSelector === "function") bindSnapshotSelector = webReactMod.bindSnapshotSelector;
-			} catch { /* compat 未注入（罕见）→ react 原生兜底 */ }
-		}
+
 		if (!bindSnapshotSelector) {
 			const { useSyncExternalStore } = require("react");
 			bindSnapshotSelector = (source) => {

--- a/dsh-desktop/assets/plugins/dsh-openclaw-bridge/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-openclaw-bridge/lib/client.js
@@ -34,12 +34,7 @@ window.__ModuleLoader__.load({
 				};
 			}
 		} catch { /* 模块不在页面表（rc.7 及更早内核）→ 走下一级回落 */ }
-		if (!bindSnapshotSelector) {
-			try {
-				const webReactMod = require("@deepseek-ai/dsh-client-web-react");
-				if (typeof webReactMod.bindSnapshotSelector === "function") bindSnapshotSelector = webReactMod.bindSnapshotSelector;
-			} catch { /* compat 未注入（罕见）→ react 原生兜底 */ }
-		}
+
 		if (!bindSnapshotSelector) {
 			const { useSyncExternalStore } = require("react");
 			bindSnapshotSelector = (source) => {

--- a/dsh-desktop/assets/plugins/dsh-prompt-custom/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-prompt-custom/lib/client.js
@@ -34,12 +34,7 @@ window.__ModuleLoader__.load({
 				};
 			}
 		} catch { /* 模块不在页面表（rc.7 及更早内核）→ 走下一级回落 */ }
-		if (!bindSnapshotSelector) {
-			try {
-				const webReactMod = require("@deepseek-ai/dsh-client-web-react");
-				if (typeof webReactMod.bindSnapshotSelector === "function") bindSnapshotSelector = webReactMod.bindSnapshotSelector;
-			} catch { /* compat 未注入（罕见）→ react 原生兜底 */ }
-		}
+
 		if (!bindSnapshotSelector) {
 			const { useSyncExternalStore } = require("react");
 			bindSnapshotSelector = (source) => {

--- a/dsh-desktop/assets/plugins/dsh-quest-ui/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-quest-ui/lib/client.js
@@ -88,12 +88,7 @@
 					};
 				}
 			} catch { /* 模块不在页面表（rc.7 及更早内核）→ 走下一级回落 */ }
-			if (!bindSnapshotSelector) {
-				try {
-					const webReactMod = require("@deepseek-ai/dsh-client-web-react");
-					if (typeof webReactMod.bindSnapshotSelector === "function") bindSnapshotSelector = webReactMod.bindSnapshotSelector;
-				} catch { /* compat 未注入（罕见）→ react 原生兜底 */ }
-			}
+
 			if (!bindSnapshotSelector) {
 				const { useSyncExternalStore } = require("react");
 				bindSnapshotSelector = (source) => {

--- a/dsh-desktop/assets/plugins/dsh-third-party-thinking/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-third-party-thinking/lib/client.js
@@ -33,12 +33,7 @@ window.__ModuleLoader__.load({
 				};
 			}
 		} catch { /* 模块不在页面表（rc.7 及更早内核）→ 走下一级回落 */ }
-		if (!bindSnapshotSelector) {
-			try {
-				const webReactMod = require("@deepseek-ai/dsh-client-web-react");
-				if (typeof webReactMod.bindSnapshotSelector === "function") bindSnapshotSelector = webReactMod.bindSnapshotSelector;
-			} catch { /* compat 未注入（罕见）→ react 原生兜底 */ }
-		}
+
 		if (!bindSnapshotSelector) {
 			const { useSyncExternalStore } = require("react");
 			bindSnapshotSelector = (source) => {

--- a/dsh-desktop/assets/plugins/dsh-vision/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-vision/lib/client.js
@@ -32,12 +32,7 @@ window.__ModuleLoader__.load({
         };
       }
     } catch { /* 模块不在页面表（rc.7 及更早内核）→ 走下一级回落 */ }
-    if (!bindSnapshotSelector) {
-      try {
-        const webReactMod = require("@deepseek-ai/dsh-client-web-react");
-        if (typeof webReactMod.bindSnapshotSelector === "function") bindSnapshotSelector = webReactMod.bindSnapshotSelector;
-      } catch { /* compat 未注入（罕见）→ react 原生兜底 */ }
-    }
+
     if (!bindSnapshotSelector) {
       const { useSyncExternalStore } = require("react");
       bindSnapshotSelector = (source) => {


### PR DESCRIPTION
### 修复的原因：

今天下午我拉起更新，npm安装完毕重启exe后，报错：

> Failed to load plugins

> failed to import loader entry 424b85d4 (dsh-session-manager): client-modules: require("@deepseek-ai/dsh-client-web-react") missed the module table — not a platform seed word, not a materialized module, and no registered package factory (a build-time externals drift, or a dynamic dependency that did not arrive)



我发现：系统加载包含 `try { require("@deepseek-ai/dsh-client-web-react") }` 回落机制的插件时，会导致底层 Module Loader 静态分析直接抛出 `missed the module table` 异常并阻断插件加载的 Bug。这会直接导致更新后软件瘫痪（我可以说是“灾难性的bug”吧），根本无法使用。

我看到 **Issue #124** (Commit `d70f558`) 中已经修复了 `dsh-session-manager` 的这个问题，但似乎遗漏了工程中的其他 5 个具有相同逻辑的插件。为了彻底根治该问题，我将剩余插件中容易引发静态词法扫描报错的 `try...catch` 块全数移除。

### 更改的文件：

针对以下 5 个插件，删除了 `bindSnapshotSelector` 对 `@deepseek-ai/dsh-client-web-react` 的 `require` 尝试机制（直接使用 React 原生的 `useSyncExternalStore` 兜底，避免触发加载器白名单审查）：

1. `dsh-vision/lib/client.js`
2. `dsh-conversation-tweaks/lib/client.js`
3. `dsh-prompt-custom/lib/client.js`
4. `dsh-third-party-thinking/lib/client.js`
5. `dsh-openclaw-bridge/lib/client.js`
6. `dsh-quest-ui/lib/client.js`

经过本地实机验证，移除后这些插件均可顺利启动，高级设置面板和视觉组件不再报错。

当然如果这是不可复现的，我本人环境问题的话，可以让我关闭pr。（PS：这是我加入开源社区后提交的第一个PR，谢谢）
