### PR TITLE
perf: 性能与资源占用审计根治——五大系列（进程隔离 / 内核生命周期 / 垫片帧守卫 / 看门狗误判 / 常态开销）

### DIFF
--- a/dsh-tauri/CHANGELOG.md
+++ b/dsh-tauri/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [未发布] — 性能与资源占用审计根治（五大系列）
+
+### 进程隔离：子进程等待全部挪出 UI 主线程
+- **根因**：Tauri 同步命令在 UI 主线程执行——`run_sidecar`（插件/诊断/备份全族）、`copy_text`（每复制一次 spawn PowerShell）、`wsl_config_get`/`wsl_recheck`、`image_paste_save`、`restart_service`/`recovery_restart`（杀树段）一律 `.output()` 同步等子进程，node 冷启动数百 ms 起、插件检查/更新分钟级 → 整窗冻结（拖动/重绘/全部 IPC 派发停摆；menu.rs check-agent-update 注释记录的同一实测形态）。**修法**：统一 `async fn` + `tauri::async_runtime::spawn_blocking`（run_sidecar 串行锁语义不变，排队发生在后台线程池）；新增 `bounded::output_with_timeout`（超时强杀整树）作为壳内子进程唯一有界出口——AV/SmartScreen 拦半死不再永挂，boot 链单步 60s / 整链 120s / sidecar 命令 300s 有界
+- **copy_text 双缺陷**：Windows 命令行 ~32K 上限使长文本（契约允许 1MB）直接失败 + PowerShell 按控制台代码页解析参数的非 ASCII 乱码面 → 改经 stdin 传 base64（纯 ASCII 代码页安全，UTF-8 精确还原），实测 90KB 中英混排往返逐字节一致
+
+### 内核进程生命周期：双内核竞态 / Job 句柄泄漏 / 探活双连接
+- **boot 竞态根治**：内核启动期退出时，崩溃自动重启臂（2s 延迟）与瀑布二层（重跑 boot 链）无互斥 → 两路各拉一个内核，后者覆盖句柄 → 前者成孤儿（数百 MB RSS 无人管直到进程退出）。**修法**：`boot_active` 互斥（BootActiveGuard，Drop 释放 + 代际感知防叠犬误清）+ `spawn_kernel` 前置回收不变量（并发违例时后来者杀先到者）。E2E 实测：伪仓库（假内核秒退 + 二层 boot 放大 5s）瀑布全程恰好 3 次 spawn（修复前 >3）
+- **Job 句柄泄漏**：每次内核 spawn 泄漏一个 Job Object 句柄（进程生命周期不回收，崩溃环/瀑布重试下日积月累上千）→ 句柄随 `KernelProc` 存活、终结即 `close()`（壳存活期间在场，强杀兜底语义不变）
+- **kill_kernel 锁外杀树**：持锁仅取句柄，taskkill（AV 下数百 ms）不再让探活节拍 / state() / kernel_url() 陪等
+- **探活单连接三态**：原实现每拍开两条连接（TCP 试探 + http_alive 各一），健康稳态 ≈ 每天 5.76 万次环回连接 → `probe_outcome` 单连接三态（Alive/TcpDead/Zombie），连接数实测减半、判定口径逐态一致
+
+### 桥垫片：iframe 守卫次序 + 监听器生命周期
+- **iframe 重复壳机制**：Tauri initialization_script 注入所有同源 iframe，守卫却写在壳机制之后——每个 iframe 都装 5s 心跳 + 3s 会话轮询 + 4 个事件订阅（开销随帧数翻倍，iframe 心跳污染全局计数掩蔽主窗假死判定）。**修法**：`IS_TOP` 帧定位前置，壳机制（订阅/心跳/轮询/错误上报/控制条/自初始化）全部主框架独占；桥对象与 dialog polyfill 保留在所有帧（Electron 时代 iframe 本无桥，只会更好）。vm 沙箱行为测试：iframe 载入零 IPC
+- **监听器泄漏**：`plugin:event|listen` 只增不减，每次导航/重载在 Rust 侧监听表留死条目（emit 向死句柄派发）→ pagehide 统一退订 + 清定时器（listen Promise 未决时 resolve 后补位退订）
+- **心跳窗口归属**：心跳载荷带 `{window: main|float|pet}`，假死看门狗只统计主窗——全窗口共用计数时活的浮窗永久掩蔽死的主窗（漏恢复）
+
+### 假死看门狗：最小化误判
+- Windows 上最小化窗 `is_visible` 仍为 true，缺 `is_minimized` 检查时定时器节流（~1 次/分）被误判为心跳停摆 → 最小化期间每 ~5-6 分钟一次 `location.reload()` 风暴（SPA 状态丢弃 + 监听器累积）。**修法**：失联判定统一 `common::window_watchable`（可见且未最小化，与余额轮询暂停门单一口径）
+
+### sidecar（Node）
+- **模块懒加载**：全部子命令共用 `loadModules` 全量 require 15 模块（patch-registry 729 行等），每 3 分钟的 balance-fetch 也整套装载（58ms+/次，AV 机器放大；未消费模块缺失还直接炸命令）→ getter 懒加载，消费面零变更；实测最小 appDir（仅 balance 两件套）balance-fetch 正常
+- **插件解压有界**：`Expand-Archive`/`unzip` 此前 `execFileSync` 无超时（AV 拦半死 → 更新链永挂 + Rust 侧串行锁被占死）→ `exec-bounded.js` 统一有界出口（120s，超时杀进程）
+- **httpGetJson 字节上限**：元数据通道（npm latest / GitHub Releases，先于 integrity 校验）原实现响应体无限累积成字符串 → 4MB 上限（对照 httpGetBuffer 64MB / balance.js 1MB，该文件族唯一缺口）
+
+### 壳层小项
+- `app_init` 三键单次读盘（SettingsStore::get 每键全量读 settings.json，垫片每次载入 + 每次菜单打开都触发）
+- `[diag] t0` 探针改 `DSH_TAURI_DIAG=1` 门控（原无条件执行：每次内核就绪顶掉真实会话指针 + preview-server 空转）
+- 静态页目录（%TEMP%/dsh-tauri-pages-*）退出清理 + 启动清扫 7 天前残留（强杀形态此前无限累积）
+
 ## [0.5.2] — 2026-08-22
 
 ### 修复（用户实测反馈驱动）

--- a/dsh-tauri/contracts/bridge-api.md
+++ b/dsh-tauri/contracts/bridge-api.md
@@ -143,9 +143,9 @@
 
 | 上行 | 载荷/节律 | 语义 |
 |------|-----------|------|
-| renderer 心跳 | 5s 一次 + `visibilitychange` 可见时立即补报 | 挂起兜底判定（仅可见窗口） |
-| `page-error` | `window.onerror` / `unhandledrejection` 文本 | 页面异常 → desktop.log |
-| `current-session` | 3s 轮询 `localStorage['dsh.sessions.current']`，变化才发 | 当前观看会话（通知调试日志用） |
+| renderer 心跳 | 5s 一次 + `visibilitychange` 可见时立即补报；载荷带窗口归属标签 `{window: 'main'\|'float'\|'pet'}`，**仅主框架发送**（iframe 全跳过——开销不随帧数翻倍，iframe 心跳不污染主窗计数） | 挂起兜底判定（仅可见且未最小化的主窗；浮窗/宠物窗心跳不参与判定） |
+| `page-error` | `window.onerror` / `unhandledrejection` 文本 | 页面异常 → desktop.log（仅主框架上报） |
+| `current-session` | 3s 轮询 `localStorage['dsh.sessions.current']`，变化才发（仅主框架） | 当前观看会话（通知调试日志用） |
 | `float:close` / `pet:close` / `pet:move-to` / `pet:set-auto-open` | — | 见 §2.6 / §2.9 |
 
 ## 5. 模式全局（浮窗 / 宠物窗）

--- a/dsh-tauri/sidecar/bridge-shim.test.js
+++ b/dsh-tauri/sidecar/bridge-shim.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * bridge-shim.js 行为级测试（vm 沙箱，无需 WebView）
+ * ====================================================
+ * 运行：`node --test sidecar/bridge-shim.test.js`（仓库 dsh-tauri/ 目录下）。
+ *
+ * 覆盖（contracts/bridge-api.md §4/§5 的页面侧行为）：
+ *  - iframe 帧必须跳过全部壳机制（心跳/事件订阅/会话轮询/错误上报）——
+ *    Tauri initialization_script 会注入所有同源 iframe（synapse /synapse/ 等），
+ *    Electron contextBridge 只跑主框架。历史缺陷：守卫写在壳机制之后，
+ *    每个 iframe 都装 5s 心跳 + 3s 会话轮询 + 4 个事件订阅（N 帧翻倍开销，
+ *    且 iframe 心跳污染全局计数、掩蔽主窗假死判定）。
+ *  - 主框架：心跳带窗口归属标签（main/float/pet）——假死看门狗只看主窗。
+ *  - pagehide 生命周期：事件订阅必须经 plugin:event|unlisten 退订——
+ *    历史缺陷：listen 只增不减，每次导航/重载在 Rust 侧监听表留死条目。
+ *  - 桥对象（window.dshDesktop 48 方法）与 dialog polyfill 在所有帧可用
+ *    （兼容性：iframe 内插件可能消费桥/确认框）。
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SHIM_PATH = path.resolve(__dirname, '..', 'src-tauri', 'crates', 'bridge', 'dist', 'bridge-shim.js');
+const SHIM_SRC = fs.readFileSync(SHIM_PATH, 'utf8');
+
+/**
+ * 构造最小页面沙箱并执行垫片。
+ * mode: 'top'（主框架）| 'iframe'（window.top !== window.self）
+ *       | 'float' / 'pet'（主框架 + 模式注入变量，同 windows.rs 真实注入序）
+ * 返回 { invokes, timers, winListeners, docListeners, firePagehide,
+ *        fireInterval, window }。
+ */
+function runShim(mode) {
+  const invokes = [];           // { cmd, args }
+  const timers = [];            // { id, fn, ms, cleared }
+  const winListeners = {};      // type → [fn]
+  const docListeners = {};
+  let listenSeq = 100;          // plugin:event|listen 返回的事件 id 序列
+  let cbSeq = 1;
+
+  const sandbox = {};
+  const fakeTop = mode === 'iframe' ? { __fake: 'top' } : null;
+
+  const internals = {
+    invoke: (cmd, args) => {
+      invokes.push({ cmd, args: args || {} });
+      if (cmd === 'plugin:event|listen') return Promise.resolve(listenSeq++);
+      if (cmd === 'app_init') return Promise.resolve({ appVersion: '0.0.0-test' });
+      return Promise.resolve(null);
+    },
+    transformCallback: (cb) => { void cb; return cbSeq++; },
+  };
+
+  const windowObj = {
+    __TAURI_INTERNALS__: internals,
+    addEventListener: (type, fn) => { (winListeners[type] = winListeners[type] || []).push(fn); },
+    dispatchEvent: () => true,
+    CustomEvent: function CustomEvent(type, init) { this.type = type; this.detail = init && init.detail; },
+    MutationObserver: function MutationObserver() { this.observe = () => {}; this.disconnect = () => {}; },
+  };
+  windowObj.window = windowObj;
+  windowObj.self = windowObj;
+  windowObj.top = fakeTop || windowObj;
+  if (mode === 'float') windowObj.__DSH_FLOAT__ = Object.freeze({ sessionId: 's1' });
+  if (mode === 'pet') windowObj.__DSH_PET__ = {};
+
+  const documentObj = {
+    addEventListener: (type, fn) => { (docListeners[type] = docListeners[type] || []).push(fn); },
+    getElementById: () => null,
+    createElement: () => ({ style: {}, setAttribute: () => {}, appendChild: () => {} }),
+    hidden: false,
+    readyState: 'complete',
+  };
+
+  Object.assign(sandbox, {
+    window: windowObj,
+    document: documentObj,
+    localStorage: {
+      getItem: (k) => (k === 'dsh.sessions.current' ? '{"sessionId":"sess-abc"}' : null),
+      setItem: () => {},
+    },
+    setInterval: (fn, ms) => { const id = timers.length + 1; timers.push({ id, fn, ms, cleared: false }); return id; },
+    clearInterval: (id) => { const t = timers.find((x) => x.id === id); if (t) t.cleared = true; },
+    setTimeout: (fn) => { void fn; return 0; }, // 载入路径上的 setTimeout 不需要真实触发
+    clearTimeout: () => {},
+    console,
+    Promise,
+    MutationObserver: windowObj.MutationObserver,
+    CustomEvent: windowObj.CustomEvent,
+  });
+  windowObj.setInterval = sandbox.setInterval;
+  windowObj.clearInterval = sandbox.clearInterval;
+  windowObj.setTimeout = sandbox.setTimeout;
+  windowObj.clearTimeout = sandbox.clearTimeout;
+  windowObj.console = console;
+  windowObj.localStorage = sandbox.localStorage;
+  windowObj.document = documentObj;
+
+  vm.createContext(sandbox);
+  vm.runInContext(SHIM_SRC, sandbox, { filename: 'bridge-shim.js' });
+
+  return {
+    invokes,
+    timers,
+    winListeners,
+    docListeners,
+    window: windowObj,
+    count: (cmd) => invokes.filter((i) => i.cmd === cmd).length,
+    firePagehide: () => { (winListeners.pagehide || []).forEach((fn) => fn()); },
+    fireHeartbeatInterval: () => { timers.filter((t) => !t.cleared && t.ms === 5000).forEach((t) => t.fn()); },
+  };
+}
+
+test('iframe：全部壳机制跳过（零 IPC），桥对象与 dialog polyfill 仍可用', () => {
+  const s = runShim('iframe');
+  // 历史缺陷实证锚点：守卫次序错误时 iframe 会装 4 个事件订阅 + 心跳 + 会话轮询。
+  assert.strictEqual(s.count('plugin:event|listen'), 0, `iframe 不得注册事件订阅，实际: ${JSON.stringify(s.invokes.map((i) => i.cmd))}`);
+  assert.strictEqual(s.count('renderer_heartbeat'), 0, 'iframe 不得发心跳（污染全局计数 → 掩蔽主窗假死判定）');
+  assert.strictEqual(s.count('current_session'), 0, 'iframe 不得起会话轮询（主框架已在跑，N 帧重复上报）');
+  assert.strictEqual(s.invokes.length, 0, `iframe 载入路径不得有任何 IPC（兼容保留的 getInfo 自初始化也归主框架）: ${JSON.stringify(s.invokes.map((i) => i.cmd))}`);
+  assert.strictEqual(s.timers.length, 0, 'iframe 不得注册任何定时器');
+  // 桥对象与 polyfill 必须保留（兼容性：iframe 内插件可能消费）。
+  assert.ok(s.window.dshDesktop, 'window.dshDesktop 必须在 iframe 内可用');
+  assert.strictEqual(typeof s.window.dshDesktop.copyText, 'function');
+  assert.strictEqual(s.window.confirm(), true, 'confirm polyfill 必须在场（删除确认不得恒取消）');
+});
+
+test('主框架：心跳带 main 标签；4 事件订阅；会话上报；getInfo 自初始化', () => {
+  const s = runShim('top');
+  const beats = s.invokes.filter((i) => i.cmd === 'renderer_heartbeat');
+  assert.ok(beats.length >= 1, '主框架载入即发首拍心跳');
+  for (const b of beats) {
+    assert.strictEqual(b.args.window, 'main', `心跳必须带窗口归属标签 main: ${JSON.stringify(b.args)}`);
+  }
+  assert.strictEqual(s.count('plugin:event|listen'), 4, '主框架注册 4 个事件订阅');
+  assert.strictEqual(s.count('current_session'), 1, 'localStorage 变化上报一次');
+  assert.strictEqual(s.count('app_init'), 1, 'getInfo 自初始化');
+  // 心跳 interval 继续带标签。
+  s.fireHeartbeatInterval();
+  assert.strictEqual(s.invokes.filter((i) => i.cmd === 'renderer_heartbeat' && i.args.window === 'main').length, beats.length + 1);
+});
+
+test('浮窗/宠物窗：心跳分别带 float / pet 标签（不参与主窗假死判定）', () => {
+  const f = runShim('float');
+  const fbeats = f.invokes.filter((i) => i.cmd === 'renderer_heartbeat');
+  assert.ok(fbeats.length >= 1);
+  for (const b of fbeats) assert.strictEqual(b.args.window, 'float', `浮窗心跳标签: ${JSON.stringify(b.args)}`);
+
+  const p = runShim('pet');
+  const pbeats = p.invokes.filter((i) => i.cmd === 'renderer_heartbeat');
+  assert.ok(pbeats.length >= 1);
+  for (const b of pbeats) assert.strictEqual(b.args.window, 'pet', `宠物窗心跳标签: ${JSON.stringify(b.args)}`);
+});
+
+test('pagehide：4 个事件订阅全部经 plugin:event|unlisten 退订；定时器清除', async () => {
+  const s = runShim('top');
+  const listened = s.invokes.filter((i) => i.cmd === 'plugin:event|listen');
+  assert.strictEqual(listened.length, 4);
+  // listen 的 Promise 在微任务队列解析——退订闭包注册需等一拍。
+  await new Promise((r) => setImmediate(r));
+  assert.ok(s.winListeners.pagehide && s.winListeners.pagehide.length > 0, '必须挂 pagehide 生命周期收尾');
+  s.firePagehide();
+  await new Promise((r) => setImmediate(r));
+  const unlistens = s.invokes.filter((i) => i.cmd === 'plugin:event|unlisten');
+  assert.strictEqual(unlistens.length, 4, `pagehide 必须退订全部 4 个订阅（历史缺陷：只增不减）: ${JSON.stringify(s.invokes.map((i) => i.cmd))}`);
+  const ids = unlistens.map((u) => u.args.id);
+  for (const id of ids) assert.ok(Number.isInteger(id), `unlisten 必须带 listen 返回的事件 id: ${JSON.stringify(ids)}`);
+  assert.strictEqual(new Set(ids).size, 4, '事件 id 不得重复');
+  // 定时器（心跳/会话轮询）在 pagehide 后清除。
+  const live = s.timers.filter((t) => !t.cleared);
+  assert.strictEqual(live.length, 0, `pagehide 后不得残留定时器: ${JSON.stringify(s.timers)}`);
+});

--- a/dsh-tauri/sidecar/cli-perf.test.js
+++ b/dsh-tauri/sidecar/cli-perf.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * sidecar CLI 性能与资源上界测试
+ * =================================
+ * 运行：`node --test sidecar/cli-perf.test.js`（仓库 dsh-tauri/ 目录下）。
+ *
+ * 覆盖（性能审计 2026-08 的三个 Node 侧根因）：
+ *  1. 模块懒加载：全部子命令共用 ctxFromArgs→loadModules 入口，而多数子命令
+ *     只碰一两个模块——此前 15 个模块全量 require（patch-registry 729 行等），
+ *     每 3 分钟的 balance-fetch 也整套装载（纯启动开销）。懒加载后：缺失的
+ *     重量级模块不再炸（最小 appDir 只有 balance 两件套也能跑 balance-fetch）。
+ *  2. 子进程有界：plugin-update 的 zip 解压此前 execFileSync 无超时——
+ *     AV/SmartScreen 拦半死时更新链永挂，并占死 Rust 侧串行锁。
+ *  3. httpGetJson 字节上限：元数据通道（npm latest / GitHub Releases）无
+ *     integrity 校验，此前响应体无限累积成字符串（对照 httpGetBuffer 的
+ *     64MB 与 balance.js 的 1MB，这是唯一缺口）。
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+const { spawnSync } = require('node:child_process');
+
+const CLI = path.join(__dirname, 'cli.js');
+const APP_DIR = path.resolve(__dirname, '..', '..', 'dsh-desktop');
+
+test('懒加载：balance-fetch 只装 balance 两件套（缺失的重量级模块不再炸）', () => {
+  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-lazy-appdir-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-lazy-home-'));
+  try {
+    // 最小 appDir：仅 balance-fetch 实际消费的两个模块（scripts/、plugin-guard
+    // 等全部缺席）。全量装载形态（历史缺陷）在此必然 Cannot find module。
+    fs.copyFileSync(path.join(APP_DIR, 'balance.js'), path.join(appDir, 'balance.js'));
+    fs.copyFileSync(path.join(APP_DIR, 'balance-scheduler.js'), path.join(appDir, 'balance-scheduler.js'));
+    const r = spawnSync(process.execPath, [CLI, 'balance-fetch', '--app-dir', appDir], {
+      encoding: 'utf8',
+      env: { ...process.env, DSH_HOME: home, DSH_TAURI_USERDATA: path.join(home, 'ud') },
+      timeout: 30_000,
+    });
+    const lastLine = (r.stdout || '').trimEnd().split('\n').pop() || '';
+    let json = null;
+    try { json = JSON.parse(lastLine); } catch { /* 保持 null */ }
+    assert.ok(json && typeof json === 'object', `stdout 末行应为 JSON（结构化降级不炸进程）: ${lastLine.slice(0, 200)}`);
+    assert.ok(
+      !(json.error && /Cannot find module/.test(String(json.error))),
+      `balance-fetch 不得因未消费的重量级模块装载失败（懒加载锚点）: ${json.error}`
+    );
+    assert.strictEqual(typeof json.ok, 'boolean', '载荷形态：ok 布尔（无密钥 → ok:false 结构化降级）');
+  } finally {
+    fs.rmSync(appDir, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+const { execFileBounded, DEFAULT_TIMEOUT_MS } = require('./exec-bounded');
+
+test('exec-bounded：挂死子进程超时被杀（有界锚点）', async () => {
+  const t0 = Date.now();
+  await assert.rejects(
+    execFileBounded(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], { timeoutMs: 400 }),
+    /超时/
+  );
+  const ms = Date.now() - t0;
+  assert.ok(ms < 5_000, `超时须及时返回（实测 {ms}ms）——否则与无超时同罪`);
+});
+
+test('exec-bounded：正常退出 resolve；非零退出码 reject', async () => {
+  await execFileBounded(process.execPath, ['-e', '']);
+  await assert.rejects(execFileBounded(process.execPath, ['-e', 'process.exit(3)']), /退出码 3/);
+});
+
+test('exec-bounded：缺省超时为有界值（不得回退无界）', () => {
+  assert.ok(Number.isFinite(DEFAULT_TIMEOUT_MS) && DEFAULT_TIMEOUT_MS > 0, '缺省超时必须是有限正值');
+});
+
+const { httpGetJson, MAX_JSON_BYTES } = require('./http-json');
+
+test('http-json：超上限响应被拒绝（内存上界锚点）', async () => {
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    // 流式慢滴 5MB（无 Content-Length，真实慢滴形态）。
+    const chunk = 'x'.repeat(64 * 1024);
+    let sent = 0;
+    const t = setInterval(() => {
+      res.write(chunk);
+      sent += chunk.length;
+      if (sent > 5 * 1024 * 1024) { clearInterval(t); res.end(); }
+    }, 5);
+    req.on('close', () => clearInterval(t));
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const url = `http://127.0.0.1:${server.address().port}/latest`;
+  try {
+    await assert.rejects(httpGetJson(url, 5000), /上限/);
+  } finally {
+    server.close();
+  }
+});
+
+test('http-json：合法小 JSON 正常解析；非 200 拒绝', async () => {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/ok') { res.writeHead(200); res.end(JSON.stringify({ version: '1.2.3' })); }
+    else { res.writeHead(404); res.end('nope'); }
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const v = await httpGetJson(base + '/ok', 2000);
+    assert.deepStrictEqual(v, { version: '1.2.3' });
+    await assert.rejects(httpGetJson(base + '/missing', 2000), /HTTP 404/);
+  } finally {
+    server.close();
+  }
+  assert.ok(MAX_JSON_BYTES > 0, '上限常量必须存在且为正');
+});

--- a/dsh-tauri/sidecar/cli.js
+++ b/dsh-tauri/sidecar/cli.js
@@ -91,25 +91,38 @@ function emit(value) {
 // ---------------------------------------------------------------------------
 
 function loadModules(appDir) {
+  // 懒加载（性能审计 2026-08）：全部子命令共用 ctxFromArgs→loadModules 入口，
+  // 而多数子命令只碰一两个模块——此前 15 个模块全量 require（patch-registry
+  // 729 行等），每 3 分钟的 balance-fetch 也整套装载（纯启动开销；缺失的
+  // 未消费模块还会直接炸掉整个命令）。getter 对 mods.* 消费方透明，接口
+  // 零变更；require 缓存保证重复访问零成本。
   // Electron 版 main.js 顶部 require 的相对路径在这里以 appDir 为根解析。
-  const req = (rel) => require(path.join(appDir, rel));
-  return {
-    integration: req('scripts/integration'),
-    presetInstaller: req('scripts/install-minimal-win-preset'),
-    pluginManagerPatch: req('scripts/plugin-manager-patch'),
-    pluginManagerUpdate: req('scripts/plugin-manager-update'),
-    companionPlugins: req('scripts/lib/companion-plugins'),
-    profileReconcile: req('scripts/lib/profile-reconcile'),
-    profilePatchHeal: req('profile-patch-heal'),
-    patchIo: req('scripts/lib/patch-io'),
-    githubReleaseAssets: req('scripts/lib/github-release-assets'),
-    desktopDiagnostics: req('scripts/desktop-diagnostics'),
-    desktopBackup: req('scripts/desktop-backup'),
-    desktopOrdering: req('scripts/desktop-ordering'),
-    desktopValidity: req('scripts/desktop-validity'),
-     sessionWatcher: req('session-watcher'),
-    pluginGuard: req('plugin-guard'),
+  const defs = {
+    integration: 'scripts/integration',
+    presetInstaller: 'scripts/install-minimal-win-preset',
+    pluginManagerPatch: 'scripts/plugin-manager-patch',
+    pluginManagerUpdate: 'scripts/plugin-manager-update',
+    companionPlugins: 'scripts/lib/companion-plugins',
+    profileReconcile: 'scripts/lib/profile-reconcile',
+    profilePatchHeal: 'profile-patch-heal',
+    patchIo: 'scripts/lib/patch-io',
+    githubReleaseAssets: 'scripts/lib/github-release-assets',
+    desktopDiagnostics: 'scripts/desktop-diagnostics',
+    desktopBackup: 'scripts/desktop-backup',
+    desktopOrdering: 'scripts/desktop-ordering',
+    desktopValidity: 'scripts/desktop-validity',
+    sessionWatcher: 'session-watcher',
+    pluginGuard: 'plugin-guard',
   };
+  const mods = {};
+  for (const name of Object.keys(defs)) {
+    const rel = defs[name];
+    Object.defineProperty(mods, name, {
+      enumerable: true,
+      get() { return require(path.join(appDir, rel)); },
+    });
+  }
+  return mods;
 }
 
 /**
@@ -397,30 +410,10 @@ function createPluginManager(mods, { appDir, home }) {
     'side-session': { kind: 'github', repo: 'hzhz314159/dsh-side-session' },
   };
 
-  function httpGetJson(url, timeoutMs = 15000, headers = {}, redirects = 0) {
-    return new Promise((resolve, reject) => {
-      if (redirects > 5) return reject(new Error('重定向次数过多'));
-      let client;
-      try {
-        const u = new URL(url);
-        client = u.protocol === 'https:' ? https : require('node:http');
-      } catch (err) { return reject(err); }
-      const req = client.get(url, { headers: { 'User-Agent': 'DSH-Desktop', ...headers }, timeout: timeoutMs }, (res) => {
-        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          res.resume();
-          return resolve(httpGetJson(new URL(res.headers.location, url).toString(), timeoutMs, headers, redirects + 1));
-        }
-        let data = '';
-        res.on('data', (c) => { data += c; });
-        res.on('end', () => {
-          if (res.statusCode !== 200) return reject(new Error('HTTP ' + res.statusCode));
-          try { resolve(JSON.parse(data)); } catch { reject(new Error('响应不是合法 JSON')); }
-        });
-      });
-      req.on('timeout', () => req.destroy(new Error('请求超时')));
-      req.on('error', (err) => reject(err));
-    });
-  }
+  // httpGetJson 迁至 ./http-json（性能审计 2026-08：补齐响应体字节上限——
+  // 本通道服务 npm latest / GitHub Releases 元数据，先于 integrity 校验、
+  // 无完整性保护，原实现无限累积成字符串）。重定向/超时/UA 语义不变。
+  const { httpGetJson } = require('./http-json');
 
   function httpGetBuffer(url, timeoutMs = 60000, redirects = 0) {
     return new Promise((resolve, reject) => {
@@ -526,14 +519,16 @@ function createPluginManager(mods, { appDir, home }) {
       } else {
         // zip：Windows 走 PowerShell Expand-Archive；其余平台 unzip（macOS 系统
         // 自带，多数 Linux 发行版预装——缺失时报可读错误，不再静默 ENOENT）。
-        const { execFileSync } = require('node:child_process');
+        // 有界执行（性能审计 2026-08）：execFileSync 无超时时，AV/SmartScreen
+        // 把解压子进程拦到半死 → 更新链永挂 + Rust 侧串行锁被占死。
+        const { execFileBounded } = require('./exec-bounded');
         const zipPath = path.join(tmp, 'dl.zip');
         fs.writeFileSync(zipPath, buf);
         const dest = path.join(tmp, 'x');
         if (process.platform === 'win32') {
-          execFileSync('powershell', ['-NoProfile', '-Command', `Expand-Archive -LiteralPath '${zipPath}' -DestinationPath '${dest}' -Force`], { stdio: 'ignore' });
+          await execFileBounded('powershell', ['-NoProfile', '-Command', `Expand-Archive -LiteralPath '${zipPath}' -DestinationPath '${dest}' -Force`], { timeoutMs: 120_000 });
         } else {
-          execFileSync('unzip', ['-o', zipPath, '-d', dest], { stdio: 'ignore' });
+          await execFileBounded('unzip', ['-o', zipPath, '-d', dest], { timeoutMs: 120_000 });
         }
       }
       const root = findPackageRoot(tmp);

--- a/dsh-tauri/sidecar/exec-bounded.js
+++ b/dsh-tauri/sidecar/exec-bounded.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * 有界子进程执行（超时强杀）
+ * ==========================
+ * sidecar 内长命子进程的统一出口。
+ *
+ * 历史缺陷（性能审计 2026-08）：plugin-update 的 zip 解压走
+ * execFileSync('powershell'/'unzip') 且无超时——AV/SmartScreen 把子进程
+ * 拦到半死时（supervisor.rs D2 诊断记录的同族形态），插件更新链永挂，
+ * 还会占死 Rust 侧 run_sidecar 的全局串行锁（后续所有 sidecar 命令排队）。
+ * 与 koffi-preflight 的 execFileSync timeout: 20000 同思路，收口成公共件。
+ */
+
+const { spawn } = require('node:child_process');
+
+/** 缺省上限：解压一个插件包（≤64MB 下载上限）绰绰有余，AV 拖慢也有界。 */
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * 执行子进程，成功（退出码 0）resolve，超时/失败 reject。
+ * 超时立即 kill 子进程（不留半死进程占资源）。
+ */
+function execFileBounded(file, args, opts = {}) {
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timer = null;
+    const done = (err) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (err) reject(err); else resolve();
+    };
+    let child;
+    try {
+      child = spawn(file, args, { stdio: opts.stdio || 'ignore', windowsHide: true });
+    } catch (err) {
+      return reject(err);
+    }
+    timer = setTimeout(() => {
+      child.kill();
+      done(new Error(`子进程超时（${timeoutMs}ms）被终止: ${file}`));
+    }, timeoutMs);
+    child.on('error', done);
+    child.on('exit', (code, signal) => {
+      if (signal) done(new Error(`子进程被信号终止: ${signal}`));
+      else if (code === 0) done();
+      else done(new Error(`子进程退出码 ${code}`));
+    });
+  });
+}
+
+module.exports = { execFileBounded, DEFAULT_TIMEOUT_MS };

--- a/dsh-tauri/sidecar/http-json.js
+++ b/dsh-tauri/sidecar/http-json.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * HTTP JSON 拉取（重定向 / 超时 / 字节上限）
+ * ==========================================
+ * 从 cli.js 原样迁出（重定向链、超时、User-Agent 语义不变），补齐字节上限。
+ *
+ * 历史缺陷（性能审计 2026-08）：响应体无限累积成字符串——本通道服务
+ * npm latest / GitHub Releases 元数据（先于 integrity 校验，无任何完整性
+ * 保护），慢滴或巨型响应可吃满内存。对照 httpGetBuffer 的 64MB 与
+ * balance.js 的 1MB maxBodyBytes，这是该文件族唯一的缺口。
+ */
+
+const https = require('node:https');
+
+/** 元数据通道上限：真实负载 <100KB，4MB 已极宽裕。 */
+const MAX_JSON_BYTES = 4 * 1024 * 1024;
+
+function httpGetJson(url, timeoutMs = 15000, headers = {}, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 5) return reject(new Error('重定向次数过多'));
+    let client;
+    try {
+      const u = new URL(url);
+      client = u.protocol === 'https:' ? https : require('node:http');
+    } catch (err) { return reject(err); }
+    const req = client.get(url, { headers: { 'User-Agent': 'DSH-Desktop', ...headers }, timeout: timeoutMs }, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume();
+        return resolve(httpGetJson(new URL(res.headers.location, url).toString(), timeoutMs, headers, redirects + 1));
+      }
+      const chunks = [];
+      let total = 0;
+      let limitHit = false;
+      res.on('data', (c) => {
+        if (limitHit) return;
+        total += c.length;
+        if (total > MAX_JSON_BYTES) {
+          limitHit = true;
+          req.destroy(new Error(`响应超过 ${MAX_JSON_BYTES} 字节上限`));
+          return;
+        }
+        chunks.push(c);
+      });
+      res.on('end', () => {
+        if (limitHit) return;
+        if (res.statusCode !== 200) return reject(new Error('HTTP ' + res.statusCode));
+        try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf8'))); }
+        catch { reject(new Error('响应不是合法 JSON')); }
+      });
+    });
+    req.on('timeout', () => req.destroy(new Error('请求超时')));
+    req.on('error', (err) => reject(err));
+  });
+}
+
+module.exports = { httpGetJson, MAX_JSON_BYTES };

--- a/dsh-tauri/src-tauri/Cargo.lock
+++ b/dsh-tauri/src-tauri/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "bridge"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
 ]
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-tauri-app"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bridge",
  "embed-resource",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "field-offset"
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-process"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "poc-sidecar-spawn"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "kernel-process",
 ]
@@ -2770,7 +2770,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preview-server"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "proc-macro-crate"
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "session-watcher"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "sha2"
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "shell-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3445,7 +3445,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sidecar-orchestrator"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "signal-hook-registry"

--- a/dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js
+++ b/dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js
@@ -16,6 +16,56 @@
  */
 (function () {
   if (window.dshDesktop) return; // 幂等（重复注入防御）
+  // ---- 帧定位（必须在任何壳机制之前）----------------------------------
+  // Tauri initialization_script 会注入同源所有 iframe（synapse /synapse/ 等），
+  // 而 Electron contextBridge 只跑主框架。守卫必须先于事件订阅/心跳/会话
+  // 轮询/错误上报/控制条注入——历史缺陷：守卫写在壳机制之后，每个 iframe
+  // 都装 5s 心跳 + 3s 会话轮询 + 4 个事件订阅（开销随帧数翻倍，且 iframe
+  // 心跳污染全局计数、掩蔽主窗假死判定）。
+  // 桥对象（window.dshDesktop）与 dialog polyfill 保留在所有帧（兼容性：
+  // iframe 内插件可能消费桥/确认框；Electron 时代 iframe 本无桥，只会更好）。
+  var IS_TOP = false;
+  try { IS_TOP = window.top === window.self; } catch (e) { /* 跨源受限帧按 iframe 处理 */ }
+  // 窗口归属标签：假死看门狗只统计主窗（main）心跳；浮窗/宠物窗独立标签，
+  // 不再与主窗共用一个全局计数（浮窗活着 ≠ 主窗活着）。
+  var WINDOW_LABEL = 'main';
+  try {
+    if (window.__DSH_FLOAT__) WINDOW_LABEL = 'float';
+    else if (window.__DSH_PET__) WINDOW_LABEL = 'pet';
+  } catch (e) {}
+
+  // ---- 页面生命周期收尾（防跨导航累积）-------------------------------
+  // Tauri 的 plugin:event|listen 在 Rust 侧监听表登记，页面导航/重载后旧
+  // 回调死亡但表项残留（emit 仍向死句柄派发）——pagehide 统一退订 + 清
+  // 定时器（listen 的 Promise 未决时先挂起，resolve 后补位退订）。
+  var lifecycleTimers = [];
+  var eventUnsubscribers = [];
+  var pageHidden = false;
+  function armLifecycleTimer(id) { if (id !== undefined) lifecycleTimers.push(id); return id; }
+  function onEventDone(registered, name) {
+    if (!registered || typeof registered.then !== 'function') return;
+    eventUnsubscribers.push(registered.then(function (id) {
+      var unsub = function () {
+        try { INVOKE('plugin:event|unlisten', { event: name, id: id }).catch(function () {}); } catch (e) {}
+      };
+      if (pageHidden) unsub(); // pagehide 先于注册完成：立即补位退订
+      return unsub;
+    }).catch(function () { /* 注册失败即无退订义务 */ }));
+  }
+  function onPageHide() {
+    if (pageHidden) return;
+    pageHidden = true;
+    while (eventUnsubscribers.length) {
+      var entry = eventUnsubscribers.pop();
+      if (entry && typeof entry.then === 'function') {
+        entry.then(function (unsub) { try { if (typeof unsub === 'function') unsub(); } catch (e) {} });
+      }
+    }
+    while (lifecycleTimers.length) {
+      try { clearInterval(lifecycleTimers.pop()); } catch (e) {}
+    }
+  }
+
   // ---- WebView2 原生 dialog polyfill ---------------------------------
   // Tauri/wry (WebView2) 不弹原生 confirm/alert/prompt：confirm 恒 false、
   // alert/prompt 静默。dsh-session-manager 的删除确认走 window.confirm →
@@ -58,12 +108,12 @@
   }
   function send(cmd, args) { call(cmd, args).catch(function () { /* fire-and-forget：失败只静默 */ }); }
 
-  // ---- 事件（主进程 → 页面）----
+  // ---- 事件（主进程 → 页面；仅主框架订阅，见帧定位守卫）----
   var listeners = { maximize: [], jump: [], balance: [], pet: [] };
   function onEvent(name, queue, map) {
     if (!INVOKE || !TRANSFORM) return;
     try {
-      INVOKE('plugin:event|listen', {
+      var registered = INVOKE('plugin:event|listen', {
         event: name,
         target: { kind: 'Any' },
         handler: TRANSFORM(function (payload) {
@@ -71,58 +121,15 @@
             try { queue[i](map ? map(payload) : payload); } catch (e) { /* 订阅方异常不外溢 */ }
           }
         })
-      }).catch(function () { /* 事件系统不可用时静默（浏览器模式） */ });
+      });
+      if (registered && typeof registered.catch === 'function') {
+        registered.catch(function () { /* 事件系统不可用时静默（浏览器模式） */ });
+      }
+      onEventDone(registered, name);
     } catch (e) { /* 同上 */ }
   }
-  onEvent('window-maximized', listeners.maximize, Boolean);
-  onEvent('notification-jump', listeners.jump, function (p) {
-    var id = p && typeof p.sessionId === 'string' ? p.sessionId.trim() : '';
-    return id && id.length <= 256 ? Object.freeze({ sessionId: id }) : null;
-  });
-  onEvent('balance-changed', listeners.balance, function (p) { return p; });
-  onEvent('pet-state', listeners.pet, function (p) { return p || {}; });
 
-  // ---- 余额 / 宠物状态 → window CustomEvent（契约 §3，dsh-balance / harness-pet 消费）----
-  listeners.balance.push(function (data) {
-    try { window.dispatchEvent(new CustomEvent('dsh-balance-changed', { detail: data })); } catch (e) {}
-  });
-  listeners.pet.push(function (data) {
-    try { window.dispatchEvent(new CustomEvent('dsh-pet-state', { detail: data })); } catch (e) {}
-  });
-
-  // ---- 通知跳转补发（订阅前收到的最后一次保留）----
-  var pendingJump = null;
-  listeners.jump.push(function (jump) { if (jump) pendingJump = jump; });
-
-  // ---- 心跳：5s + visibilitychange 补报（契约 §4）----
-  send('renderer_heartbeat');
-  setInterval(function () { send('renderer_heartbeat'); }, 5000);
-  document.addEventListener('visibilitychange', function () {
-    if (!document.hidden) send('renderer_heartbeat');
-  });
-
-  // ---- 页面异常上报（契约 §4）----
-  window.addEventListener('error', function (e) {
-    send('page_error', { message: 'window.onerror: ' + ((e && (e.message || e.error)) || 'unknown') });
-  });
-  window.addEventListener('unhandledrejection', function (e) {
-    send('page_error', { message: 'unhandledrejection: ' + String((e && e.reason && (e.reason.message || e.reason)) || e) });
-  });
-
-  // ---- 当前会话上报：3s 轮询 localStorage，变化才发（契约 §4）----
-  (function () {
-    var last = '';
-    var tick = function () {
-      try {
-        var raw = localStorage.getItem('dsh.sessions.current');
-        var parsed = raw ? JSON.parse(raw) : null;
-        var id = parsed && typeof parsed === 'object' ? String(parsed.sessionId || '') : '';
-        if (id && id !== last) { last = id; send('current_session', { sessionId: id }); }
-      } catch (e) { /* 会话未就绪时无值 */ }
-    };
-    tick();
-    setInterval(tick, 3000);
-  })();
+  // ---- 桥对象（48 方法，签名见 contracts/bridge-api.md）----
 
   // ---- 桥对象（48 方法，签名见 contracts/bridge-api.md）----
   var dshDesktop = {
@@ -226,6 +233,62 @@
   };
 
   Object.defineProperty(window, 'dshDesktop', { value: dshDesktop, writable: false, configurable: false });
+
+  // ---- 壳机制（仅主框架；iframe 全跳过——开销不随帧数翻倍，心跳不污染主窗计数）----
+  if (IS_TOP) {
+    onEvent('window-maximized', listeners.maximize, Boolean);
+    onEvent('notification-jump', listeners.jump, function (p) {
+      var id = p && typeof p.sessionId === 'string' ? p.sessionId.trim() : '';
+      return id && id.length <= 256 ? Object.freeze({ sessionId: id }) : null;
+    });
+    onEvent('balance-changed', listeners.balance, function (p) { return p; });
+    onEvent('pet-state', listeners.pet, function (p) { return p || {}; });
+
+    // ---- 余额 / 宠物状态 → window CustomEvent（契约 §3，dsh-balance / harness-pet 消费）----
+    listeners.balance.push(function (data) {
+      try { window.dispatchEvent(new CustomEvent('dsh-balance-changed', { detail: data })); } catch (e) {}
+    });
+    listeners.pet.push(function (data) {
+      try { window.dispatchEvent(new CustomEvent('dsh-pet-state', { detail: data })); } catch (e) {}
+    });
+
+    // ---- 通知跳转补发（订阅前收到的最后一次保留）----
+    var pendingJump = null;
+    listeners.jump.push(function (jump) { if (jump) pendingJump = jump; });
+
+    // ---- 心跳：5s + visibilitychange 补报（契约 §4，带窗口归属标签）----
+    send('renderer_heartbeat', { window: WINDOW_LABEL });
+    armLifecycleTimer(setInterval(function () { send('renderer_heartbeat', { window: WINDOW_LABEL }); }, 5000));
+    document.addEventListener('visibilitychange', function () {
+      if (!document.hidden) send('renderer_heartbeat', { window: WINDOW_LABEL });
+    });
+
+    // ---- 页面异常上报（契约 §4）----
+    window.addEventListener('error', function (e) {
+      send('page_error', { message: 'window.onerror: ' + ((e && (e.message || e.error)) || 'unknown') });
+    });
+    window.addEventListener('unhandledrejection', function (e) {
+      send('page_error', { message: 'unhandledrejection: ' + String((e && e.reason && (e.reason.message || e.reason)) || e) });
+    });
+
+    // ---- 当前会话上报：3s 轮询 localStorage，变化才发（契约 §4）----
+    (function () {
+      var last = '';
+      var tick = function () {
+        try {
+          var raw = localStorage.getItem('dsh.sessions.current');
+          var parsed = raw ? JSON.parse(raw) : null;
+          var id = parsed && typeof parsed === 'object' ? String(parsed.sessionId || '') : '';
+          if (id && id !== last) { last = id; send('current_session', { sessionId: id }); }
+        } catch (e) { /* 会话未就绪时无值 */ }
+      };
+      tick();
+      armLifecycleTimer(setInterval(tick, 3000));
+    })();
+
+    // pagehide 收尾（事件退订 + 定时器清除，见「页面生命周期收尾」段）。
+    window.addEventListener('pagehide', onPageHide);
+  }
 
   // ---- 窗口控制条注入（内核页，沉浸式双主题）--------------------------
   // 主窗 decorations:false：loading/recovery/poc 壳页自带标题栏，但内核
@@ -650,23 +713,22 @@
       else cb();
     }
   }
-  // iframe 守卫（用户实测「会话地图双层壳」根治）：Tauri initialization_script
-  // 会注入同源所有 iframe（synapse /synapse/ 等），而 Electron contextBridge
-  // 只跑主框架——主框架独占壳（标题栏/菜单/拖拽），iframe 里全部跳过。
-  if (window.top !== window.self) return;
+  // 控制条注入与自初始化同样只属主框架（帧定位守卫见文件首；历史形态
+  // 「会话地图双层壳」的根治语义不变——iframe 不注入第二层壳）。
+  if (IS_TOP) {
+    onBodyReady(function () {
+      injectChromeBar();
+      try {
+        // 内核 SPA/插件重挂载防御：控制条是 body 直接子元素，childList（无需
+        // subtree）即可精确感知「被移除」→ 重注（injectChromeBar 自身幂等）。
+        var watch = new MutationObserver(function () {
+          if (!document.getElementById(CHROME_ID)) injectChromeBar();
+        });
+        watch.observe(document.body, { childList: true });
+      } catch (e) { /* 同上：防御性兜底 */ }
+    });
 
-  onBodyReady(function () {
-    injectChromeBar();
-    try {
-      // 内核 SPA/插件重挂载防御：控制条是 body 直接子元素，childList（无需
-      // subtree）即可精确感知「被移除」→ 重注（injectChromeBar 自身幂等）。
-      var watch = new MutationObserver(function () {
-        if (!document.getElementById(CHROME_ID)) injectChromeBar();
-      });
-      watch.observe(document.body, { childList: true });
-    } catch (e) { /* 同上：防御性兜底 */ }
-  });
-
-  // 自初始化：回填 appVersion（失败静默——浏览器模式常见）。
-  try { dshDesktop.getInfo().catch(function () {}); } catch (e) {}
+    // 自初始化：回填 appVersion（失败静默——浏览器模式常见）。
+    try { dshDesktop.getInfo().catch(function () {}); } catch (e) {}
+  }
 })();

--- a/dsh-tauri/src-tauri/crates/bridge/src/shim.rs
+++ b/dsh-tauri/src-tauri/crates/bridge/src/shim.rs
@@ -364,3 +364,50 @@ mod window_chrome_tests {
         );
     }
 }
+
+/// 帧定位与生命周期（iframe 重复壳机制 / 监听表累积的历史缺陷回归锚点；
+/// 行为级验证在 sidecar/bridge-shim.test.js 的 vm 沙箱测试，此处固化源码形态）。
+#[cfg(test)]
+mod frame_guard_tests {
+    use super::BRIDGE_SHIM_JS;
+
+    /// 守卫次序：IS_TOP 判定必须先于任何壳机制注册——历史缺陷是守卫写在
+    /// 壳机制之后，每个同源 iframe 都装 5s 心跳 + 3s 会话轮询 + 4 个事件
+    /// 订阅（开销随帧数翻倍，且 iframe 心跳污染全局计数、掩蔽主窗假死判定）。
+    #[test]
+    fn top_frame_guard_precedes_shell_machinery_shape() {
+        assert!(BRIDGE_SHIM_JS.contains("var IS_TOP = false;"), "帧定位守卫缺失");
+        assert!(BRIDGE_SHIM_JS.contains("window.top === window.self"), "守卫语义必须是 top===self");
+        let guard_pos = BRIDGE_SHIM_JS.find("var IS_TOP = false;").expect("帧定位守卫位置");
+        let top_block = BRIDGE_SHIM_JS.find("if (IS_TOP) {").expect("主框架壳机制分支");
+        let first_listen = BRIDGE_SHIM_JS.find("onEvent('window-maximized'").expect("首个事件订阅");
+        let first_beat = BRIDGE_SHIM_JS.find("send('renderer_heartbeat'").expect("首拍心跳");
+        assert!(guard_pos < first_listen, "帧定位守卫必须先于事件订阅注册");
+        assert!(guard_pos < first_beat, "帧定位守卫必须先于心跳发送");
+        assert!(top_block < first_listen, "事件订阅必须在 IS_TOP 分支内（iframe 全跳过）");
+    }
+
+    /// 心跳窗口归属标签：主窗假死判定只统计 main；浮窗（__DSH_FLOAT__）与
+    /// 宠物窗（__DSH_PET__）独立标签——多窗共用一个全局计数时，活的浮窗会
+    /// 永久掩蔽死的主窗（漏恢复），反之亦然（误重载）。
+    #[test]
+    fn heartbeat_carries_window_label_shape() {
+        assert!(BRIDGE_SHIM_JS.contains("WINDOW_LABEL"), "心跳必须带窗口归属标签");
+        assert!(BRIDGE_SHIM_JS.contains("window.__DSH_FLOAT__"), "浮窗标签判定缺失");
+        assert!(BRIDGE_SHIM_JS.contains("window.__DSH_PET__"), "宠物窗标签判定缺失");
+        let beat = BRIDGE_SHIM_JS.find("send('renderer_heartbeat', { window: WINDOW_LABEL })").expect("心跳发送必须带标签");
+        let label_def = BRIDGE_SHIM_JS.find("var WINDOW_LABEL = 'main';").expect("标签定义");
+        assert!(label_def < beat, "标签定义必须先于心跳发送");
+    }
+
+    /// pagehide 生命周期：plugin:event|listen 注册的监听在页面导航/重载后
+    /// 由 Rust 侧监听表持有死回调——必须经 plugin:event|unlisten 退订 + 清
+    /// 定时器（历史缺陷：listen 只增不减）。
+    #[test]
+    fn pagehide_unlistens_events_and_clears_timers_shape() {
+        assert!(BRIDGE_SHIM_JS.contains("plugin:event|unlisten"), "必须经 plugin:event|unlisten 退订");
+        assert!(BRIDGE_SHIM_JS.contains("onPageHide"), "必须有 pagehide 收尾函数");
+        assert!(BRIDGE_SHIM_JS.contains("addEventListener('pagehide'"), "必须挂 pagehide 监听");
+        assert!(BRIDGE_SHIM_JS.contains("clearInterval(lifecycleTimers.pop())"), "pagehide 必须清壳机制定时器");
+    }
+}

--- a/dsh-tauri/src-tauri/crates/kernel-process/src/job_object.rs
+++ b/dsh-tauri/src-tauri/crates/kernel-process/src/job_object.rs
@@ -5,20 +5,34 @@
 //! 63283 端口 LISTENING 残留）。Job Object + KILL_ON_JOB_CLOSE 是 OS 级保证：
 //! 壳进程句柄表关闭（无论正常退出还是强杀）→ 内核树全部终结。
 //!
-//! handle 故意不 Drop（进程生命周期持有）；正常退出路径仍走显式
-//! taskkill（kill_kernel），Job Object 只兜「来不及清理」的场景。
+//! **句柄生命周期（性能审计 2026-08 修正）**：句柄由调用方持有（随内核
+//! 存活），内核终结时关闭——原实现每次 spawn 故意泄漏一个句柄（注释称
+//! 「随本进程句柄表关闭触发收割」），崩溃环/自动重启/瀑布重试下每天可累积
+//! 上千句柄。语义不变：壳存活期间句柄在场（强杀兜底有效）；内核已终结后
+//! 关闭只是释放内核对象（Job 内已无进程，KILL_ON_JOB_CLOSE 无从触发）。
 
 #[cfg(windows)]
 mod imp {
-    use windows_sys::Win32::Foundation::HANDLE;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
     use windows_sys::Win32::System::JobObjects::{
         AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
         JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
         JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
     };
 
-    /// 将子进程纳入杀树 Job。成功后调用方应 forget 返回值（句柄随进程关闭）。
-    pub fn assign_child_to_kill_on_close_job(child: &std::process::Child) -> Result<(), String> {
+    /// 活跃 Job 句柄计数（泄漏回归锚点：assign +1 / close -1；
+    /// 测试断言 spawn/kill 循环后计数回基线）。
+    pub static LIVE_JOBS: AtomicUsize = AtomicUsize::new(0);
+
+    /// 杀树 Job 句柄：内核存活期间持有，终结后 Drop 关闭。
+    /// （usize 承载原始 HANDLE 以获得 Send——句柄跨线程移交给 supervisor。）
+    #[derive(Debug)]
+    pub struct JobHandle(usize);
+
+    /// 将子进程纳入杀树 Job。失败时调用方用 [`JobHandle::noop`] 降级
+    /// （杀树退回显式 taskkill 路径，不阻断启动）。
+    pub fn assign_child_to_kill_on_close_job(child: &std::process::Child) -> Result<JobHandle, String> {
         use std::os::windows::io::AsRawHandle;
         unsafe {
             let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
@@ -40,14 +54,41 @@ mod imp {
             if AssignProcessToJobObject(job, proc) == 0 {
                 return Err("AssignProcessToJobObject 失败（杀树保护未生效）".into());
             }
-            // 故意泄漏 job 句柄：随本进程句柄表关闭触发 OS 收割。
-            Ok(())
+            LIVE_JOBS.fetch_add(1, Ordering::Relaxed);
+            Ok(JobHandle(job as usize))
         }
+    }
+
+    impl JobHandle {
+        /// 降级空句柄（赋值失败路径：杀树走显式 taskkill）。
+        pub fn noop() -> Self {
+            JobHandle(0)
+        }
+
+        /// 关闭句柄（幂等）。应在内核进程终结后调用（Drop 兜底同语义）。
+        pub fn close(&mut self) {
+            if self.0 != 0 {
+                unsafe { CloseHandle(self.0 as HANDLE); }
+                LIVE_JOBS.fetch_sub(1, Ordering::Relaxed);
+                self.0 = 0;
+            }
+        }
+    }
+
+    impl Drop for JobHandle {
+        fn drop(&mut self) {
+            self.close();
+        }
+    }
+
+    /// 当前活跃 Job 句柄数（测试泄漏断言用）。
+    pub fn live_jobs() -> usize {
+        LIVE_JOBS.load(Ordering::Relaxed)
     }
 }
 
 #[cfg(windows)]
-pub use imp::assign_child_to_kill_on_close_job;
+pub use imp::{assign_child_to_kill_on_close_job, live_jobs, JobHandle};
 
 #[cfg(not(windows))]
 /// 非 Windows 空壳（保持现状，无 OS 句柄可建）。Unix 侧的进程树收割语义
@@ -57,10 +98,29 @@ pub use imp::assign_child_to_kill_on_close_job;
 /// Object 的边界差异：Job Object 连「壳被第三方强杀」都能兜（句柄表关闭即
 /// 收割）；进程组只覆盖显式 kill 路径——壳本身被 SIGKILL 时内核组不随父
 /// 死，属 Unix 已知边界（本次修复目标是「退出应用杀不干净」，显式路径
-/// 已全覆盖）。本函数恒成功（no-op）。
-pub fn assign_child_to_kill_on_close_job(_child: &std::process::Child) -> Result<(), String> {
-    Ok(())
+/// 已全覆盖）。
+pub mod imp {
+    /// 空句柄（无 OS 对象可管）。
+    pub struct JobHandle;
+
+    impl JobHandle {
+        pub fn noop() -> Self {
+            JobHandle
+        }
+        pub fn close(&mut self) {}
+    }
+
+    pub fn assign_child_to_kill_on_close_job(_child: &std::process::Child) -> Result<JobHandle, String> {
+        Ok(JobHandle)
+    }
+
+    pub fn live_jobs() -> usize {
+        0
+    }
 }
+
+#[cfg(not(windows))]
+pub use imp::{assign_child_to_kill_on_close_job, live_jobs, JobHandle};
 
 #[cfg(all(test, windows))]
 mod tests {
@@ -78,5 +138,30 @@ mod tests {
         let _ = child.kill();
         let _ = child.wait();
         assert!(r.is_ok(), "Job Object 赋值应成功: {r:?}");
+    }
+
+    /// 句柄泄漏回归锚点（性能审计 2026-08）：assign→close 循环后活跃计数
+    /// 必须回基线——原实现每次 assign 泄漏一个句柄（进程生命周期内不回收，
+    /// 崩溃环/瀑布重试下累积上千）。
+    #[test]
+    fn handle_count_returns_to_baseline_after_cycles() {
+        let baseline = live_jobs();
+        let mut handles = Vec::new();
+        for _ in 0..20 {
+            let mut child = Command::new("cmd").args(["/C", "exit 0"]).spawn().expect("spawn");
+            handles.push(assign_child_to_kill_on_close_job(&child).expect("assign"));
+            let _ = child.wait();
+        }
+        assert_eq!(live_jobs(), baseline + 20, "assign 后计数 +20");
+        for mut h in handles {
+            h.close();
+        }
+        assert_eq!(live_jobs(), baseline, "全部 close 后计数必须回基线（句柄不泄漏）");
+        // Drop 兜底路径：不显式 close，drop 时关闭。
+        let mut child = Command::new("cmd").args(["/C", "exit 0"]).spawn().expect("spawn");
+        let h = assign_child_to_kill_on_close_job(&child).expect("assign");
+        let _ = child.wait();
+        drop(h);
+        assert_eq!(live_jobs(), baseline, "Drop 必须兜底关闭句柄");
     }
 }

--- a/dsh-tauri/src-tauri/src/app/src/bounded.rs
+++ b/dsh-tauri/src-tauri/src/app/src/bounded.rs
@@ -1,0 +1,134 @@
+//! 有界子进程执行（超时强杀整树）。
+//!
+//! 性能审计 2026-08 根因收口：壳内子进程派生（sidecar 转发 / boot 链辅助）
+//! 此前一律 `.output()` 无超时——AV/SmartScreen 把子进程拦到半死时（D2 诊断
+//! 记录的形态族），调用线程永挂：
+//! - 调用线程是 UI 主线程（同步 Tauri 命令）= 整窗冻结（不可拖动/不可 repaint）；
+//! - boot 线程 = loading 页直到 5 分钟看门狗兜底（且挂死的子进程本身没人杀）；
+//! - 串行锁持有者（run_sidecar 的 SIDECAR_LOCK）= 后续全部 sidecar 命令排队。
+//!
+//! 本模块是壳内子进程的唯一有界出口：超时按失败处理并杀整树（子进程可能
+//! 再派生孙进程——复用 kernel-process 的跨平台杀树：Windows taskkill /T /F，
+//! Unix killpg），不留半死进程占资源。stdout/stderr 由读线程先行排空，
+//! 防管道写满把子进程卡死在半途（经典死锁形态）。
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// 有界执行结果。
+pub struct BoundedOutput {
+    /// 子进程完整输出；`None` = 超时被杀（超时路径只关心失败事实，部分输出丢弃）。
+    pub output: Option<std::process::Output>,
+    /// 是否超时被杀。
+    pub timed_out: bool,
+}
+
+/// 读线程：把管道排空进缓冲（管道容量 ~64KB，不排空会阻塞子进程写入）。
+fn pipe_reader(pipe: Option<Box<dyn Read + Send>>) -> std::thread::JoinHandle<Vec<u8>> {
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    })
+}
+
+/// 有界执行：`timeout` 内未退出 → 杀整树并按超时失败返回。
+pub fn output_with_timeout(cmd: &mut Command, timeout: Duration) -> std::io::Result<BoundedOutput> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let pid = child.id();
+    let out_thread = pipe_reader(child.stdout.take().map(|p| Box::new(p) as Box<dyn Read + Send>));
+    let err_thread = pipe_reader(child.stderr.take().map(|p| Box::new(p) as Box<dyn Read + Send>));
+
+    let deadline = Instant::now() + timeout;
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait()? {
+            Some(st) => break Some(st),
+            None => {
+                if Instant::now() >= deadline {
+                    timed_out = true;
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+    };
+    if timed_out {
+        kernel_process::kill_tree(&mut child, pid);
+    }
+    let stdout = out_thread.join().unwrap_or_default();
+    let stderr = err_thread.join().unwrap_or_default();
+    let output = status.map(|st| std::process::Output { status: st, stdout, stderr });
+    Ok(BoundedOutput { output, timed_out })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 挂死子进程：超时被杀、及时返回（有界锚点——旧行为是永挂）。
+    #[test]
+    fn hung_child_is_killed_at_deadline() {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "ping -n 30 127.0.0.1 >nul"]).creation_flags_no_window_for_test();
+        let t0 = Instant::now();
+        let r = output_with_timeout(&mut cmd, Duration::from_millis(400)).expect("执行");
+        assert!(r.timed_out, "挂死子进程必须判超时");
+        assert!(!matches!(&r.output, Some(o) if o.status.success()));
+        assert!(t0.elapsed() < Duration::from_secs(5), "超时须及时返回（实测 {:?}）", t0.elapsed());
+    }
+
+    /// 正常路径：成功 / 非零退出码 / 输出捕获。
+    #[test]
+    fn success_and_nonzero_exit() {
+        let mut ok = Command::new("cmd");
+        ok.args(["/C", "echo hello"]).creation_flags_no_window_for_test();
+        let r = output_with_timeout(&mut ok, Duration::from_secs(10)).expect("执行");
+        assert!(matches!(&r.output, Some(o) if o.status.success()) && !r.timed_out);
+        let out = r.output.expect("完整输出");
+        assert!(String::from_utf8_lossy(&out.stdout).contains("hello"));
+
+        let mut bad = Command::new("cmd");
+        bad.args(["/C", "exit 3"]).creation_flags_no_window_for_test();
+        let r2 = output_with_timeout(&mut bad, Duration::from_secs(10)).expect("执行");
+        assert!(matches!(&r2.output, Some(o) if !o.status.success()) && !r2.timed_out);
+        assert_eq!(r2.output.unwrap().status.code(), Some(3));
+    }
+
+    /// 大输出不死锁：2MB stdout（远超管道容量）完整捕获——读线程排空证明。
+    #[test]
+    fn large_output_does_not_deadlock() {
+        let dir = std::env::temp_dir().join(format!("dsh-bounded-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("big.txt");
+        std::fs::write(&file, "x".repeat(2 * 1024 * 1024)).unwrap();
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "type", &file.to_string_lossy()]).creation_flags_no_window_for_test();
+        let r = output_with_timeout(&mut cmd, Duration::from_secs(30)).expect("执行");
+        assert!(matches!(&r.output, Some(o) if o.status.success()), "2MB 输出不得死锁（读线程须排空管道）");
+        assert_eq!(r.output.unwrap().stdout.len() >= 2 * 1024 * 1024, true, "输出完整捕获");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 测试辅助：与生产同口径的 CREATE_NO_WINDOW（Windows）。
+    trait NoWindowForTest {
+        fn creation_flags_no_window_for_test(&mut self) -> &mut Self;
+    }
+    #[cfg(windows)]
+    impl NoWindowForTest for Command {
+        fn creation_flags_no_window_for_test(&mut self) -> &mut Self {
+            use std::os::windows::process::CommandExt;
+            self.creation_flags(0x0800_0000)
+        }
+    }
+    #[cfg(not(windows))]
+    impl NoWindowForTest for Command {
+        fn creation_flags_no_window_for_test(&mut self) -> &mut Self {
+            self
+        }
+    }
+}

--- a/dsh-tauri/src-tauri/src/app/src/commands/balance.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/balance.rs
@@ -107,16 +107,14 @@ pub fn trigger_fetch(app: &AppHandle) {
     std::thread::spawn(move || fetch_and_push(&h));
 }
 
-/// 可见性判定纯函数（主窗缺省按不可见处理——无窗时轮询暂停，防后台空刷）。
-fn window_visibility(visible: Option<bool>, minimized: Option<bool>) -> bool {
-    visible.unwrap_or(true) && !minimized.unwrap_or(false)
-}
+/// 可见性判定统一口径见 [`super::common::window_watchable`]（全仓单一判定：
+/// 余额轮询暂停门与假死看门狗共用，防两处口径漂移）。
 
 /// 主窗是否可见且未最小化（Electron shouldSkipRefresh 注入的同款判定，
 /// P1-2+A-7：不以失焦为触发——副屏并排可见时失焦是常态）。
 fn main_window_visible(app: &AppHandle) -> bool {
     app.get_webview_window("main")
-        .map(|w| window_visibility(w.is_visible().ok(), w.is_minimized().ok()))
+        .map(|w| super::common::window_watchable(w.is_visible().ok(), w.is_minimized().ok()))
         .unwrap_or(false)
 }
 
@@ -225,10 +223,11 @@ mod tests {
         assert_eq!(BALANCE_POLL_SECS, 180, "轮询周期 = Electron balance-scheduler DEFAULT_POLL_MS");
     }
 
-    /// 可见性判定表：缺省可见（unwrap_or(true)）；最小化即暂停；窗口缺失
-    /// （Option 外层 None）由 main_window_visible 归为不可见。
+    /// 可见性判定表：已迁 common::window_watchable（全仓单一口径），
+    /// 此处锚定余额链消费的一侧语义不回退。
     #[test]
     fn window_visibility_decision_table() {
+        use super::super::common::window_watchable as window_visibility;
         assert!(window_visibility(Some(true), Some(false)), "可见且未最小化");
         assert!(window_visibility(None, None), "查询失败按可见（不误杀正常轮询）");
         assert!(!window_visibility(Some(true), Some(true)), "最小化 → 暂停");

--- a/dsh-tauri/src-tauri/src/app/src/commands/common.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/common.rs
@@ -10,6 +10,16 @@ pub fn terr(e: tauri::Error) -> BridgeError {
     BridgeError::internal(e.to_string())
 }
 
+/// 窗口可观测判定（纯函数，全仓单一判定口径）：
+/// 可见且未最小化才算「前台可交互」。消费方：余额轮询暂停门（Electron
+/// shouldSkipRefresh 同语义）、渲染层假死看门狗（最小化窗口定时器被节流，
+/// 心跳停摆不计失联——Windows 上 is_visible 对最小化窗仍为 true，缺
+/// minimized 检查会把节流误判为假死 → 周期性重载风暴）。
+/// 查询失败缺省：visible 按 true（不误杀正常逻辑）、minimized 按 false。
+pub fn window_watchable(visible: Option<bool>, minimized: Option<bool>) -> bool {
+    visible.unwrap_or(true) && !minimized.unwrap_or(false)
+}
+
 /// 系统浏览器打开 http(s) URL。
 pub fn open_http_url(url: &str) -> Result<serde_json::Value, BridgeError> {
     if !(url.starts_with("http://") || url.starts_with("https://")) {
@@ -208,6 +218,17 @@ mod tests {
         assert_eq!(s.len(), 15, "YYYYMMDD-HHMMSS：{s}");
         assert_eq!(s.as_bytes()[8], b'-');
         assert!(s.starts_with("20"), "{s}");
+    }
+
+    /// 窗口可观测判定表（全仓单一口径）：可见未最小化；最小化/隐藏均停；
+    /// 查询失败缺省不误杀（visible=true / minimized=false）。
+    #[test]
+    fn window_watchable_decision_table() {
+        assert!(window_watchable(Some(true), Some(false)), "可见且未最小化");
+        assert!(window_watchable(None, None), "查询失败按可观测（不误杀正常逻辑）");
+        assert!(!window_watchable(Some(true), Some(true)), "最小化 → 停（定时器被节流）");
+        assert!(!window_watchable(Some(false), Some(false)), "隐藏 → 停");
+        assert!(!window_watchable(Some(false), None), "隐藏（最小化未知）→ 停");
     }
 
     #[test]

--- a/dsh-tauri/src-tauri/src/app/src/commands/image.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/image.rs
@@ -12,8 +12,13 @@ use super::common::b64_decode;
 const E_IMAGE_PASTE: &str = "E_IMAGE_PASTE";
 
 #[tauri::command]
-pub fn image_paste_save(payload: serde_json::Value) -> Result<serde_json::Value, BridgeError> {
-    image_paste_save_impl(&payload).map_err(|e| BridgeError::new(E_IMAGE_PASTE, &e))
+pub async fn image_paste_save(payload: serde_json::Value) -> Result<serde_json::Value, BridgeError> {
+    // 进程隔离（性能审计 2026-08）：≤15MB base64 解码 + 落盘在 UI 主线程上
+    // 可冻结整窗数百 ms——spawn_blocking 挪出（载荷经 IPC 已到壳侧，纯 CPU/IO）。
+    tauri::async_runtime::spawn_blocking(move || image_paste_save_impl(&payload))
+        .await
+        .map_err(|e| BridgeError::internal(format!("图片落盘任务失败: {e}")))?
+        .map_err(|e| BridgeError::new(E_IMAGE_PASTE, &e))
 }
 
 fn image_paste_save_impl(payload: &serde_json::Value) -> Result<serde_json::Value, String> {

--- a/dsh-tauri/src-tauri/src/app/src/commands/lifecycle.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/lifecycle.rs
@@ -10,7 +10,6 @@ use tauri::{AppHandle, Manager, State};
 use crate::AppState;
 
 use super::common::{open_http_url, NoWindow};
-use super::menu::setting_bool;
 
 /// 更新源仓库（Electron client-updater DEFAULT_REPOS 同源；⋯ 菜单「更新源」展示+复制）。
 pub const REPO_URLS: (&str, &str) = (
@@ -31,7 +30,12 @@ pub fn app_init(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     // ⋯ 菜单面板状态（对齐 Electron chrome:init 的消费字段）：agent 版本/来源、
     // 三个持久化开关现值（settings.json，缺省 true）、更新源 URL——
     // bridge-shim 的菜单 openMenu 经 getInfo 拉取渲染。
+    // 单次读盘（性能审计 2026-08）：SettingsStore::get 每次调用都全量读 +
+    // 解析 settings.json，三键三次读纯属浪费（垫片每次窗口载入与每次菜单
+    // 打开都走 app_init）——一次 load 读三键，语义不变（仍每次调用取最新值）。
     let store = shell_core::SettingsStore::new(state.paths.settings.clone());
+    let map = store.load().unwrap_or_default();
+    let bool_of = |k: &str| map.get(k).and_then(|v| v.as_bool()).unwrap_or(true);
     Ok(serde_json::json!({
         "appVersion": env!("CARGO_PKG_VERSION"),
         "shell": "tauri",
@@ -40,35 +44,52 @@ pub fn app_init(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
         "platform": std::env::consts::OS,
         "agentVersion": kernel_version,
         "agentSource": "bundled", // Tauri 版内核随客户端分发（Electron 的「内置」对应物）
-        "notifyOnTurnEnd": setting_bool(&store, "notifyOnTurnEnd"),
-        "closeToTray": setting_bool(&store, "closeToTray"),
-        "showBalanceDock": setting_bool(&store, "showBalanceDock"),
+        "notifyOnTurnEnd": bool_of("notifyOnTurnEnd"),
+        "closeToTray": bool_of("closeToTray"),
+        "showBalanceDock": bool_of("showBalanceDock"),
         "repoUrls": { "github": REPO_URLS.0, "gitee": REPO_URLS.1 },
     }))
 }
 
 #[tauri::command]
-pub fn copy_text(text: String) -> Result<serde_json::Value, BridgeError> {
+pub async fn copy_text(text: String) -> Result<serde_json::Value, BridgeError> {
     if text.len() > 1_000_000 {
         return Err(BridgeError::invalid_arg("文本过长"));
     }
-    set_clipboard_text(&text)?;
+    // 进程隔离（性能审计 2026-08）：剪贴板写入 spawn PowerShell（冷启
+    // ~200ms+），同步命令会在 UI 主线程上整窗冻结——spawn_blocking 挪出。
+    let t = text;
+    tauri::async_runtime::spawn_blocking(move || set_clipboard_text(&t))
+        .await
+        .map_err(|e| BridgeError::internal(format!("剪贴板任务失败: {e}")))??;
     Ok(serde_json::Value::Null)
 }
 
-/// 剪贴板写入（平台三分支）：Windows PowerShell Set-Clipboard（单引号包裹 +
-/// 内部单引号翻倍防注入）；macOS pbcopy；Linux xclip/xsel/wl-copy 尝试链
-/// （发行版/会话各异，均缺则报可读错误）——此前无平台分支，非 Windows 上
-/// spawn powershell 直接失败，复制功能全坏。
+/// 剪贴板写入（平台三分支）：Windows PowerShell Set-Clipboard；macOS
+/// pbcopy；Linux xclip/xsel/wl-copy 尝试链（发行版/会话各异，均缺则报可读
+/// 错误）——此前无平台分支，非 Windows 上 spawn powershell 直接失败，复制
+/// 功能全坏。
+///
+/// Windows 经 stdin 传 base64（性能审计 2026-08 修正）：命令行内嵌原文有
+/// 两个缺陷——Windows ~32K 命令行上限使长文本（上限允许到 1MB）直接失败；
+/// PowerShell 按控制台代码页解析参数，非 ASCII 有乱码面。base64 是纯
+/// ASCII，任意代码页安全，UTF-8 精确还原。
 #[cfg(windows)]
 fn set_clipboard_text(text: &str) -> Result<(), BridgeError> {
-    let escaped = text.replace('\'', "''");
-    let status = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-Command", &format!("Set-Clipboard -Value '{escaped}'")])
+    use std::io::Write;
+    let b64 = super::common::b64(text.as_bytes());
+    let script = "$t=[Console]::In.ReadToEnd(); Set-Clipboard -Value ([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($t)))";
+    let mut child = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", script])
+        .stdin(std::process::Stdio::piped())
         .creation_flags_no_window()
-        .output()
+        .spawn()
         .map_err(BridgeError::from)?;
-    if !status.status.success() {
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(b64.as_bytes()).map_err(BridgeError::from)?;
+    } // drop → EOF，PowerShell 读尽 stdin
+    let status = child.wait().map_err(BridgeError::from)?;
+    if !status.success() {
         return Err(BridgeError::internal("剪贴板写入失败"));
     }
     Ok(())
@@ -131,9 +152,20 @@ pub fn page_error(state: State<AppState>, message: String) -> Result<serde_json:
     Ok(serde_json::Value::Null)
 }
 
+/// 心跳归属判定（纯函数）：`None` / `"main"` → 主窗（假死看门狗只统计主窗）；
+/// `float` / `pet` / 未知标签 → 副窗。未知不得按主窗计——防未来形态的帧
+/// 污染主窗计数、掩蔽假死判定（垫片侧标签见 bridge-shim.js WINDOW_LABEL）。
+pub(crate) fn heartbeat_is_main(label: Option<&str>) -> bool {
+    matches!(label, None | Some("main"))
+}
+
 #[tauri::command]
-pub fn renderer_heartbeat(state: State<AppState>) -> Result<serde_json::Value, BridgeError> {
-    state.heartbeats.fetch_add(1, Ordering::Relaxed);
+pub fn renderer_heartbeat(window: Option<String>, state: State<AppState>) -> Result<serde_json::Value, BridgeError> {
+    if heartbeat_is_main(window.as_deref()) {
+        state.heartbeats_main.fetch_add(1, Ordering::Relaxed);
+    } else {
+        state.heartbeats_side.fetch_add(1, Ordering::Relaxed);
+    }
     Ok(serde_json::Value::Null)
 }
 
@@ -148,7 +180,7 @@ pub fn current_session(state: State<AppState>, session_id: String) -> Result<ser
 }
 
 #[tauri::command]
-pub fn restart_service(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn restart_service(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     let state = app.state::<AppState>();
     let sv = state.supervisor.lock().unwrap_or_else(|p| p.into_inner()).clone();
     let sv = sv.ok_or_else(|| BridgeError::internal("supervisor 未初始化"))?;
@@ -163,7 +195,9 @@ pub fn restart_service(app: AppHandle) -> Result<serde_json::Value, BridgeError>
         .lock()
         .unwrap_or_else(|p| p.into_inner())
         .clone();
-    match tx {
+    // 进程隔离（性能审计 2026-08）：restart 的杀树段（taskkill /T /F +
+    // wait，AV 下数百 ms）挪出 UI 主线程——同步命令会整窗冻结。
+    let joined = tauri::async_runtime::spawn_blocking(move || match tx {
         Some(tx) => sv.restart(tx, u16::try_from(preferred).ok()),
         None => {
             // 兜底（理论不可达：supervisor 在场则装配通道必在）：drain 防阻塞。
@@ -175,7 +209,10 @@ pub fn restart_service(app: AppHandle) -> Result<serde_json::Value, BridgeError>
             });
             sv.restart(tx, u16::try_from(preferred).ok());
         }
-    }
+    })
+    .await
+    .map_err(|e| BridgeError::internal(format!("重启任务失败: {e}")))?;
+    let _ = joined;
     Ok(serde_json::json!({ "ok": true }))
 }
 
@@ -187,6 +224,8 @@ pub fn poc_echo_json(payload: serde_json::Value) -> Result<serde_json::Value, Br
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     /// restart_service 必须复用 supervisor_tx 装配通道（v0.5.1「重启后白屏」
     /// 回归锚点）：此前新建通道 + drain 线程把 KernelReady/CrashLoop 全部
     /// 吞掉——重启成功无人换页（真机复现：内核就绪且稳定落定，页面永远停在
@@ -195,7 +234,7 @@ mod tests {
     fn restart_service_reuses_supervisor_tx_shape() {
         let src = include_str!("lifecycle.rs").replace("\r\n", "\n");
         let seg = src
-            .split("pub fn restart_service")
+            .split("pub async fn restart_service")
             .nth(1)
             .and_then(|s| s.split("pub fn poc_echo_json").next())
             .expect("restart_service 段");
@@ -230,7 +269,62 @@ mod tests {
             .expect("Linux set_clipboard_text 分支");
         assert!(linux.contains("xclip") && linux.contains("xsel") && linux.contains("wl-copy"), "Linux 尝试链须齐: {linux}");
         // 命令主体不得残留平台外的 powershell 直调（防回退到单一实现）。
-        let cmd_seg = src.split("pub fn copy_text").nth(1).and_then(|s| s.split("\n}").next()).unwrap_or("");
+        let cmd_seg = src.split("pub async fn copy_text").nth(1).and_then(|s| s.split("\n}").next()).unwrap_or("");
         assert!(!cmd_seg.contains("powershell"), "copy_text 主体须委托 set_clipboard_text: {cmd_seg}");
+        // 经 stdin 传 base64（长文本/非 ASCII 的根治锚点）：不得回退到
+        // 命令行内嵌原文（~32K 命令行上限 + 代码页乱码面）。
+        assert!(seg.contains("FromBase64String"), "Windows 分支必须经 stdin base64 精确还原: {seg}");
+        assert!(!seg.contains("-Value '{"), "不得再把原文拼进命令行: {seg}");
+    }
+
+    /// 心跳归属判定表（性能审计 2026-08）：None（旧垫片兼容）/ main →
+    /// 主窗；float / pet / 未知 → 副窗——副窗心跳不得污染主窗计数
+    /// （活的浮窗掩蔽死的主窗 = 假死恢复失效）。
+    #[test]
+    fn heartbeat_label_decision_table() {
+        assert!(heartbeat_is_main(None), "无标签（旧垫片兼容）按主窗计");
+        assert!(heartbeat_is_main(Some("main")), "main 标签按主窗计");
+        assert!(!heartbeat_is_main(Some("float")), "浮窗心跳按副窗计");
+        assert!(!heartbeat_is_main(Some("pet")), "宠物窗心跳按副窗计");
+        assert!(!heartbeat_is_main(Some("weird")), "未知标签按副窗计（防污染主窗计数）");
+    }
+
+    /// 大文本剪贴板往返（Windows 实测；历史缺陷实证：命令行内嵌形态在
+    /// ~32K 上限直接失败）。测试会短暂占用剪贴板（尽力保存/恢复）。
+    #[cfg(windows)]
+    #[test]
+    fn clipboard_roundtrip_large_and_unicode_text() {
+        use super::NoWindow;
+        // 尽力保存现文本（失败照常测——剪贴板本就是易失资源）。
+        let saved = std::process::Command::new("powershell")
+            .args(["-NoProfile", "-Command", "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; Get-Clipboard -Raw"])
+            .creation_flags_no_window()
+            .output()
+            .ok()
+            .map(|o| String::from_utf8_lossy(&o.stdout).into_owned());
+        let text = format!("{}你好世界 {}", "a".repeat(80_000), "插件文案".repeat(1_000));
+        set_clipboard_text(&text).expect("大文本（~90KB，超 32K 命令行上限）写入必须成功");
+        let out = std::process::Command::new("powershell")
+            .args(["-NoProfile", "-Command", "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; Get-Clipboard -Raw"])
+            .creation_flags_no_window()
+            .output()
+            .expect("读回");
+        let got = String::from_utf8_lossy(&out.stdout).replace("\r\n", "\n");
+        let want = text.replace("\r\n", "\n");
+        assert_eq!(got.trim_end(), want.trim_end(), "大文本 + 非 ASCII 必须逐字节还原（base64 通道）");
+        if let Some(prev) = saved {
+            let _ = std::process::Command::new("powershell")
+                .args(["-NoProfile", "-Command", "Set-Clipboard -Value $input"])
+                .stdin(std::process::Stdio::piped())
+                .creation_flags_no_window()
+                .spawn()
+                .and_then(|mut c| {
+                    if let Some(mut stdin) = c.stdin.take() {
+                        use std::io::Write;
+                        let _ = stdin.write_all(prev.as_bytes());
+                    }
+                    c.wait()
+                });
+        }
     }
 }

--- a/dsh-tauri/src-tauri/src/app/src/commands/mod.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/mod.rs
@@ -22,7 +22,7 @@
 // balance 供 lib.rs（AppState 字段与轮询环接线）与 menu.rs（toggle 后触发）
 // 经路径直取，pub(crate)；其余子模块保持私有、只走下方 glob 门面。
 pub(crate) mod balance;
-mod common;
+pub(crate) mod common;
 mod file;
 mod image;
 mod lifecycle;

--- a/dsh-tauri/src-tauri/src/app/src/commands/recovery.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/recovery.rs
@@ -50,13 +50,13 @@ pub fn recovery_reload(app: AppHandle) -> Result<serde_json::Value, BridgeError>
 }
 
 #[tauri::command]
-pub fn recovery_restart(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn recovery_restart(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     let state = app.state::<AppState>();
     let sv = state.supervisor.lock().unwrap_or_else(|p| p.into_inner()).clone();
     if let Some(sv) = sv {
         // 事件路由复用（v0.5.1「恢复页重启后白屏」回归根治）：走 route_events
         // 消费的 supervisor_tx 通道——此前新建通道且 rx 即刻丢弃，重启成功后
-        // KernelReady 无人路由、失败后 CrashLoop 无人路由，页面永远停在
+        // KernelReady 无人路由、失败后 CrashLoop 也无人路由，页面永远停在
         // loading 页（真机复现：内核 3s 就绪 + 稳定落定，页面零进度卡死）。
         // 端口优先复用上次内核端口（origin 稳定，SPA localStorage 偏好不丢）。
         let preferred = state.last_port.load(std::sync::atomic::Ordering::Relaxed);
@@ -65,13 +65,18 @@ pub fn recovery_restart(app: AppHandle) -> Result<serde_json::Value, BridgeError
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .clone();
-        match tx {
+        // 进程隔离（性能审计 2026-08）：重启的杀树段（taskkill /T /F + wait）
+        // 挪出 UI 主线程——同步命令会整窗冻结。
+        let joined = tauri::async_runtime::spawn_blocking(move || match tx {
             Some(tx) => sv.recovery_restart_with_port(tx, u16::try_from(preferred).ok()),
             None => {
                 let (tx, _rx) = std::sync::mpsc::channel();
                 sv.recovery_restart_with_port(tx, u16::try_from(preferred).ok());
             }
-        }
+        })
+        .await
+        .map_err(|e| BridgeError::internal(format!("重启任务失败: {e}")))?;
+        let _ = joined;
     } else {
         // 内核从未装配：恢复页「重启内核」= 重新装配（如用户刚补齐安装产物）。
         crate::start_supervisor(app.clone()).map_err(BridgeError::internal)?;
@@ -97,7 +102,7 @@ mod tests {
     fn recovery_restart_reuses_supervisor_tx_shape() {
         let src = include_str!("recovery.rs").replace("\r\n", "\n");
         let seg = src
-            .split("pub fn recovery_restart")
+            .split("pub async fn recovery_restart")
             .nth(1)
             .and_then(|s| s.split("pub fn recovery_open_logs").next())
             .expect("recovery_restart 段");

--- a/dsh-tauri/src-tauri/src/app/src/commands/sidecar.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/sidecar.rs
@@ -3,10 +3,13 @@
 //! 全部经 `run_sidecar`（node cli.js <子命令> --app-dir）——单一数据流的
 //! Rust 编排侧，业务全在 Node sidecar（plugin-contract.md §3）。
 
+use std::time::Duration;
+
 use bridge::BridgeError;
 use tauri::{AppHandle, Manager};
 
 use crate::AppState;
+use crate::bounded;
 
 use super::common::{chrono_now, dirs_docs, NoWindow};
 
@@ -14,26 +17,47 @@ use super::common::{chrono_now, dirs_docs, NoWindow};
 /// 串行；跨进程并发会竞写 cordis.patch.yml——Review#2 修复）。
 static SIDECAR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// sidecar 子命令执行上限：最重链路是 plugin-update（下载 ≤64MB + 解压
+/// ≤120s）——300s 足够宽裕；AV 拦半死时有界失败（旧行为：无界永挂 +
+/// 串行锁被占死，后续全部 sidecar 命令排队到天荒地老）。
+const SIDECAR_TIMEOUT: Duration = Duration::from_secs(300);
+
 /// 跑 sidecar CLI 子命令，解析 stdout 末行 JSON。
-pub fn run_sidecar(app: &AppHandle, args: &[&str]) -> Result<serde_json::Value, BridgeError> {
-    let _serial = SIDECAR_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+///
+/// 进程隔离（性能审计 2026-08）：Tauri 同步命令在 UI 主线程执行——子进程
+/// 等待（node 冷启动数百 ms 起、插件检查/更新分钟级）会冻结整窗（拖动/
+/// 重绘/全部 IPC 派发停摆，menu.rs check-agent-update 注释记录的同一实测
+/// 形态）。统一 spawn_blocking 挪出主线程；串行锁语义不变（防竞写
+/// cordis.patch.yml），只是排队发生在后台线程池而非 UI 线程。
+pub async fn run_sidecar(app: &AppHandle, args: &[&str]) -> Result<serde_json::Value, BridgeError> {
     let state = app.state::<AppState>();
     let sv = state.supervisor.lock().unwrap_or_else(|p| p.into_inner()).clone();
     let sv = sv.ok_or_else(|| BridgeError::internal("supervisor 未初始化"))?;
-    let out = std::process::Command::new(&sv.node_exe)
-        .arg(&sv.sidecar_cli)
-        .args(args)
-        .arg("--app-dir")
-        .arg(&sv.app_dir)
-        .env("DSH_TAURI_VERSION", env!("CARGO_PKG_VERSION"))
-        // GUI 进程起 console 子进程必须抑制终端窗（每个桥命令都走这里，
-        // 无旗则插件/诊断/备份每次闪终端窗——0.5.0 实测修复）。
-        .creation_flags_no_window()
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .map_err(BridgeError::from)?;
-    let stdout = String::from_utf8_lossy(&out.stdout);
+    let argv: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let node_exe = sv.node_exe.clone();
+    let sidecar_cli = sv.sidecar_cli.clone();
+    let app_dir = sv.app_dir.clone();
+    let out = tauri::async_runtime::spawn_blocking(move || {
+        let _serial = SIDECAR_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut cmd = std::process::Command::new(&node_exe);
+        cmd.arg(&sidecar_cli)
+            .args(&argv)
+            .arg("--app-dir")
+            .arg(&app_dir)
+            .env("DSH_TAURI_VERSION", env!("CARGO_PKG_VERSION"))
+            // GUI 进程起 console 子进程必须抑制终端窗（每个桥命令都走这里，
+            // 无旗则插件/诊断/备份每次闪终端窗——0.5.0 实测修复）。
+            .creation_flags_no_window();
+        bounded::output_with_timeout(&mut cmd, SIDECAR_TIMEOUT)
+    })
+    .await
+    .map_err(|e| BridgeError::internal(format!("sidecar 执行任务失败: {e}")))?
+    .map_err(BridgeError::from)?;
+    if out.timed_out {
+        return Err(BridgeError::internal("sidecar 子命令超时（300s）被终止"));
+    }
+    let raw = out.output.expect("非超时路径必有完整输出");
+    let stdout = String::from_utf8_lossy(&raw.stdout);
     let line = stdout.trim_end().lines().last().unwrap_or("");
     let parsed: serde_json::Value =
         serde_json::from_str(line).map_err(|e| BridgeError::internal(format!("sidecar 输出解析: {e}")))?;
@@ -45,28 +69,28 @@ pub fn run_sidecar(app: &AppHandle, args: &[&str]) -> Result<serde_json::Value, 
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn plugin_list(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["plugin-list"])
+pub async fn plugin_list(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["plugin-list"]).await
 }
 #[tauri::command]
-pub fn plugin_set_enabled(id: String, enabled: bool, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["plugin-set-enabled", &id, if enabled { "1" } else { "0" }])
+pub async fn plugin_set_enabled(id: String, enabled: bool, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["plugin-set-enabled", &id, if enabled { "1" } else { "0" }]).await
 }
 #[tauri::command]
-pub fn plugin_uninstall(id: String, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["plugin-uninstall", &id])
+pub async fn plugin_uninstall(id: String, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["plugin-uninstall", &id]).await
 }
 #[tauri::command]
-pub fn plugin_restore(id: String, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["plugin-restore", &id])
+pub async fn plugin_restore(id: String, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["plugin-restore", &id]).await
 }
 #[tauri::command]
-pub fn plugin_check_updates(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["plugin-check-updates"])
+pub async fn plugin_check_updates(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["plugin-check-updates"]).await
 }
 #[tauri::command]
-pub fn plugin_update(id: String, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["plugin-update", &id])
+pub async fn plugin_update(id: String, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["plugin-update", &id]).await
 }
 
 // ---------------------------------------------------------------------------
@@ -74,54 +98,54 @@ pub fn plugin_update(id: String, app: AppHandle) -> Result<serde_json::Value, Br
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn diag_run(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["diag-run"])
+pub async fn diag_run(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["diag-run"]).await
 }
 
 #[tauri::command]
-pub fn diag_export(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn diag_export(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     // Electron 语义：主进程选路径（对话框）。Tauri Phase 3 用固定日志目录 + 时间戳。
     let dir = shell_core::DshPaths::resolve().logs;
     let _ = std::fs::create_dir_all(&dir);
     let out = dir.join(format!("dsh-diagnostics-{}.json", chrono_now()));
     let out_str = out.to_string_lossy().into_owned();
-    run_sidecar(&app, &["diag-export", "--out", &out_str])
+    run_sidecar(&app, &["diag-export", "--out", &out_str]).await
 }
 
 #[tauri::command]
-pub fn diag_validate(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["diag-validate"])
+pub async fn diag_validate(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["diag-validate"]).await
 }
 
 #[tauri::command]
-pub fn diag_order(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
-    run_sidecar(&app, &["diag-order"])
+pub async fn diag_order(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+    run_sidecar(&app, &["diag-order"]).await
 }
 
 #[tauri::command]
-pub fn diag_order_apply(order: Vec<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn diag_order_apply(order: Vec<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     let json = serde_json::to_string(&order).map_err(|e| BridgeError::internal(e.to_string()))?;
-    run_sidecar(&app, &["diag-order-apply", &json])
+    run_sidecar(&app, &["diag-order-apply", &json]).await
 }
 
 #[tauri::command]
-pub fn diag_remove_bundle(names: Vec<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn diag_remove_bundle(names: Vec<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     let json = serde_json::to_string(&names).map_err(|e| BridgeError::internal(e.to_string()))?;
-    run_sidecar(&app, &["diag-remove-bundle", &json])
+    run_sidecar(&app, &["diag-remove-bundle", &json]).await
 }
 
 #[tauri::command]
-pub fn backup_export(label: Option<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn backup_export(label: Option<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     // Electron 语义：对话框选路径。Tauri：固定到「文档」目录 + 时间戳名。
     let docs = dirs_docs();
     let _ = std::fs::create_dir_all(&docs);
     let out = docs.join(format!("dsh-desktop-backup-{}.json", chrono_now()));
     let out_str = out.to_string_lossy().into_owned();
-    run_sidecar(&app, &["backup-export", &label.unwrap_or_default(), &out_str])
+    run_sidecar(&app, &["backup-export", &label.unwrap_or_default(), &out_str]).await
 }
 
 #[tauri::command]
-pub fn backup_restore(preview: bool, token: Option<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn backup_restore(preview: bool, token: Option<String>, app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     if preview {
         // Electron 语义：主进程选文件。Tauri：读最近一次导出的备份文件（日志/文档目录）。
         let docs = dirs_docs();
@@ -130,7 +154,7 @@ pub fn backup_restore(preview: bool, token: Option<String>, app: AppHandle) -> R
             return Err(BridgeError::not_found("未找到可恢复的备份文件（文档目录）"));
         };
         let file_str = file.to_string_lossy().into_owned();
-        return run_sidecar(&app, &["backup-restore-preview", &file_str]);
+        return run_sidecar(&app, &["backup-restore-preview", &file_str]).await;
     }
     let docs = dirs_docs();
     let latest = latest_backup(&docs);
@@ -139,7 +163,7 @@ pub fn backup_restore(preview: bool, token: Option<String>, app: AppHandle) -> R
     };
     let token = token.ok_or_else(|| BridgeError::invalid_arg("缺少恢复令牌（先 preview）"))?;
     let file_str = file.to_string_lossy().into_owned();
-    run_sidecar(&app, &["backup-restore-apply", &file_str, &token])
+    run_sidecar(&app, &["backup-restore-apply", &file_str, &token]).await
 }
 
 /// 文档目录里最新的 `dsh-desktop-backup-*.json`（backup_restore 的 Tauri
@@ -186,11 +210,39 @@ mod tests {
     fn run_sidecar_suppresses_console_window_shape() {
         let src = include_str!("sidecar.rs");
         let seg = src
-            .split("pub fn run_sidecar")
+            .split("pub async fn run_sidecar")
             .nth(1)
             .and_then(|s| s.split("// ---").next())
             .expect("run_sidecar 函数体");
-        assert!(seg.contains("Command::new(&sv.node_exe)"), "锚点漂移（改了 spawn 写法需同步测试）: {seg}");
+        assert!(seg.contains("Command::new(&node_exe)"), "锚点漂移（改了 spawn 写法需同步测试）: {seg}");
         assert!(seg.contains(".creation_flags_no_window()"), "sidecar spawn 必须抑制终端窗: {seg}");
+    }
+
+    /// 进程隔离锚点（性能审计 2026-08）：run_sidecar 必须是 async + 经
+    /// spawn_blocking 执行子进程——Tauri 同步命令在 UI 主线程跑，node 子进程
+    /// 等待（数百 ms 起、插件更新分钟级）会冻结整窗（拖动/重绘/全部 IPC
+    /// 停摆）。且必须有超时上限（旧行为无界永挂 + 占死串行锁）。
+    #[test]
+    fn run_sidecar_off_main_thread_and_bounded_shape() {
+        let src = include_str!("sidecar.rs");
+        let seg = src
+            .split("pub async fn run_sidecar")
+            .nth(1)
+            .and_then(|s| s.split("// ---").next())
+            .expect("run_sidecar 函数体");
+        assert!(seg.contains("spawn_blocking"), "子进程等待必须挪出调用线程（spawn_blocking）: {seg}");
+        assert!(src.contains("const SIDECAR_TIMEOUT"), "必须有执行超时上限常量");
+        assert!(seg.contains("SIDECAR_TIMEOUT"), "执行必须受超时约束");
+        assert!(seg.contains("out.timed_out"), "超时必须显式报错（不得当成功/静默）");
+        // 串行锁语义保持（Review#2：防竞写 cordis.patch.yml）。
+        assert!(seg.contains("SIDECAR_LOCK.lock()"), "串行锁必须保持（锁内移到后台线程，语义不变）");
+        // 全部包装命令必须 async（同步包装会让等待链断在主线程）。
+        for cmd in [
+            "pub async fn plugin_list", "pub async fn plugin_set_enabled", "pub async fn plugin_uninstall",
+            "pub async fn plugin_restore", "pub async fn plugin_check_updates", "pub async fn plugin_update",
+            "pub async fn diag_run", "pub async fn backup_export", "pub async fn backup_restore",
+        ] {
+            assert!(src.contains(cmd), "sidecar 包装命令必须 async: {cmd}");
+        }
     }
 }

--- a/dsh-tauri/src-tauri/src/app/src/commands/wsl.rs
+++ b/dsh-tauri/src-tauri/src/app/src/commands/wsl.rs
@@ -120,14 +120,19 @@ fn wsl_config_payload(backend: &str, distro: &str, install_dir: &str) -> serde_j
 }
 
 #[tauri::command]
-pub fn wsl_config_get(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn wsl_config_get(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     // WSL 托管：Phase 3 简版（配置存取 + recheck 探活）；完整 wsl-backend 复用
     // 随 Phase 3 后续（migration-roadmap）。形态必须与 Electron 一致——此前
     // 返回 `{mode:"local"}` 致设置页 backend/status 全空、dirty 恒真（实测 bug）。
     let state = app.state::<AppState>();
     let store = shell_core::SettingsStore::new(state.paths.settings.clone());
     let (backend, distro, install_dir) = wsl_settings_load_from(&store);
-    Ok(wsl_config_payload(&backend, &distro, &install_dir))
+    // 进程隔离（性能审计 2026-08）：wsl --status 探活在半安装形态下可达秒级，
+    // spawn_blocking 挪出 UI 主线程。
+    let payload = tauri::async_runtime::spawn_blocking(move || wsl_config_payload(&backend, &distro, &install_dir))
+        .await
+        .map_err(|e| BridgeError::internal(format!("wsl 探活任务失败: {e}")))?;
+    Ok(payload)
 }
 
 #[tauri::command]
@@ -159,14 +164,17 @@ pub fn wsl_config_save(cfg: serde_json::Value, app: AppHandle) -> Result<serde_j
 }
 
 #[tauri::command]
-pub fn wsl_recheck(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
+pub async fn wsl_recheck(app: AppHandle) -> Result<serde_json::Value, BridgeError> {
     // Electron 语义：recheck 返回与 getConfig 同形态（status 强制重探测）。
     // 此前返回 `{ok,available}` 与契约不符——设置页「重新检测」把表单状态
     // 打回空（实测「WSL 行空」根因之一）。
     let state = app.state::<AppState>();
     let store = shell_core::SettingsStore::new(state.paths.settings.clone());
     let (backend, distro, install_dir) = wsl_settings_load_from(&store);
-    Ok(wsl_config_payload(&backend, &distro, &install_dir))
+    let payload = tauri::async_runtime::spawn_blocking(move || wsl_config_payload(&backend, &distro, &install_dir))
+        .await
+        .map_err(|e| BridgeError::internal(format!("wsl 探活任务失败: {e}")))?;
+    Ok(payload)
 }
 
 #[cfg(test)]

--- a/dsh-tauri/src-tauri/src/app/src/lib.rs
+++ b/dsh-tauri/src-tauri/src/app/src/lib.rs
@@ -10,6 +10,7 @@
 //! - 默认：loading 页 → sidecar boot → 内核拉起 → 就绪换页到内核 Web UI；
 //! - `DSH_TAURI_POC=1`：PoC 回归模式（不拉内核，加载 PoC 页，Phase 0 验收复用）。
 
+mod bounded;
 mod commands;
 mod pages;
 mod poc_page;
@@ -32,7 +33,12 @@ pub struct AppState {
     pub supervisor: Mutex<Option<SupervisorHandle>>,
     pub loading_url: Mutex<String>,
     pub recovery_url: Mutex<String>,
-    pub heartbeats: AtomicU32,
+    /// 主窗心跳计数（性能审计 2026-08 拆分）：假死看门狗只看本计数——
+    /// 全窗口共用一个计数时，活的浮窗/宠物窗会永久掩蔽死的主窗（漏恢复）。
+    /// 垫片按窗口归属标签上报（bridge-shim.js WINDOW_LABEL）。
+    pub heartbeats_main: AtomicU32,
+    /// 副窗（浮窗/宠物窗/未知标签）心跳计数（诊断用途，不参与假死判定）。
+    pub heartbeats_side: AtomicU32,
     pub page_errors: AtomicU32,
     pub current_session: Mutex<Option<String>>,
     pub last_port: AtomicU32,
@@ -43,6 +49,8 @@ pub struct AppState {
     pub boot_error: Mutex<Option<String>>,
     /// 余额链状态（commands/balance.rs：事件载荷缓存 + in-flight 去重）。
     pub balance: commands::balance::BalanceState,
+    /// 静态页目录（%TEMP%/dsh-tauri-pages-<pid>；退出时清理，防随启动累积）。
+    pub pages_dir: std::path::PathBuf,
 }
 
 impl AppState {
@@ -51,7 +59,8 @@ impl AppState {
             supervisor: Mutex::new(None),
             loading_url: Mutex::new(String::new()),
             recovery_url: Mutex::new(String::new()),
-            heartbeats: AtomicU32::new(0),
+            heartbeats_main: AtomicU32::new(0),
+            heartbeats_side: AtomicU32::new(0),
             page_errors: AtomicU32::new(0),
             current_session: Mutex::new(None),
             last_port: AtomicU32::new(0),
@@ -59,6 +68,7 @@ impl AppState {
             supervisor_tx: Mutex::new(None),
             boot_error: Mutex::new(None),
             balance: commands::balance::BalanceState::new(),
+            pages_dir: std::env::temp_dir().join(format!("dsh-tauri-pages-{}", std::process::id())),
         }
     }
 }
@@ -216,6 +226,8 @@ pub fn run() {
                         if let Some(sv) = state.supervisor.lock().unwrap_or_else(|p| p.into_inner()).clone() {
                             sv.shutdown();
                         }
+                        // 静态页目录随退出清理（防 %TEMP% 随启动累积）。
+                        let _ = std::fs::remove_dir_all(&state.pages_dir);
                     }
                     if let Some(mut g) = INSTANCE_LOCK.lock().unwrap_or_else(|p| p.into_inner()).take() {
                         g.release();
@@ -237,8 +249,12 @@ fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     }
     let state = AppState::empty();
     upgrade_first_run_report(&state);
+    // 历史残留清扫（性能审计 2026-08）：静态页目录每次启动新建一个
+    // （dsh-tauri-pages-<pid>），强杀形态无人清理会在 %TEMP% 无限累积——
+    // 启动时清 7 天前的旧目录（本次目录刚建，mtime 新，天然不受影响）。
+    sweep_stale_page_dirs();
     // ---- 静态页（loading / recovery / poc）经 preview-server 托管 ----
-    let dir = std::env::temp_dir().join(format!("dsh-tauri-pages-{}", std::process::id()));
+    let dir = state.pages_dir.clone();
     std::fs::create_dir_all(&dir)?;
     std::fs::write(dir.join("loading.html"), pages::LOADING_HTML)?;
     std::fs::write(dir.join("recovery.html"), pages::RECOVERY_HTML)?;
@@ -363,11 +379,17 @@ fn route_one_event(app: &tauri::AppHandle, ev: SupervisorEvent) {
                     let _ = store.set("lastWebPort", serde_json::json!(port));
                 }
                 let _ = commands::navigate_main(&app, &url);
-                if let Some(w) = app.get_webview_window("main") {
-                    let diag_base = { let u = app.state::<AppState>().loading_url.lock().unwrap_or_else(|p| p.into_inner()).clone(); let mut o = String::new(); if let Some(pos) = u.rfind('/') { o = u[..pos].to_string(); } o };
-                    match w.eval(&format!("window.__DIAG_BASE__={:?}; window.__TAURI_INTERNALS__.invoke('current_session',{{sessionId:'[diag] t0'}}).then(function(){{fetch(window.__DIAG_BASE__+'/__diag/t0-invoke-OK')}},function(err){{fetch(window.__DIAG_BASE__+'/__diag/t0-invoke-REJECT-'+encodeURIComponent(String(err&&err.message||err)))}})", diag_base)) {
-                        Ok(_) => eprintln!("[diag] t0 eval OK"),
-                        Err(e) => eprintln!("[diag] t0 eval ERR: {e}"),
+                // 诊断探针 t0：DSH_TAURI_DIAG=1 才启用（性能审计 2026-08 门控
+                // 修正）——历史缺陷：无条件执行，每次内核就绪都 invoke 一次
+                // current_session('[diag] t0')，把真实会话指针顶掉（通知跳转
+                // 的聚焦豁免失效直到用户切会话）+ 一次 preview-server 空转。
+                if std::env::var("DSH_TAURI_DIAG").ok().as_deref() == Some("1") {
+                    if let Some(w) = app.get_webview_window("main") {
+                        let diag_base = { let u = app.state::<AppState>().loading_url.lock().unwrap_or_else(|p| p.into_inner()).clone(); let mut o = String::new(); if let Some(pos) = u.rfind('/') { o = u[..pos].to_string(); } o };
+                        match w.eval(&format!("window.__DIAG_BASE__={:?}; window.__TAURI_INTERNALS__.invoke('current_session',{{sessionId:'[diag] t0'}}).then(function(){{fetch(window.__DIAG_BASE__+'/__diag/t0-invoke-OK')}},function(err){{fetch(window.__DIAG_BASE__+'/__diag/t0-invoke-REJECT-'+encodeURIComponent(String(err&&err.message||err)))}})", diag_base)) {
+                            Ok(_) => eprintln!("[diag] t0 eval OK"),
+                            Err(e) => eprintln!("[diag] t0 eval ERR: {e}"),
+                        }
                     }
                 }
                 if let Some(w) = app.get_webview_window("main") {
@@ -684,6 +706,13 @@ fn upgrade_first_run_report(state: &AppState) {
 ///（页面加载），此后可见主窗连续 ~40s 心跳零增长 → location.reload()。
 /// 覆盖「内核活着但页面白屏/JS 死循环」——dsh 可用优先于页面完美。
 ///
+/// 判定口径（性能审计 2026-08 修正）：
+/// - 只统计主窗心跳（heartbeats_main，垫片按窗口归属标签上报）——全窗口
+///   共用一个计数时，活的浮窗/宠物窗会永久掩蔽死的主窗（漏恢复）。
+/// - 不可见**或最小化**都不计失联（common::window_watchable 单一口径）——
+///   Windows 上最小化窗 is_visible 仍为 true，缺 minimized 检查时定时器
+///   节流（~1 次/分）被误判为停摆 → 每 ~5-6 分钟一次的重载风暴。
+///
 /// 内存审计（2026-08）：KernelReady 事件在每次内核重启（自动重启 / 假死受控
 /// 重启 / restart_service / 恢复页重试）都会触发——且单次 boot 会发两回
 /// （stdout 就绪行线程 + 瀑布 on_boot_success）。旧实现每次都 spawn 一个
@@ -698,20 +727,20 @@ fn watch_renderer_heartbeat(app: tauri::AppHandle) {
         // 宽限：等第一条心跳到达（或 60s 超时进入持续监测）。
         let baseline = app
             .try_state::<AppState>()
-            .map(|s| s.heartbeats.load(Ordering::Relaxed))
+            .map(|s| s.heartbeats_main.load(Ordering::Relaxed))
             .unwrap_or(0);
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
         while std::time::Instant::now() < deadline {
             std::thread::sleep(std::time::Duration::from_secs(5));
             if let Some(state) = app.try_state::<AppState>() {
-                if state.heartbeats.load(Ordering::Relaxed) > baseline {
+                if state.heartbeats_main.load(Ordering::Relaxed) > baseline {
                     break;
                 }
             }
         }
         let mut last = app
             .try_state::<AppState>()
-            .map(|s| s.heartbeats.load(Ordering::Relaxed))
+            .map(|s| s.heartbeats_main.load(Ordering::Relaxed))
             .unwrap_or(0);
         let mut stall: u32 = 0;
         loop {
@@ -722,13 +751,15 @@ fn watch_renderer_heartbeat(app: tauri::AppHandle) {
             }
             let Some(state) = app.try_state::<AppState>() else { return };
             let Some(win) = app.get_webview_window("main") else { return };
-            // 不可见窗口定时器被节流（与 Electron 判定口径一致）——不计失联。
-            if !win.is_visible().unwrap_or(true) {
+            // 不可见/最小化窗口定时器被节流（Electron 判定口径 + minimized，
+            // 全仓统一 common::window_watchable）——不计失联。
+            let watchable = commands::common::window_watchable(win.is_visible().ok(), win.is_minimized().ok());
+            if !watchable {
                 stall = 0;
-                last = state.heartbeats.load(Ordering::Relaxed);
+                last = state.heartbeats_main.load(Ordering::Relaxed);
                 continue;
             }
-            let now = state.heartbeats.load(Ordering::Relaxed);
+            let now = state.heartbeats_main.load(Ordering::Relaxed);
             if now == last {
                 stall += 1;
             } else {
@@ -742,6 +773,32 @@ fn watch_renderer_heartbeat(app: tauri::AppHandle) {
             }
         }
     });
+}
+
+/// 清扫 %TEMP% 里 7 天前的 dsh-tauri-pages-* 残留目录（强杀形态无人清理；
+/// 原子性：目录 mtime 判龄，本次运行的目录天然不受影响）。
+fn sweep_stale_page_dirs() {
+    const SEVEN_DAYS_SECS: u64 = 7 * 86400;
+    let Ok(rd) = std::fs::read_dir(std::env::temp_dir()) else { return };
+    for entry in rd.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !name.starts_with("dsh-tauri-pages-") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_dir() {
+            continue;
+        }
+        let aged = meta
+            .modified()
+            .ok()
+            .and_then(|m| m.elapsed().ok())
+            .map(|age| age.as_secs() > SEVEN_DAYS_SECS)
+            .unwrap_or(false);
+        if aged {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 /// 诊断探针：非侵入读取页面健康度（confirm 返回值 / composer 可用性 /
@@ -809,16 +866,22 @@ fn inject_diag_probe(app: tauri::AppHandle) {
 
 #[cfg(test)]
 mod heartbeat_watcher_tests {
+    use super::*;
+
     /// 形态锚点（内存审计 2026-08）：心跳监测线程必须带代数交替退出路径
     /// ——KernelReady 每次内核重启都会触发（且单次 boot 发两回），无守卫时
     /// 监测线程随重启次数只增不减（各持 AppHandle 永久 10s 轮询）。
+    /// 性能审计（同月）追加两条判定口径锚点：
+    /// - 只统计主窗计数 heartbeats_main（全窗共用计数会被活的浮窗掩蔽）；
+    /// - 不可见**或最小化**均不计失联（window_watchable 单一口径——Windows
+    ///   上最小化窗 is_visible 仍为 true，缺此检查 = 周期性重载风暴）。
     #[test]
     fn heartbeat_watcher_has_generation_guard_shape() {
         let src = include_str!("lib.rs");
         let seg = src
             .split("fn watch_renderer_heartbeat")
             .nth(1)
-            .and_then(|s| s.split("\n}\n\n/// 诊断探针").next())
+            .and_then(|s| s.split("\n}\n\n/// 清扫 %TEMP%").next())
             .expect("watch_renderer_heartbeat 函数体");
         assert!(src.contains("static HEARTBEAT_WATCHER_GEN"), "必须有全局代数号");
         assert!(
@@ -829,6 +892,60 @@ mod heartbeat_watcher_tests {
             seg.contains("HEARTBEAT_WATCHER_GEN.load") && seg.contains("return;"),
             "监测循环必须校验代数号并退出旧线程: {seg}"
         );
+        assert!(
+            !seg.contains("s.heartbeats.load") && !seg.contains("state.heartbeats.load"),
+            "不得再读全窗口混计的 heartbeats（浮窗掩蔽主窗假死）: {seg}"
+        );
+        assert!(
+            seg.contains("heartbeats_main.load"),
+            "必须只统计主窗计数 heartbeats_main: {seg}"
+        );
+        assert!(
+            seg.contains("window_watchable") && seg.contains("is_minimized"),
+            "失联判定必须含最小化检查（window_watchable 单一口径）: {seg}"
+        );
+    }
+
+    /// 静态页目录清扫（性能审计 2026-08）：7 天前的 dsh-tauri-pages-* 删除，
+    /// 新建的与无关目录不动。（目录 mtime 回拨需 PowerShell——std 无法对
+    /// 目录句柄 set_modified，Windows 目录句柄不可写。）
+    #[cfg(windows)]
+    #[test]
+    fn sweep_stale_page_dirs_removes_only_aged() {
+        use crate::commands::common::NoWindow;
+        let tmp = std::env::temp_dir();
+        let mk = |name: &str| {
+            let d = tmp.join(name);
+            let _ = std::fs::remove_dir_all(&d);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("x.html"), b"x").unwrap();
+            d
+        };
+        let backdate = |d: &std::path::Path, days: u64| {
+            let script = format!(
+                "(Get-Item -LiteralPath '{}').LastWriteTime = (Get-Date).AddDays(-{})",
+                d.to_string_lossy().replace('\'', "''"),
+                days
+            );
+            let ok = std::process::Command::new("powershell")
+                .args(["-NoProfile", "-Command", &script])
+                .creation_flags_no_window()
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            assert!(ok, "目录 mtime 回拨失败（前置条件）: {}", d.display());
+        };
+        let stale = mk(&format!("dsh-tauri-pages-19999-stale-{}", std::process::id()));
+        let fresh = mk(&format!("dsh-tauri-pages-19998-fresh-{}", std::process::id()));
+        let unrelated = mk(&format!("dsh-unrelated-{}", std::process::id()));
+        backdate(&stale, 8);
+        backdate(&unrelated, 30);
+        sweep_stale_page_dirs();
+        assert!(!stale.exists(), "8 天前的静态页目录必须被清");
+        assert!(fresh.exists(), "新目录不得误删");
+        assert!(unrelated.exists(), "无关目录不得误删");
+        let _ = std::fs::remove_dir_all(&fresh);
+        let _ = std::fs::remove_dir_all(&unrelated);
     }
 }
 

--- a/dsh-tauri/src-tauri/src/app/src/supervisor.rs
+++ b/dsh-tauri/src-tauri/src/app/src/supervisor.rs
@@ -26,8 +26,49 @@ use kernel_process::crash_loop::Verdict;
 const SERVICE_STABLE_SECS: u64 = 45;
 /// boot 看门狗上限（D2「永挂形态」根治）：boot 全链有界 5 分钟。
 const BOOT_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(300);
+/// 单步 sidecar 子进程上限（有界执行，性能审计 2026-08）：健康路径每步
+/// 秒级；AV 拦半死时按失败处理进瀑布/恢复页，不再拖满整个看门狗窗口。
+const SIDECAR_STEP_TIMEOUT: Duration = Duration::from_secs(60);
+/// boot 链整体（cli.js boot 五步）上限：健康 ~4s；两层瀑布最坏 2×120s
+/// 仍留在看门狗 300s 之内。
+const SIDECAR_BOOT_TIMEOUT: Duration = Duration::from_secs(120);
 
 use shell_core::RunState;
+
+/// 探活三态（单连接判定：连不上 = 进程死；连得上但 HTTP 无响应 = 假死；
+/// 有响应字节 = 活）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeOutcome {
+    Alive,
+    TcpDead,
+    Zombie,
+}
+
+use crate::bounded;
+
+/// 内核进程 + 其杀树 Job 句柄（进程隔离不变量：两者同进同出——
+/// 内核终结（kill_tree / 自然退出）后 Job 句柄随本结构 Drop 关闭，
+/// 不再随 spawn 泄漏；壳存活期间句柄在场，强杀兜底语义不变）。
+struct KernelProc {
+    child: Child,
+    job: kernel_process::job_object::JobHandle,
+}
+
+/// boot 进行中标志（「双内核竞态」根治，性能审计 2026-08）：瀑布运行期间
+/// 内核启动期退出由瀑布层独占接管——崩溃自动重启臂（2s 延迟线程）必须
+/// 让位。历史缺陷：两条恢复路径无互斥，瀑布二层重跑 boot 链（~4s）期间
+/// 自动重启线程先拉起内核 A，随后瀑布又拉起内核 B 并直接覆盖句柄——A 成为
+/// 无人管理的孤儿内核（数百 MB RSS 常驻，直到进程退出才被 Job Object 收割）。
+struct BootActiveGuard(Arc<Supervisor>, u64);
+impl Drop for BootActiveGuard {
+    fn drop(&mut self) {
+        // 代际感知：旧瀑布的守卫不得清掉新瀑布的标志（restart 叠加场景）。
+        let mut g = self.0.inner.lock().unwrap_or_else(|p| p.into_inner());
+        if g.generation == self.1 {
+            g.boot_active = false;
+        }
+    }
+}
 
 /// supervisor 对外事件（发给装配层，转发给窗口/托盘/日志）。
 #[derive(Debug, Clone)]
@@ -60,7 +101,7 @@ pub struct Supervisor {
 
 struct Inner {
     state: RunState,
-    kernel: Option<Child>,
+    kernel: Option<KernelProc>,
     kernel_url: Option<String>,
     port: Option<u16>,
     last_error: Option<String>,
@@ -78,6 +119,9 @@ struct Inner {
     /// （同代际下崩溃自动重启换内核后，旧环不得继续探活/误杀新内核）。
     probe_gen: u64,
     stopping: bool,
+    /// 瀑布进行中（BootActiveGuard 维护）：启动期退出由瀑布独占接管，
+    /// 崩溃自动重启臂让位（防双内核竞态，见 BootActiveGuard）。
+    boot_active: bool,
 }
 
 
@@ -143,6 +187,7 @@ impl Supervisor {
                 generation: 0,
                 probe_gen: 0,
                 stopping: false,
+                boot_active: false,
             })),
         }
     }
@@ -230,6 +275,10 @@ impl Supervisor {
     fn boot_waterfall(this: Arc<Self>, tx: Sender<SupervisorEvent>, preferred_port: Option<u16>) {
         {
             let gen = this.inner.lock().unwrap_or_else(|p| p.into_inner()).generation;
+            // 瀑布启动：独占内核恢复权直到本链终局（就绪/恢复页/取消）——
+            // Drop 守卫保证任何 return / panic 路径都释放（代际感知防叠犬误清）。
+            this.inner.lock().unwrap_or_else(|p| p.into_inner()).boot_active = true;
+            let _boot_guard = BootActiveGuard(Arc::clone(&this), gen);
             // ---- [0.5] farm 实体目录去材料化（Electron repairProfileFallback
             // 等价物，H/V2 实测定论的残余风险）：farm 条目被云同步/复制还原成
             // 实体目录时内核 heal 直接放弃（"exists and is not a symlink"），
@@ -399,15 +448,16 @@ impl Supervisor {
     }
 
     /// guard 子命令薄跑（stdout 末行 JSON 解析；失败返回 None——瀑布降级而非崩）。
+    /// 有界执行：AV 拦半死的 node 不再拖住 boot 线程（超时按失败处理）。
     fn guard_cli_json(&self, args: &[&str]) -> Option<serde_json::Value> {
-        let out = Command::new(&self.node_exe)
-            .arg(&self.sidecar_cli)
+        let mut cmd = Command::new(&self.node_exe);
+        cmd.arg(&self.sidecar_cli)
             .args(args)
             .arg("--app-dir")
             .arg(&self.app_dir)
-            .creation_flags_win()
-            .output()
-            .ok()?;
+            .creation_flags_win();
+        let out = bounded::output_with_timeout(&mut cmd, SIDECAR_STEP_TIMEOUT).ok()?;
+        let out = out.output?;
         if !out.status.success() { return None; }
         let stdout = String::from_utf8_lossy(&out.stdout);
         let line = stdout.trim_end().lines().last()?;
@@ -436,18 +486,18 @@ impl Supervisor {
             eprintln!("[farm-repair] 脚本缺失（{:?}），跳过", script);
             return;
         }
-        let out = Command::new(&self.node_exe)
-            .arg(&script)
+        let mut cmd = Command::new(&self.node_exe);
+        cmd.arg(&script)
             .arg(&self.app_dir)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .creation_flags_win()
-            .output();
+            .creation_flags_win();
+        let out = bounded::output_with_timeout(&mut cmd, SIDECAR_STEP_TIMEOUT);
         match out {
             Ok(o) => {
-                let stderr = String::from_utf8_lossy(&o.stderr);
-                for line in stderr.lines().filter(|l| l.contains("[farm-repair]")) {
-                    log_line(line);
+                if let Some(out) = o.output {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    for line in stderr.lines().filter(|l| l.contains("[farm-repair]")) {
+                        log_line(line);
+                    }
                 }
             }
             Err(e) => eprintln!("[farm-repair] 执行失败（不阻断）：{e}"),
@@ -455,23 +505,23 @@ impl Supervisor {
     }
 
     fn run_sidecar_boot(&self, tx: &Sender<SupervisorEvent>, _gen: u64) -> Result<(), String> {
-        let out = Command::new(&self.node_exe)
-            .arg(&self.sidecar_cli)
+        let mut cmd = Command::new(&self.node_exe);
+        cmd.arg(&self.sidecar_cli)
             .arg("boot")
             .arg("--app-dir")
             .arg(&self.app_dir)
             .env("DSH_TAURI_VERSION", env!("CARGO_PKG_VERSION"))
             // GUI 进程起 console 子进程抑制终端窗（boot 是「启动后弹终端」主源，
             // 与本文件其余 node spawn 同口径——0.5.0 实测修复）。
-            .creation_flags_win()
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
+            .creation_flags_win();
+        let out = bounded::output_with_timeout(&mut cmd, SIDECAR_BOOT_TIMEOUT)
             .map_err(|e| {
                 let msg = format!("sidecar spawn 失败（node: {} cli: {}）: {e}", self.node_exe.display(), self.sidecar_cli.display());
                 eprintln!("[boot] {msg}");
                 msg
-            })?;
+            })?
+            .output
+            .ok_or("sidecar boot 超时被终止（有界执行）")?;
         if !out.status.success() {
             let msg = format!("sidecar boot 退出码 {:?}: {}", out.status.code(), String::from_utf8_lossy(&out.stderr).lines().take(6).collect::<Vec<_>>().join(" | "));
             eprintln!("[boot] {msg}");
@@ -504,14 +554,16 @@ impl Supervisor {
         let ok = match cached {
             Some(true) => true,
             _ => {
-                let out = std::process::Command::new(&self.node_exe)
-                    .arg(&self.sidecar_cli)
+                let mut cmd = std::process::Command::new(&self.node_exe);
+                cmd.arg(&self.sidecar_cli)
                     .arg("koffi-preflight")
                     .arg("--app-dir")
                     .arg(&self.app_dir)
-                    .creation_flags_win()
-                    .output();
-                let ok = matches!(out, Ok(o) if o.status.success()
+                    .creation_flags_win();
+                let out = bounded::output_with_timeout(&mut cmd, SIDECAR_STEP_TIMEOUT)
+                    .ok()
+                    .and_then(|o| o.output);
+                let ok = matches!(out, Some(o) if o.status.success()
                     && String::from_utf8_lossy(&o.stdout).trim_end().ends_with("{\"ok\":true}"));
                 if ok {
                     let _ = settings.set("koffiPreflightOk", serde_json::json!(true));
@@ -520,14 +572,16 @@ impl Supervisor {
             }
         };
         if !ok {
-            let out = std::process::Command::new(&self.node_exe)
-                .arg(&self.sidecar_cli)
+            let mut cmd = std::process::Command::new(&self.node_exe);
+            cmd.arg(&self.sidecar_cli)
                 .arg("picker-overlay")
                 .arg("--app-dir")
                 .arg(&self.app_dir)
-                .creation_flags_win()
-                .output();
-            if let Ok(o) = out {
+                .creation_flags_win();
+            let out = bounded::output_with_timeout(&mut cmd, SIDECAR_STEP_TIMEOUT)
+                .ok()
+                .and_then(|o| o.output);
+            if let Some(o) = out {
                 let stdout = String::from_utf8_lossy(&o.stdout);
                 if let Some(line) = stdout.trim_end().lines().last() {
                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
@@ -558,14 +612,16 @@ impl Supervisor {
 
     /// 刷新 safe-boot overlay（崩溃自动重启前）：解析 dsh-web.log 失败插件 → 禁用。
     fn refresh_safe_overlay(&self) -> bool {
-        let out = std::process::Command::new(&self.node_exe)
-            .arg(&self.sidecar_cli)
+        let mut cmd = std::process::Command::new(&self.node_exe);
+        cmd.arg(&self.sidecar_cli)
             .arg("safe-overlay")
             .arg("--app-dir")
             .arg(&self.app_dir)
-            .creation_flags_win()
-            .output();
-        let Ok(o) = out else { return false };
+            .creation_flags_win();
+        let Some(o) = bounded::output_with_timeout(&mut cmd, SIDECAR_STEP_TIMEOUT)
+            .ok()
+            .and_then(|o| o.output)
+        else { return false };
         let stdout = String::from_utf8_lossy(&o.stdout);
         let Some(line) = stdout.trim_end().lines().last() else { return false };
         let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else { return false };
@@ -586,6 +642,16 @@ impl Supervisor {
 
     /// spawn 内核进程 + 就绪行监视线程。
     fn spawn_kernel(self: Arc<Self>, port: u16, tx: &Sender<SupervisorEvent>) -> Result<(), String> {
+        // 进程隔离不变量：spawn 前必须无活内核——任何并发路径违反互斥
+        // （瀑布 vs 自动重启）时，后来者负责回收先到者。历史缺陷：直接覆盖
+        // 句柄 = 先到内核成为孤儿（数百 MB RSS 无人管，占着端口直到进程退出）。
+        let orphan = self.inner.lock().unwrap_or_else(|p| p.into_inner()).kernel.take();
+        if let Some(mut victim) = orphan {
+            let pid = victim.child.id();
+            log_line(&format!("spawn 前发现未回收内核 pid={pid}（并发 spawn 违例，先杀后起）"));
+            kernel_process::kill_tree(&mut victim.child, pid);
+            victim.job.close(); // 内核已终结：释放 Job 句柄
+        }
         let overlays = self.inner.lock().unwrap_or_else(|p| p.into_inner()).overlays.clone();
         let spec = SpawnSpec::new(&self.node_exe, &self.bin_js, &self.kernel_version, port, &overlays);
         let mut cmd = Command::new(&spec.node_exe);
@@ -610,12 +676,17 @@ impl Supervisor {
         log_line(&format!("内核 pid={pid} spawn: {}", spec.display_cmd()));
 
         // Review#2 根治：Job Object 杀树保护（父进程被强杀时 OS 收割内核树）。
-        if let Err(e) = kernel_process::job_object::assign_child_to_kill_on_close_job(&child) {
-            log_line(&format!("Job Object 赋值失败（杀树保护降级为显式 taskkill）: {e}"));
-        }
+        // 句柄随 KernelProc 存活，内核终结后 Drop 关闭（不再随 spawn 泄漏）。
+        let job = match kernel_process::job_object::assign_child_to_kill_on_close_job(&child) {
+            Ok(job) => job,
+            Err(e) => {
+                log_line(&format!("Job Object 赋值失败（杀树保护降级为显式 taskkill）: {e}"));
+                kernel_process::job_object::JobHandle::noop()
+            }
+        };
         let stdout = child.stdout.take().ok_or("stdout piped 失败")?;
         let stderr = child.stderr.take();
-        self.inner.lock().unwrap_or_else(|p| p.into_inner()).kernel = Some(child);
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).kernel = Some(KernelProc { child, job });
 
         // 就绪行监视（独占读 stdout；读 EOF 时若进程仍在则继续探活兜底）。
         let this = Arc::clone(&self);
@@ -665,7 +736,7 @@ impl Supervisor {
             let (code, exited) = {
                 let mut g = this.inner.lock().unwrap_or_else(|p| p.into_inner());
                 match g.kernel.as_mut() {
-                    Some(c) => match c.try_wait() {
+                    Some(kp) => match kp.child.try_wait() {
                         Ok(Some(st)) => (st.code(), true),
                         Ok(None) => (None, true), // stdout 关了但进程在：罕见，按退出处理
                         Err(_) => (None, true),
@@ -720,10 +791,20 @@ impl Supervisor {
             // 经 KernelReady 把页面从恢复页拉回内核页（页面反复横跳）。
             Verdict::Tripped | Verdict::Cooldown => self.enter_recovery_tx(tx, "崩溃环触发"),
             Verdict::Ok => {
+                // 瀑布进行中：启动期退出由瀑布层独占接管（boot_active 互斥）——
+                // 历史缺陷：自动重启臂（2s 延迟）与瀑布二层（重跑 boot 链 ~4s）
+                // 无互斥，两路各拉一个内核，后者覆盖句柄 → 前者成孤儿内核
+                // （数百 MB RSS 常驻；若同端口其一还吃 EADDRINUSE 记假崩溃）。
+                let (port, gen, boot_active) = {
+                    let g = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+                    (g.port, g.generation, g.boot_active)
+                };
+                if boot_active {
+                    log_line("瀑布进行中：启动期退出由瀑布层接管，本次不自动重启（防双内核竞态）");
+                    return;
+                }
                 // 未成环：自动重启一次（Electron watchServerProc 语义：异常退出自动拉起）。
                 // 探活/换页不在此布防：新内核的就绪行线程统一负责（probe_gen 令牌）。
-                let port = self.inner.lock().unwrap_or_else(|p| p.into_inner()).port;
-                let gen = self.inner.lock().unwrap_or_else(|p| p.into_inner()).generation;
                 let this = Arc::clone(self);
                 let tx2 = tx.clone();
                 std::thread::spawn(move || {
@@ -744,23 +825,33 @@ impl Supervisor {
         }
     }
 
-    /// 探活循环：TCP connect + 就绪超时。
-    /// HTTP 应用层探活：读到任何响应字节（含 404/401——内核对 / 至少回
-    /// index/错误页）即证明事件循环在转。TCP 握手由 OS 协议栈完成，进程
-    /// 假死时也恒成功——必须发请求读响应才能区分（issue #122/#129）。
-    fn http_alive(port: u16) -> bool {
+    /// 单连接三态探活（性能审计 2026-08：原实现每拍开两条连接——TCP 试探
+    /// 一条、http_alive 再开一条，健康稳态每天 ~5.76 万次环回连接纯浪费）。
+    fn probe_outcome(port: u16) -> ProbeOutcome {
         use std::io::{Read, Write};
-        let Ok(addr) = format!("127.0.0.1:{port}").parse() else { return false };
+        let Ok(addr) = format!("127.0.0.1:{port}").parse() else { return ProbeOutcome::TcpDead };
         let Ok(mut s) = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(2)) else {
-            return false;
+            return ProbeOutcome::TcpDead;
         };
         let _ = s.set_read_timeout(Some(Duration::from_secs(3)));
         let _ = s.set_write_timeout(Some(Duration::from_secs(3)));
         if s.write_all(b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n").is_err() {
-            return false;
+            // 端口在、协议死：按假死计；进程若真死，下一拍 connect 失败归 TcpDead。
+            return ProbeOutcome::Zombie;
         }
         let mut buf = [0u8; 16];
-        matches!(s.read(&mut buf), Ok(n) if n > 0)
+        match s.read(&mut buf) {
+            Ok(n) if n > 0 => ProbeOutcome::Alive,
+            _ => ProbeOutcome::Zombie,
+        }
+    }
+
+    /// HTTP 应用层探活（bool 语义，热探路径消费）：读到任何响应字节（含
+    /// 404/401——内核对 / 至少回 index/错误页）即证明事件循环在转。TCP 握手
+    /// 由 OS 协议栈完成，进程假死时也恒成功——必须发请求读响应才能区分
+    /// （issue #122/#129）。
+    fn http_alive(port: u16) -> bool {
+        Self::probe_outcome(port) == ProbeOutcome::Alive
     }
 
     fn probe_loop(self: &Arc<Self>, port: u16, tx: Sender<SupervisorEvent>, gen: u64, probe_gen: u64) {
@@ -792,46 +883,43 @@ impl Supervisor {
                         return;
                     }
                 }
-                let tcp_ok = std::net::TcpStream::connect_timeout(
-                    &format!("127.0.0.1:{port}").parse().unwrap(),
-                    Duration::from_secs(2),
-                )
-                .is_ok();
-                if tcp_ok && Self::http_alive(port) {
-                    consecutive = 0;
-                    zombie = 0;
-                    continue;
-                }
-                if !tcp_ok {
-                    zombie = 0;
-                    consecutive += 1;
-                    let _ = tx.send(SupervisorEvent::ProbeFailed { consecutive });
-                    if consecutive >= 3 {
-                        // 端口连续失联但进程可能还活着：杀掉按退出处理。
-                        // 内核已不在（退出处理链已接管：自动重启或恢复页）时
-                        // 不得再记一次崩溃——那会把后续自动重启的新内核当作
-                        // 本次失败连带处理。
-                        let kernel_present = {
-                            let g = this.inner.lock().unwrap_or_else(|p| p.into_inner());
-                            g.kernel.is_some()
-                        };
-                        if kernel_present {
+                match Self::probe_outcome(port) {
+                    ProbeOutcome::Alive => {
+                        consecutive = 0;
+                        zombie = 0;
+                    }
+                    ProbeOutcome::TcpDead => {
+                        zombie = 0;
+                        consecutive += 1;
+                        let _ = tx.send(SupervisorEvent::ProbeFailed { consecutive });
+                        if consecutive >= 3 {
+                            // 端口连续失联但进程可能还活着：杀掉按退出处理。
+                            // 内核已不在（退出处理链已接管：自动重启或恢复页）时
+                            // 不得再记一次崩溃——那会把后续自动重启的新内核当作
+                            // 本次失败连带处理。
+                            let kernel_present = {
+                                let g = this.inner.lock().unwrap_or_else(|p| p.into_inner());
+                                g.kernel.is_some()
+                            };
+                            if kernel_present {
+                                this.kill_kernel();
+                                this.on_kernel_exit(None, &tx);
+                            }
+                            return;
+                        }
+                    }
+                    // TCP 通、HTTP 无响应：假死形态。
+                    ProbeOutcome::Zombie => {
+                        zombie += 1;
+                        let _ = tx.send(SupervisorEvent::ZombieSuspect { consecutive: zombie });
+                        log_line(&format!("内核假死可疑（端口通、HTTP 无响应）×{zombie}"));
+                        if zombie >= 20 {
+                            log_line("内核假死判定成立（连续 60s HTTP 无响应，20×3s 探活），受控重启");
                             this.kill_kernel();
                             this.on_kernel_exit(None, &tx);
+                            return;
                         }
-                        return;
                     }
-                    continue;
-                }
-                // TCP 通、HTTP 无响应：假死形态。
-                zombie += 1;
-                let _ = tx.send(SupervisorEvent::ZombieSuspect { consecutive: zombie });
-                log_line(&format!("内核假死可疑（端口通、HTTP 无响应）×{zombie}"));
-                if zombie >= 20 {
-                    log_line("内核假死判定成立（连续 60s HTTP 无响应，20×3s 探活），受控重启");
-                    this.kill_kernel();
-                    this.on_kernel_exit(None, &tx);
-                    return;
                 }
             }
         });
@@ -893,12 +981,14 @@ impl Supervisor {
 
     /// 杀内核整树（restart / 恢复页 / 探活失败 / 应用退出共用）。
     /// Windows：taskkill /T /F；Unix：killpg(-pgid, SIGKILL) 整组收割
-    /// ——OS 绑定见 kernel_process::kill_tree（本函数仅持锁取 child + 派发）。
+    /// ——OS 绑定见 kernel_process::kill_tree。
+    /// 持锁仅取句柄，杀树（taskkill 子进程 + wait，AV 下数百 ms）在锁外
+    /// 进行——旧行为全程持锁，探活节拍 / state() / kernel_url() 全部陪等。
     pub fn kill_kernel(&self) {
-        let mut g = self.inner.lock().unwrap_or_else(|p| p.into_inner());
-        if let Some(mut c) = g.kernel.take() {
-            let pid = c.id();
-            kill_tree(&mut c, pid);
+        if let Some(mut kp) = self.inner.lock().unwrap_or_else(|p| p.into_inner()).kernel.take() {
+            let pid = kp.child.id();
+            kill_tree(&mut kp.child, pid);
+            kp.job.close(); // 内核已终结：释放 Job 句柄（不再随 spawn 泄漏）
         }
     }
 
@@ -1020,6 +1110,92 @@ Content-Length: 0
             }
         }
         None
+    }
+
+    /// 单连接三态探活（性能审计 2026-08）：每拍恰好一次 TCP 连接——原实现
+    /// TCP 试探 + http_alive 各开一条（健康稳态 3s 一拍 ×2 条 ≈ 每天 5.76 万
+    /// 次环回连接）。计数服务器实测连接数 == 探测次数。
+    #[test]
+    fn probe_once_opens_exactly_one_connection_per_tick() {
+        use std::sync::atomic::AtomicUsize;
+        let conns = Arc::new(AtomicUsize::new(0));
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let c2 = Arc::clone(&conns);
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut s = stream.unwrap();
+                c2.fetch_add(1, Ordering::Relaxed);
+                use std::io::{Read, Write};
+                let mut buf = [0u8; 128];
+                let _ = s.read(&mut buf);
+                let _ = s.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+            }
+        });
+        std::thread::sleep(Duration::from_millis(150));
+        const N: usize = 5;
+        for _ in 0..N {
+            assert_eq!(Supervisor::probe_outcome(port), ProbeOutcome::Alive);
+        }
+        assert_eq!(conns.load(Ordering::Relaxed), N, "每拍必须恰好一次连接（旧实现 2×N = 纯浪费）");
+    }
+
+    /// 三态对照：假死（TCP 通、HTTP 永不响应）/ 无监听端口——单连接判定
+    /// 与旧双连接口径逐态一致。
+    #[test]
+    fn probe_outcome_classifies_zombie_and_dead() {
+        let zombie = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let zport = zombie.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            for stream in zombie.incoming() {
+                let _stream: std::net::TcpStream = stream.unwrap();
+                std::thread::sleep(Duration::from_secs(30)); // 持住连接不响应
+            }
+        });
+        let dead = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let dport = dead.local_addr().unwrap().port();
+        drop(dead);
+        std::thread::sleep(Duration::from_millis(150));
+        assert_eq!(Supervisor::probe_outcome(zport), ProbeOutcome::Zombie, "TCP 通、HTTP 永不响应 → 假死");
+        assert_eq!(Supervisor::probe_outcome(dport), ProbeOutcome::TcpDead, "无监听端口 → 进程死");
+    }
+
+    /// 进程生命周期不变量形态锚点（性能审计 2026-08）：
+    /// ① boot_active 互斥：瀑布运行期启动期退出不得进入自动重启臂；
+    /// ② spawn 前回收：spawn_kernel 必须先杀未回收内核（孤儿根治的第二道防线）；
+    /// ③ 杀树在锁外：kill_kernel 持锁仅取句柄（探活节拍不陪等 taskkill）；
+    /// ④ Job 句柄随内核终结关闭（不随 spawn 泄漏）。
+    #[test]
+    fn kernel_lifecycle_invariants_shape() {
+        let src = include_str!("supervisor.rs").replace("\r\n", "\n");
+        // ① 自动重启臂必须让位瀑布。
+        let exit_seg = src
+            .split("fn on_kernel_exit")
+            .nth(1)
+            .and_then(|s| s.split("/// 单连接三态探活").next())
+            .expect("on_kernel_exit 段");
+        let boot_check = exit_seg.find("boot_active").expect("自动重启臂必须检查 boot_active");
+        let restart_arm = exit_seg.find("std::thread::spawn(move || {\n                    std::thread::sleep(Duration::from_secs(2));").expect("自动重启线程臂");
+        assert!(boot_check < restart_arm, "boot_active 检查必须先于自动重启线程拉起（瀑布独占恢复权）");
+        // ② spawn 前回收。
+        let spawn_seg = src
+            .split("fn spawn_kernel")
+            .nth(1)
+            .and_then(|s| s.split("let overlays =").next())
+            .expect("spawn_kernel 段头");
+        assert!(spawn_seg.contains("并发 spawn 违例，先杀后起"), "spawn 前必须回收未收割内核: {spawn_seg}");
+        // ③ 杀树锁外。
+        let kill_seg = src
+            .split("pub fn kill_kernel")
+            .nth(1)
+            .and_then(|s| s.split("/// 应用退出路径").next())
+            .expect("kill_kernel 段");
+        assert!(kill_seg.contains("kernel.take()"), "持锁仅取句柄");
+        assert!(kill_seg.contains("job.close()"), "内核终结后必须关闭 Job 句柄");
+        // ④ BootActiveGuard 存在且代际感知。
+        assert!(src.contains("struct BootActiveGuard"), "瀑布互斥守卫必须存在");
+        let guard_seg = src.split("impl Drop for BootActiveGuard").nth(1).and_then(|s| s.split("}").next()).unwrap_or("");
+        assert!(guard_seg.contains("g.generation == self.1"), "守卫清理必须代际感知（restart 叠加场景）");
     }
 
     /// 干净临时 home + userData（测试沙箱）。
@@ -1213,7 +1389,7 @@ Content-Length: 0
         let exit_seg = src
             .split("fn on_kernel_exit")
             .nth(1)
-            .and_then(|s| s.split("/// 探活循环").next())
+            .and_then(|s| s.split("/// 单连接三态探活").next())
             .expect("on_kernel_exit 段");
         assert!(
             exit_seg.contains("Verdict::Tripped | Verdict::Cooldown =>"),
@@ -1323,6 +1499,95 @@ mod stability_tests {
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d
+    }
+
+    /// 构造伪仓库根（boot 竞态 E2E 用）：<root>/dsh-desktop/vendor/node/<node> +
+    /// <root>/sidecar/cli.js（假分发器）+ <root>/dsh-desktop/node_modules/.../bin.js
+    /// （秒退假内核，每次执行向计数文件追加一行）。
+    fn fake_repo_root(node_exe: &std::path::Path, counter: &std::path::Path, boot_sleep_ms: u64) -> std::path::PathBuf {
+        let root = sandbox(&format!("fake-root-{}", std::process::id()));
+        let app_dir = root.join("dsh-desktop");
+        std::fs::create_dir_all(app_dir.join("vendor").join("node")).unwrap();
+        std::fs::create_dir_all(root.join("sidecar")).unwrap();
+        let dsh_dir = app_dir.join("node_modules").join("@deepseek-ai").join("dsh").join("lib");
+        std::fs::create_dir_all(&dsh_dir).unwrap();
+        // vendor node：同卷硬链接（零拷贝），跨卷回退复制。
+        let vendored = app_dir.join("vendor").join("node").join("node.exe");
+        if std::fs::hard_link(node_exe, &vendored).is_err() {
+            std::fs::copy(node_exe, &vendored).unwrap();
+        }
+        // 假内核：立即退出（无就绪行）→ 每次拉起都失败 → 瀑布三层全走。
+        let counter_js = counter.to_string_lossy().replace('\\', "\\\\").replace('\'', "\\'");
+        std::fs::write(
+            dsh_dir.join("bin.js"),
+            format!("require('node:fs').appendFileSync('{counter_js}', 'spawn\\n'); process.exit(1);"),
+        )
+        .unwrap();
+        // 假 sidecar cli：boot 子命令睡眠（放大竞态窗口：自动重启延迟 2s <
+        // 二层 boot 链耗时），其余子命令按协议输出末行 JSON。
+        std::fs::write(
+            root.join("sidecar").join("cli.js"),
+            format!(
+                r#""use strict";
+const cmd = process.argv[2];
+if (cmd === 'boot') {{
+  const end = Date.now() + {boot_sleep_ms};
+  while (Date.now() < end) {{}}
+  process.stdout.write(JSON.stringify({{ ok: true, totalMs: {boot_sleep_ms}, steps: [] }}) + "\n");
+  process.exit(0);
+}}
+if (cmd === 'koffi-preflight') {{ process.stdout.write('{{"ok":true}}' + "\n"); process.exit(0); }}
+process.stdout.write('{{"ok":true}}' + "\n");
+"#
+            ),
+        )
+        .unwrap();
+        root
+    }
+
+    /// 双内核竞态 E2E（性能审计 2026-08 根治锚点）：内核启动期退出时，
+    /// 崩溃自动重启臂（2s 延迟）与瀑布二层（重跑 boot 链，此处放大到 5s）
+    /// 无互斥 → 两条路径各拉一个内核，后者覆盖句柄 → 前者成孤儿
+    /// （数百 MB RSS 无人管，直到进程退出才被 Job Object 收割）。
+    /// 修复后（boot_active 互斥 + spawn 前回收），瀑布全过程恰好拉起 3 次
+    /// （三层各一）。修复前实测 spawn 数 > 3。
+    #[test]
+    fn boot_race_does_not_spawn_orphan_kernels() {
+        let Some(root) = repo_root() else { eprintln!("[skip] 无依赖环境"); return; };
+        let _env = crate::ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let home = sandbox("race-home");
+        std::env::set_var("DSH_HOME", &home);
+        std::env::set_var("DSH_TAURI_USERDATA", home.join("ud"));
+        let counter = std::env::temp_dir().join(format!("dsh-fake-kernel-count-{}", std::process::id()));
+        let _ = std::fs::remove_file(&counter);
+        let node_exe = root.join("dsh-desktop").join("vendor").join("node").join("node.exe");
+        let fake_root = fake_repo_root(&node_exe, &counter, 5_000);
+
+        let sv: Arc<Supervisor> = Arc::new(Supervisor::new(&fake_root));
+        let (tx, rx) = std::sync::mpsc::channel();
+        sv.spawn_boot(tx, None);
+        // 瀑布终局：伪 cli 无可回滚快照（guard-lastgood 无 id）→ 两层拉起
+        // （首拉 + 修复层）后直接进恢复页。二层 boot 放大 5s > 自动重启臂
+        // 延迟 2s——竞态窗口确定敞开（修复前此处会多出自动重启的 spawn）。
+        let deadline = Instant::now() + Duration::from_secs(120);
+        loop {
+            let left = deadline.saturating_duration_since(Instant::now()).max(Duration::from_millis(1));
+            match rx.recv_timeout(left) {
+                Ok(SupervisorEvent::CrashLoop { .. }) => break,
+                Ok(_) => {}
+                Err(_) => panic!("120s 内瀑布未到终局（应三层失败进恢复页）"),
+            }
+        }
+        // 先关停（压住迟到的自动重启线程），再数 spawn。
+        sv.shutdown();
+        std::thread::sleep(Duration::from_secs(3));
+        let spawns = std::fs::read_to_string(&counter).unwrap_or_default().lines().filter(|l| !l.trim().is_empty()).count();
+        assert_eq!(spawns, 2, "瀑布两层恰好各拉起一次内核（实测 {spawns} 次；>2 = 双内核竞态回归：自动重启臂与瀑布未互斥）");
+        std::env::remove_var("DSH_HOME");
+        std::env::remove_var("DSH_TAURI_USERDATA");
+        let _ = std::fs::remove_file(&counter);
+        let _ = std::fs::remove_dir_all(&fake_root);
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     /// 伴随插件入口文件被写坏（用户磁盘坏块/更新中断的真实形态）：


### PR DESCRIPTION
## 背景与方法

对 Tauri 版做了一轮全栈性能与资源占用审计（Rust 壳 / Node sidecar / WebView 垫片），定位出五大系列问题。每项均按 **实证 → 根因 → 根治 → 回归** 闭环处理：先写测试证明问题真实存在（红），修复后回绿；关键项附端到端对照（缺陷形态 vs 修复形态）。

## 一、进程隔离：子进程等待全部挪出 UI 主线程

**根因**：Tauri 同步命令在 UI 主线程执行——`run_sidecar`（插件/诊断/备份全族）、`copy_text`（每次复制 spawn PowerShell）、`wsl_config_get`/`wsl_recheck`、`image_paste_save`、`restart_service`/`recovery_restart`（杀树段）一律 `.output()` 同步等子进程（node 冷启动数百 ms 起、插件检查/更新分钟级）→ 整窗冻结（拖动/重绘/全部 IPC 派发停摆）。两个放大器：全局 `SIDECAR_LOCK` 让慢命令把后续全部 sidecar 命令排队串冻；所有子进程**无超时**（AV/SmartScreen 拦半死 = 永挂 + 串行锁被永久占死）。

**修法**：
- 新增 `bounded.rs`——壳内子进程唯一有界出口：超时强杀整树（复用 kernel-process 跨平台杀树），读线程排空管道防死锁。分级上限：boot 单步 60s / boot 整链 120s / sidecar 命令 300s
- 全部进程派生命令统一 `async fn` + `spawn_blocking`；串行锁语义不变（Review#2 防竞写 cordis.patch.yml 契约保留），排队挪到后台线程池
- `copy_text` 顺带根治两个真实缺陷：Windows ~32K 命令行上限使长文本（契约允许 1MB）直接失败 + PowerShell 按控制台代码页解析参数的乱码面 → 改经 **stdin 传 base64**（纯 ASCII 代码页安全，UTF-8 精确还原），实测 90KB 中英混排剪贴板往返逐字节一致（含测试）

## 二、内核进程生命周期

**双内核竞态 → 孤儿内核**：内核启动期崩溃时（坏插件/坏补丁——恰是守护瀑布存在的场景），「崩溃自动重启臂（2s 延迟）」与「瀑布二层（重跑 boot 链 ~4s）」无互斥，两路各拉一个内核，后者直接覆盖句柄——前者成为数百 MB RSS 的孤儿，直到进程退出才被 Job Object 收割。
- 修法：`boot_active` 互斥（`BootActiveGuard`——Drop 守卫保证 panic 路径也释放，代际感知防 restart 叠加误清）+ `spawn_kernel` 前置回收不变量（任何并发违例时后来者杀先到者，孤儿在结构上不可能存在）
- **端到端对照实证**：伪仓库（假内核秒退 + 二层 boot 放大 5s 敞开竞态窗口），E2E 计数真实 spawn 次数：**缺陷形态 4 次（自动重启臂抢跑），修复后恰好 2 次（瀑布两层各一）**——测试在两种形态下分别红/绿

**Job 句柄泄漏**：每次内核 spawn 泄漏一个 Job Object 句柄（崩溃环/瀑布重试日积月累上千）→ 句柄随新的 `KernelProc{child, job}` 同进同出，内核终结即 `close()`；壳存活期间在场，强杀兜底语义不变。测试：20 轮 assign/close 后活跃计数回基线（含 Drop 兜底路径）。

**探活双连接**：每 3 秒开两条 TCP 连接（TCP 试探一条、`http_alive` 再开一条），健康稳态约每天 5.76 万次环回连接纯浪费 → `probe_outcome` 单连接三态判定（Alive/TcpDead/Zombie），连接数实测减半、假死判定口径逐态不变。

**杀树持锁**：`kill_kernel` 全程持 supervisor 锁跑 taskkill（AV 下数百 ms），探活节拍/`state()`/`kernel_url()` 全部陪等 → 持锁仅取句柄，杀树锁外执行。

## 三、桥垫片：iframe 守卫次序 + 监听器生命周期

**iframe 重复壳机制**：Tauri initialization_script 注入所有同源 iframe（内核 UI 的 synapse 等），守卫却写在壳机制之后——vm 沙箱行为测试实测：**修复前每个 iframe 载入即产生 6 次 IPC**（4 个 `plugin:event|listen` + 心跳 + 会话上报）且永不停止，开销随帧数翻倍、iframe 心跳污染全局计数。
- 修法：`IS_TOP` 帧定位**前置**，壳机制（订阅/心跳/轮询/错误上报/控制条/自初始化）全部主框架独占；桥对象 48 方法与 dialog polyfill **保留在所有帧**（Electron 时代 iframe 本无桥，兼容性只增不减）。修复后 iframe 载入**零 IPC**

**监听器只增不减**：每次导航/重载在 Rust 侧监听表留死条目（emit 向死句柄派发）→ pagehide 统一退订（`plugin:event|unlisten`）+ 清定时器，listen Promise 未决时 resolve 后补位退订。vm 测试实证：pagehide 后 4 个订阅全部退订、事件 id 不重复、定时器全清。

**心跳窗口归属**：载荷带 `{window: main|float|pet}`，假死看门狗只统计主窗——原全窗口共用一个计数器时，活的浮窗会永久掩蔽死的主窗（假死恢复失效）。

## 四、假死看门狗：最小化误判

Windows 上最小化窗 `is_visible()` 仍为 true，定时器被节流到 ~1 次/分 → 被误判「心跳停摆 40s」→ **最小化期间每 ~5-6 分钟一次 `location.reload()` 风暴**（SPA 状态丢弃 + 监听器累积）。修法：失联判定统一 `common::window_watchable`（可见**且未最小化**，与余额轮询暂停门单一口径，判定表单测）。

## 五、常态开销与资源上界（sidecar + 壳层）

| 项 | 实证 | 修法 |
|---|---|---|
| sidecar 全量装载 | balance-fetch 每 3 分钟 spawn node 并全量 require 15 模块（实测 58ms+/次，AV 机放大）；未消费模块缺失直接炸整条命令（最小 appDir 实测 `Cannot find module`） | `loadModules` getter 懒加载，消费面零变更；最小 appDir 实测正常 |
| 插件解压无超时 | `Expand-Archive`/`unzip` 走 `execFileSync` 无 timeout——AV 拦半死 = 更新链永挂 + Rust 串行锁被占死 | `exec-bounded.js` 统一有界出口（120s，超时杀进程），行为测试覆盖 |
| httpGetJson 无字节上限 | 元数据通道（npm latest/GitHub Releases，先于 integrity 校验、无完整性保护）响应体无限累积成字符串 | 迁出为 `http-json.js` + 4MB 上限（对照 httpGetBuffer 64MB / balance.js 1MB 的家族缺口），慢滴流拒绝测试 |
| app_init 三次读盘 | `SettingsStore::get` 每键全量读 settings.json，垫片每次载入 + 每次菜单打开都触发 | 一次 `load()` 读三键（仍每次取最新值） |
| `[diag] t0` 常驻 | 每次内核就绪无条件 invoke `current_session('[diag] t0')`——顶掉真实会话指针（通知跳转豁免失效）+ preview-server 空转 | 与其他诊断探针对齐，`DSH_TAURI_DIAG=1` 门控 |
| 临时页目录累积 | `%TEMP%/dsh-tauri-pages-<pid>` 每次启动一个，强杀形态无人清理 | 退出清理 + 启动清扫 7 天前残留（含判定表测试） |

## 测试与验证

- `cargo test --workspace`：**196/196 通过**（含既有真机 boot 集成、崩溃自愈瀑布、窗口状态往返等），新增约 20 项行为/形态锚点测试
- `node --test sidecar/`：**28/28 通过**（新增 bridge-shim vm 沙箱行为测试 4 项 + cli-perf 6 项）
- `cargo build`（debug）：通过
- 先红后绿对照：iframe 零 IPC（修复前 6 次 IPC）、懒加载（修复前 Cannot find module）、双内核竞态 E2E（缺陷形态 4 次 spawn → 修复后 2 次）

## 兼容性与契约

- IPC 命令签名零破坏：`renderer_heartbeat` 新参 `window` 为可选（不传按主窗计，旧调用兼容）；其余命令参数与返回形态不变；`run_sidecar` 串行锁契约保留
- 垫片在 iframe 仍提供完整桥对象与 dialog polyfill（超出 Electron 时代能力，只增不减）
- 契约文档同步：`contracts/bridge-api.md` §4 心跳条目（标签化 + 主框架独占语义）
- CHANGELOG 未发布段全量记录

## 提交内容边界

**已提交（22 文件，+1660/−335）**：上述全部修复与测试、契约文档、CHANGELOG、Cargo.lock 版本对齐（0.5.1→0.5.2，上游 Cargo.toml 已升版而锁文件未再生的收口）。

**明确不提交**（构建/测试环境产物，均已被 .gitignore 覆盖）：`node_modules/`、`vendor/node`、`vendor/npm`（测试用 node 运行时拷贝）、`package-payload/`（打包暂存镜像）、`src-tauri/target/`（构建产物）。
