### PR TITLE
fix(balance): 本轮费用改按 token 消耗时段计价 + isPeakHour 补周末规则（issue #168）

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -6,6 +6,14 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 
 ## [Unreleased]
 
+### 余额 dock：本轮费用改「按 token 消耗时段」计价 + 峰谷判定补周末规则（issue #168）
+
+- **修复本轮费用随峰谷切换整段重算**：旧实现是「累计 token × 推送时刻的时段价」——高峰/空闲切换后（最长一个轮询周期），整段历史费用跟着跳变（如高峰期 ¥12 的会话到晚上显示 ¥6），与官方「按请求发生时刻结算、不追溯」的计费口径不符。现改为展示层**增量计价账本**：每个观察到的用量增量按其消耗时刻的时段价入账，已入账部分不随推送重算；账本按会话 id 键控、localStorage 持久化（页面重载延续、32 会话 LRU、脏数据/配额满静默降级纯内存）。已知近似（token 无时间戳的架构边界）：基线与页面关闭期间的量按观察/重开时刻的时段价估算（详见 `docs/balance-architecture.md` §3.1）。
+- **主进程推送 `periodTables`（peak/off/legacy 三张时段价目表）+ `pricingSince`（峰谷生效节点）**：客户端按自身时钟选档，推送滞后不再影响计价正确性；`balancePrices.<model>` 用户覆盖同时并入三张表（覆盖语义与时段无关）。旧接线（未注入 `periodTables`）不产生新字段，客户端回退旧口径，向后兼容。
+- **`balance.js` `isPeakHour` 补周末规则**：官方 2026-08-23 公告起周六/周日全天按空闲价计费——旧实现周末 9-12/14-18 仍判高峰（dock 误显 ⛰高峰价、费用按全价估算），现与 `dsh-offpeak` 插件（issue #158）同口径，生效节点前不溯及既往。
+- **峰谷 chip 改客户端本地判定**（`isPeakAt`，镜像主进程口径）：整点切换即时生效，不受推送周期滞后影响；推送未携带 `periodTables`（旧形态）时回退主进程 `peak` 字段。
+- **测试**：`unit-balance.test.js` 新增 isPeakHour 周末矩阵（生效前后周六/周日、工作日不受影响）与 periodTables 三张表内容/纯快照断言；`unit-balance-scheduler.test.js` 新增 periodTables/pricingSince 载荷与覆盖并入断言；`edge-client.test.js` 新增时段计价回归组（峰→谷同用量不重算、跨边界增量分段、周末/legacy 选档、会话键控、重载延续、脏 storage 降级、模型档）+ 修正「prices 覆盖」用例为新语义（同一用量换价不重算）。
+
 ### 插件市场整体替换：dshmarket → dsh-community-market（F5）
 
 - **内置市场切换为上游 DSH Desktop 同款社区市场**：`assets/plugins/dsh-community-market`（源码构建自 [anywhere-labs/deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) 的 `dsh-community-market`，MIT）——开放目录源架构（内置 DSH 1024Store / dshfind 两个合作目录适配器 + 标准 HTTP 目录源，用户自行添加与启用）、契约 schema 校验的目录快照、npm registry 精确版本 + 完整性校验安装（禁装产品包/生命周期脚本防护、失败自动回滚）、安装回执与启停管理。宿主半边挂 `/api/community-market/*` 十条路由；客户端半边（`window.__ModuleLoader__` CJS bundle）注册设置页市场 tab + 侧栏入口 + 全屏 overlay。

--- a/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
@@ -12,9 +12,13 @@ window.__ModuleLoader__.load({
 		 *
 		 * 数据来源：DSH Desktop 壳层通过 preload 派发的
 		 * window "dsh-balance-changed" 事件（detail = { ok, balances, prices,
-		 * priceTable, model, peak, opencodeGo, at }，契约见
-		 * docs/balance-architecture.md）；纯浏览器环境（无桌面壳）时只显示
-		 * 「本轮费用」，价格用内置默认档。
+		 * priceTable, periodTables, pricingSince, model, peak, opencodeGo, at }，
+		 * 契约见 docs/balance-architecture.md）；纯浏览器环境（无桌面壳）时
+		 * 只显示「本轮费用」，价格用内置默认档。
+		 *
+		 * 本轮费用按「token 消耗时刻」的时段单价增量入账（见下方账本实现）：
+		 * 峰谷切换只影响之后的新增量，已入账部分不随推送重算——与官方
+		 * 峰谷计费口径一致。
 		 *
 		 * 单一投递契约：数据只从事件通道进入（window.dshDesktop.refreshBalance
 		 * 只用于触发刷新、不消费其返回值），杜绝「IPC 返回值 + 事件推送」
@@ -23,6 +27,93 @@ window.__ModuleLoader__.load({
 		// 纯浏览器降级（无桌面壳）时的兜底价格档：与全链路默认模型
 		// DEFAULT_MODEL = deepseek-v4-pro 一致（保守档，避免少报费用）。
 		const FALLBACK_PRICES = { cacheMiss: 9, cacheHit: 0.3, output: 27 };
+
+		// -----------------------------------------------------------------
+		// 按消耗时段计价（与官方峰谷计费口径对齐）
+		//
+		// 官方规则：每个 token 按它被消耗那一刻的时段单价结算，已结算的量
+		// 不随后续峰谷切换重算。tokenUsage 投影只给出累计四桶、无时间戳，
+		// 因此在展示层做增量计价账本：每次观察到累计用量前进，只对增量按
+		// 「观察时刻」的时段价入账；基线（首次观察到的存量）按当时时段价
+		// 一次性入账。峰谷切换只影响之后的新增量，显示不再随推送整段跳变。
+		// 时段价目来自主进程推送的三张表（periodTables：peak/off/legacy，
+		// 见 docs/balance-architecture.md §2）；客户端按自身时钟选档，推送
+		// 滞后（一个轮询周期）不影响计价正确性。
+		// -----------------------------------------------------------------
+
+		// 高峰窗口（分钟数，含起点不含终点）——镜像 balance.js isPeakHour。
+		const PEAK_WINDOWS = [
+			{ start: 9 * 60, end: 12 * 60 },
+			{ start: 14 * 60, end: 18 * 60 },
+		];
+		// 周末全天空闲的生效日（北京日历日）——官方 2026-08-23 公告，
+		// 与 dsh-offpeak 插件（issue #158）、balance.js 同口径，不溯及既往。
+		const WEEKEND_OFFPEAK_SINCE = "2026-08-23";
+
+		/** 北京时间（UTC+8，无夏令时）的分钟数/日历日/星期；用 UTC 字段平移读墙钟。 */
+		function beijingPartsOf(ms) {
+			const shifted = new Date(ms + 8 * 3600 * 1000);
+			const year = shifted.getUTCFullYear();
+			const month = shifted.getUTCMonth() + 1;
+			const day = shifted.getUTCDate();
+			const jsWeekday = shifted.getUTCDay(); // 0=周日 … 6=周六
+			return {
+				minutes: shifted.getUTCHours() * 60 + shifted.getUTCMinutes(),
+				date: year + "-" + (month < 10 ? "0" : "") + month + "-" + (day < 10 ? "0" : "") + day,
+				weekday: jsWeekday === 0 ? 7 : jsWeekday, // 1=周一 … 7=周日
+			};
+		}
+
+		/** 指定时刻是否高峰时段（镜像主进程 isPeakHour 的峰谷期语义）。 */
+		function isPeakAt(ms) {
+			const p = beijingPartsOf(ms);
+			if ((p.weekday === 6 || p.weekday === 7) && p.date >= WEEKEND_OFFPEAK_SINCE) return false;
+			return PEAK_WINDOWS.some((w) => p.minutes >= w.start && p.minutes < w.end);
+		}
+
+		/** 推送载荷里的三张时段价目表（无该字段 → null，调用方走旧口径）。 */
+		function periodTablesOf(data) {
+			return data !== null && typeof data === "object" && data.periodTables !== null && typeof data.periodTables === "object"
+				? data.periodTables
+				: null;
+		}
+
+		/**
+		 * 消耗时刻 ms 所处的时段价目表（peak/off/legacy 三选一）。
+		 * 返回 null = 载荷未携带 periodTables（旧形态）→ 调用方回退
+		 * pricesFor（按推送时刻已解析的单价）。
+		 */
+		function periodTableAt(data, ms) {
+			const tables = periodTablesOf(data);
+			if (tables === null) return null;
+			const sinceMs = typeof data.pricingSince === "string" ? Date.parse(data.pricingSince) : NaN;
+			let table;
+			if (Number.isFinite(sinceMs) && ms < sinceMs) table = tables.legacy;
+			else table = isPeakAt(ms) ? tables.peak : tables.off;
+			return table !== null && typeof table === "object" ? table : null;
+		}
+
+		/** 价目表中该用量所属模型的档位（与 pricesFor 的取档规则一致）。 */
+		function pickModelEntry(table, usage, data) {
+			if (table === null) return null;
+			const model = normalizeUsage(usage)?.model ?? null;
+			const defaultModel = (data && typeof data.model === "string" && data.model) || "deepseek-v4-pro";
+			const entry = (model !== null && table[model]) || table[defaultModel];
+			return entry !== null && typeof entry === "object" ? entry : null;
+		}
+
+		/**
+		 * 当前时刻的本地高峰判定（chip 显示与增量计价共用）。
+		 * 返回 null = 无 periodTables（旧形态载荷）→ 调用方回退推送的 peak。
+		 * 峰谷生效节点之前恒 false（旧版固定价期无高峰概念，与主进程一致）。
+		 */
+		function livePeakState(data) {
+			if (periodTablesOf(data) === null) return null;
+			const nowMs = Date.now();
+			const sinceMs = typeof data.pricingSince === "string" ? Date.parse(data.pricingSince) : NaN;
+			if (Number.isFinite(sinceMs) && nowMs < sinceMs) return false;
+			return isPeakAt(nowMs);
+		}
 
 		/**
 		 * token 用量归一化 —— 单一真源。
@@ -57,10 +148,12 @@ window.__ModuleLoader__.load({
 			return !!u && (u.uncached > 0 || u.read > 0 || u.write > 0 || u.output > 0);
 		}
 
-		/** token 用量 → 本轮费用（¥）。缓存写入按 miss 价计费（与官方一致）。 */
-		function sessionCost(usage, prices) {
-			const u = normalizeUsage(usage);
-			if (!u) return 0;
+		/**
+		 * token 桶用量 → 费用（¥）。缓存写入按 miss 价计费（与官方一致）。
+		 * 桶分量允许为负——增量计价时 (turn,step) 样本替换会造成累计回退，
+		 * 按有符号增量冲回；总费用下限 0，任何异常输入都不产生负费用。
+		 */
+		function bucketsCost(buckets, prices) {
 			const price = (key, fallback) => {
 				const v = Number(prices && prices[key]);
 				return Number.isFinite(v) && v >= 0 ? v : fallback;
@@ -69,12 +162,18 @@ window.__ModuleLoader__.load({
 			const cacheHit = price("cacheHit", FALLBACK_PRICES.cacheHit);
 			const output = price("output", FALLBACK_PRICES.output);
 			const perM = (n) => n / 1e6;
-			// 输入未命中 = 未缓存输入 + 缓存写；逐桶下限保护：任何异常输入
-			// 都不会产生负费用。
-			const miss = Math.max(0, perM(u.uncached + u.write));
-			const hit = Math.max(0, perM(u.read));
-			const out = Math.max(0, perM(u.output));
+			// 输入未命中 = 未缓存输入 + 缓存写（两桶合并按 miss 价，不双计）。
+			const miss = perM(buckets.uncached + buckets.write);
+			const hit = perM(buckets.read);
+			const out = perM(buckets.output);
 			return Math.max(0, miss * cacheMiss + hit * cacheHit + out * output);
+		}
+
+		/** token 用量 → 本轮费用（¥）。缓存写入按 miss 价计费（与官方一致）。 */
+		function sessionCost(usage, prices) {
+			const u = normalizeUsage(usage);
+			if (!u) return 0;
+			return bucketsCost({ uncached: u.uncached, read: u.read, write: u.write, output: u.output }, prices);
 		}
 
 		/**
@@ -86,6 +185,140 @@ window.__ModuleLoader__.load({
 			const table = data && typeof data.priceTable === "object" ? data.priceTable : null;
 			if (u && u.model && table && table[u.model]) return table[u.model];
 			return data && data.prices ? data.prices : void 0;
+		}
+
+		// -----------------------------------------------------------------
+		// 会话费用账本（按消耗时段增量计价，见文件头「按消耗时段计价」段）
+		//
+		// - 键 = 会话 id（sessions 服务读取；取不到时退化为单槽 "unknown"）；
+		// - localStorage 持久化：页面重载后从上次的累计与费用继续，不重置；
+		// - 同一 usage 重复观察增量为零，天然幂等——渲染期调用安全（React
+		//   StrictMode 双渲染/丢弃渲染重放同一份投影值，不会重复入账）；
+		// - 已知近似（架构权衡，token 无时间戳）：基线（首次观察到的存量）
+		//   按观察时刻的时段价一次性入账；页面关闭期间消耗的量在下次打开时
+		//   按当时的时段价补记。自本插件在场起的新增量全部按真实消耗时段
+		//   计价，显示不再随推送时刻的峰谷状态整段重算。
+		// -----------------------------------------------------------------
+		const LEDGER_STORAGE_KEY = "dsh-balance:cost-ledger:v1";
+		const LEDGER_MAX_SESSIONS = 32;
+		const LEDGER_TOUCH_PERSIST_MS = 60 * 1000;
+
+		let ledgerMap = null; // Map<sessionId, {u:{uncached,read,write,output}, cost:number, at:number}>
+		let ledgerPersistBroken = false;
+
+		function ledgerStorage() {
+			if (ledgerPersistBroken) return null;
+			try {
+				if (typeof localStorage === "undefined") return null;
+				return localStorage;
+			} catch {
+				ledgerPersistBroken = true;
+				return null;
+			}
+		}
+
+		function validBuckets(b) {
+			return b !== null && typeof b === "object"
+				&& ["uncached", "read", "write", "output"].every((k) => Number.isFinite(b[k]));
+		}
+
+		function loadLedger() {
+			if (ledgerMap !== null) return ledgerMap;
+			ledgerMap = new Map();
+			const store = ledgerStorage();
+			if (store !== null) {
+				try {
+					const raw = store.getItem(LEDGER_STORAGE_KEY);
+					const parsed = raw === null || raw === "" ? null : JSON.parse(raw);
+					const sessions = parsed !== null && typeof parsed === "object"
+						&& parsed.v === 1 && typeof parsed.sessions === "object" && parsed.sessions !== null
+						? parsed.sessions
+						: null;
+					if (sessions !== null) {
+						for (const key of Object.keys(sessions)) {
+							const e = sessions[key];
+							if (e !== null && typeof e === "object" && validBuckets(e.u)
+								&& Number.isFinite(e.cost) && e.cost >= 0) {
+								ledgerMap.set(String(key), {
+									u: { uncached: e.u.uncached, read: e.u.read, write: e.u.write, output: e.u.output },
+									cost: e.cost,
+									at: Number.isFinite(e.at) ? e.at : 0,
+								});
+							}
+						}
+					}
+				} catch {
+					/* 脏数据 → 空账本继续（下次观察重建基线），绝不让 dock 挂掉 */
+				}
+			}
+			return ledgerMap;
+		}
+
+		function persistLedger() {
+			const store = ledgerStorage();
+			if (store === null) return;
+			try {
+				// 容量上限：按最近使用时间保留最新 LEDGER_MAX_SESSIONS 条。
+				let entries = Array.from(loadLedger().entries());
+				if (entries.length > LEDGER_MAX_SESSIONS) {
+					entries.sort((a, b) => (b[1].at || 0) - (a[1].at || 0));
+					entries = entries.slice(0, LEDGER_MAX_SESSIONS);
+					ledgerMap = new Map(entries);
+				}
+				const sessions = {};
+				for (const [key, e] of entries) {
+					sessions[key] = { u: e.u, cost: Math.max(0, e.cost), at: e.at };
+				}
+				store.setItem(LEDGER_STORAGE_KEY, JSON.stringify({ v: 1, sessions }));
+			} catch {
+				ledgerPersistBroken = true; // 配额满/隐私模式 → 之后只走内存账本
+			}
+		}
+
+		/**
+		 * 观察一次累计用量并返回入账后的会话费用（¥）。
+		 * 增量按观察时刻的时段价入账（periodTables 优先，旧形态载荷回退
+		 * pricesFor）；账本领先于当前累计（异常回退）时重新入基线。
+		 * 同一 usage 重复观察增量为零（幂等，见上方注释）。
+		 */
+		function observeCost(sessionId, usage, data) {
+			const u = normalizeUsage(usage);
+			if (!u) return 0;
+			const map = loadLedger();
+			const id = typeof sessionId === "string" && sessionId !== "" ? sessionId : "unknown";
+			const current = { uncached: u.uncached, read: u.read, write: u.write, output: u.output };
+			const nowMs = Date.now();
+			const prices = pickModelEntry(periodTableAt(data, nowMs), usage, data) || pricesFor(usage, data);
+			let entry = map.get(id);
+			if (entry === undefined
+				|| entry.u.uncached > current.uncached || entry.u.read > current.read
+				|| entry.u.write > current.write || entry.u.output > current.output) {
+				// 新会话或账本异常领先：以当前时刻的时段价对存量入基线。
+				entry = { u: current, cost: bucketsCost(current, prices), at: nowMs };
+				map.set(id, entry);
+				persistLedger();
+				return entry.cost;
+			}
+			const du = {
+				uncached: current.uncached - entry.u.uncached,
+				read: current.read - entry.u.read,
+				write: current.write - entry.u.write,
+				output: current.output - entry.u.output,
+			};
+			if (du.uncached === 0 && du.read === 0 && du.write === 0 && du.output === 0) {
+				// 无增量：纯读路径；超过触碰窗口才回写 at（维持 LRU 新鲜度，
+				// 推送触发的重渲染零 localStorage 写入）。
+				if (nowMs - entry.at > LEDGER_TOUCH_PERSIST_MS) {
+					entry.at = nowMs;
+					persistLedger();
+				}
+				return entry.cost;
+			}
+			entry.cost = Math.max(0, entry.cost + bucketsCost(du, prices));
+			entry.u = current;
+			entry.at = nowMs;
+			persistLedger();
+			return entry.cost;
 		}
 
 		/** 金额显示：非有限 → "—"；0 → "0.00"；大额走本地化（不会出现 "1e+21"）。 */
@@ -154,17 +387,30 @@ window.__ModuleLoader__.load({
 			const goText = go ? goUsageText(go) : null;
 			// 三样都无内容时整体不渲染（goUsageText 全空返回 null，不再渲染空白 chip）。
 			if (!hasBalance && !usageKnown && !goText) return null;
-			const peak = typeof data?.peak === "boolean";
-			// 峰谷提醒：主进程按当前时刻推送 peak（高峰=全价，空闲=高峰一半）。
-			// 可见文本放最前；高峰橙/空闲绿着色。
-			const peakChip = peak
+			const peakState = livePeakState(data);
+			// 峰谷提醒：优先客户端本地判定（整点切换即时生效，不受推送周期
+			// 滞后影响；含 2026-08-23 起周末全天空闲）；旧形态载荷（无
+			// periodTables）回退主进程推送的 peak。可见文本放最前；高峰橙/空闲绿。
+			const peak = peakState !== null ? peakState : (typeof data?.peak === "boolean" ? data.peak : null);
+			const peakChip = peak !== null
 				? react_jsx_runtime.jsx("span", {
-					className: data.peak ? "dsh-balance-peak" : "dsh-balance-offpeak",
-					children: data.peak ? "⛰ 高峰价" : "🌙 空闲价"
+					className: peak ? "dsh-balance-peak" : "dsh-balance-offpeak",
+					children: peak ? "⛰ 高峰价" : "🌙 空闲价"
 				}, "peak")
 				: null;
 			const usagePrices = pricesFor(usage, data);
 			const usageModel = normalizeUsage(usage)?.model ?? null;
+			// 本轮费用：账本按「token 消耗时刻」的时段单价增量入账（data 到位
+			// 后启用）；data 缺位（纯浏览器模式/首次推送前）退回旧口径
+			// （全量 × 已知单价）——首帧不空，浏览器模式行为与历史版本一致。
+			const sessionCostNow = usageKnown && data
+				? observeCost(sessionIdOf(), usage, data)
+				: sessionCost(usage, usagePrices);
+			// tooltip 里的当前单价：优先「此刻时段」的模型档（与增量计价同一
+			// 取价口径，告诉用户新 token 现在什么价）。
+			const nowPrices = usageKnown && data
+				? (pickModelEntry(periodTableAt(data, Date.now()), usage, data) || usagePrices || FALLBACK_PRICES)
+				: (usagePrices || FALLBACK_PRICES);
 			// 计价模型说明：usage 带真实模型且价目表可用 → 按真实模型；否则明确
 			// 标注「按默认模型估算」（会话实际模型不可知时不假装精确）。
 			const table = data && typeof data.priceTable === "object" ? data.priceTable : null;
@@ -179,7 +425,7 @@ window.__ModuleLoader__.load({
 			}
 			const items = [];
 			if (peakChip) items.push(peakChip);
-			if (usageKnown) items.push(react_jsx_runtime.jsx("span", { children: "本轮 ¥" + money(sessionCost(usage, usagePrices)) }, "cost"));
+			if (usageKnown) items.push(react_jsx_runtime.jsx("span", { children: "本轮 ¥" + money(sessionCostNow) }, "cost"));
 			if (hasBalance) items.push(react_jsx_runtime.jsx("span", { children: "余额 ¥" + money(primary.total) }, "balance"));
 			// children 传数组且每项带稳定 key（真实 React 下数组子元素必须带 key，
 			// 否则 dev 模式持续告警）；分隔符用 span 包裹避免字符串无法挂 key。
@@ -190,8 +436,8 @@ window.__ModuleLoader__.load({
 				joined.push(it);
 			});
 			const title = hasBalance
-				? `${primary.currency} 余额 ¥${money(primary.total)}（充值 ¥${money(primary.toppedUp)} · 赠送 ¥${money(primary.granted)}）；本轮费用${priceNote}（¥/百万 token：命中 ${usagePrices?.cacheHit ?? FALLBACK_PRICES.cacheHit} / 未命中 ${usagePrices?.cacheMiss ?? FALLBACK_PRICES.cacheMiss} / 输出 ${usagePrices?.output ?? FALLBACK_PRICES.output}${peak ? (data.peak ? " · 高峰价（北京时间 9:00-12:00 / 14:00-18:00，全价）" : " · 空闲价（高峰价的一半）") : ""}），点击前往充值`
-				: "本轮费用按 token 用量估算；未读取到 DeepSeek API Key，无法显示余额";
+				? `${primary.currency} 余额 ¥${money(primary.total)}（充值 ¥${money(primary.toppedUp)} · 赠送 ¥${money(primary.granted)}）；本轮费用${priceNote}，按 token 消耗时段单价累加估算（¥/百万 token：命中 ${nowPrices?.cacheHit ?? FALLBACK_PRICES.cacheHit} / 未命中 ${nowPrices?.cacheMiss ?? FALLBACK_PRICES.cacheMiss} / 输出 ${nowPrices?.output ?? FALLBACK_PRICES.output}${peak !== null ? (peak ? " · 当前高峰（工作日北京时间 9:00-12:00 / 14:00-18:00 全价，周末空闲价）" : " · 当前空闲（高峰价的一半）") : ""}），点击前往充值`
+				: "本轮费用按 token 消耗时段单价累加估算；未读取到 DeepSeek API Key，无法显示余额";
 			const dock = react_jsx_runtime.jsx("a", {
 				className: "dsh-balance-dock",
 				href: "https://platform.deepseek.com/top_up",
@@ -272,7 +518,23 @@ window.__ModuleLoader__.load({
 		 * Client plugin body: register a dock entry right after the session stats
 		 * line. The slot's standard kit supplies `useProjection` (session-scoped).
 		 */
+		// 会话 id 读取（费用账本键控）：sessions 服务的当前会话快照（与
+		// dsh-offpeak 客户端同款取法）；服务缺席/形态不符时退化为单槽
+		// "unknown"（单会话场景不受影响，会话间切换会重建基线）。
+		let currentCtx = null; // apply(ctx) 捕获
+		function sessionIdOf() {
+			try {
+				const sessions = currentCtx !== null ? currentCtx.get("sessions") : undefined;
+				if (sessions !== undefined && sessions.list !== undefined) {
+					const snap = sessions.list.getSnapshot();
+					if (snap !== null && typeof snap === "object" && typeof snap.current === "string" && snap.current !== "") return snap.current;
+				}
+			} catch { /* 服务缺席 → unknown 单槽账本 */ }
+			return "unknown";
+		}
+
 		function apply(ctx) {
+			currentCtx = ctx;
 			ensureCss();
 			// 一方包正确姿势（C2 定性，对齐 dsh-client-ui-goal 同款）：keyed slot 的
 			// 子条目必须经 ctx.slots.inject(key, factory) 注册——前端 boot 用

--- a/dsh-desktop/balance-scheduler.js
+++ b/dsh-desktop/balance-scheduler.js
@@ -37,6 +37,10 @@ const DEFAULT_MODEL = 'deepseek-v4-pro';
  * @param {(dshHome: string) => string} options.readActiveModel 默认模型读取
  * @param {(model: string, date: Date) => object} options.effectivePrice 有效单价
  * @param {(date: Date) => object} options.priceTable 全模型价目表
+ * @param {() => {peak: object, off: object, legacy: object}} [options.periodTables]
+ *   三张时段价目表（peak/off/legacy，见 balance.js periodTables()）——客户端
+ *   「按 token 消耗时刻计价」的数据源；未注入则载荷不含 periodTables（旧形态）
+ * @param {() => string} [options.pricingSinceIso] 峰谷定价生效节点（ISO 字符串）
  * @param {(date: Date) => boolean} options.isPeakHour 高峰判定
  * @param {(result: object) => void} options.push 数据唯一出口（推送渲染进程）
  * @param {(tag: string, msg: string) => void} [options.log] 日志
@@ -56,6 +60,8 @@ function createBalanceScheduler(options) {
     readActiveModel,
     effectivePrice,
     priceTable,
+    periodTables = null,
+    pricingSinceIso = null,
     isPeakHour,
     push,
     log = () => {},
@@ -128,6 +134,29 @@ function createBalanceScheduler(options) {
     result.model = model;
     result.peak = isPeakHour(now);
     result.at = now.toISOString();
+    // 三张时段价目表 + 峰谷生效节点：客户端对每个观察到的用量增量按「消耗时刻」
+    // 选档计价（本轮费用不随推送时刻的峰谷状态整段重算）。用户覆盖同样并入
+    // 三张表——覆盖语义是「该模型就用这套价」，与时段无关。
+    if (typeof periodTables === 'function') {
+      const tables = periodTables();
+      if (tables && typeof tables === 'object' && tables.peak && tables.off && tables.legacy) {
+        if (overrides && typeof overrides === 'object') {
+          for (const t of [tables.peak, tables.off, tables.legacy]) {
+            for (const m of Object.keys(overrides)) {
+              const ov = overrides[m];
+              if (ov && typeof ov === 'object') {
+                t[m] = { ...(t[m] || t[model] || effectivePrice(m, now)), ...ov };
+              }
+            }
+          }
+        }
+        result.periodTables = tables;
+      }
+    }
+    if (typeof pricingSinceIso === 'function') {
+      const since = pricingSinceIso();
+      if (typeof since === 'string' && since !== '') result.pricingSince = since;
+    }
     return result;
   }
 

--- a/dsh-desktop/balance.js
+++ b/dsh-desktop/balance.js
@@ -93,6 +93,11 @@ const PRICING_MODELS = ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-chat',
 // 峰谷定价生效节点：2026-08-17 00:00 北京时间 = 2026-08-16 16:00 UTC。
 const PEAK_PRICING_SINCE_UTC = Date.UTC(2026, 7, 16, 16, 0, 0);
 
+// 周末闲时生效节点：官方 2026-08-23 公告——周六/周日全天不再区分峰谷，
+// 统一按空闲价计费。2026-08-23 00:00 北京时间 = 2026-08-22 16:00 UTC。
+// 与 dsh-offpeak 插件的周末规则（issue #158）同口径。
+const WEEKEND_OFFPEAK_SINCE_UTC = Date.UTC(2026, 7, 22, 16, 0, 0);
+
 // 模型缺失 / 未知时的兜底档（与价目表回退一致，避免少报费用）。
 const DEFAULT_MODEL = 'deepseek-v4-pro';
 
@@ -210,13 +215,20 @@ async function queryOpencodeUsage(dshHome) {
  * 当前（或指定时刻）是否处于高峰时段（北京时间 9:00-12:00、14:00-18:00）。
  * 契约：峰谷定价生效（2026-08-16 16:00 UTC）之前一律 false——旧版期没有
  * 峰谷概念，避免「chip 显示高峰价、实际按旧版固定价计」的自相矛盾。
+ * 2026-08-23（北京时间）起周末（周六/周日）整天空闲（官方公告），
+ * 不溯及既往：生效节点前的周末仍按工作日峰谷窗口判定。
  * 无效日期返回 false（宁可显示空闲，不可显示错误的高峰态）。
  */
 function isPeakHour(date) {
   const d = date ? new Date(date) : new Date();
   if (!Number.isFinite(d.getTime())) return false;
-  if (d.getTime() < PEAK_PRICING_SINCE_UTC) return false;
-  const hour = new Date(d.getTime() + 8 * 3600 * 1000).getUTCHours();
+  const t = d.getTime();
+  if (t < PEAK_PRICING_SINCE_UTC) return false;
+  // 北京 = UTC+8（无夏令时）：平移后按 UTC 字段读北京墙钟。
+  const shifted = new Date(t + 8 * 3600 * 1000);
+  const weekday = shifted.getUTCDay(); // 0=周日 … 6=周六
+  if ((weekday === 0 || weekday === 6) && t >= WEEKEND_OFFPEAK_SINCE_UTC) return false;
+  const hour = shifted.getUTCHours();
   return (hour >= 9 && hour < 12) || (hour >= 14 && hour < 18);
 }
 
@@ -251,6 +263,50 @@ function priceTable(date) {
   const out = {};
   for (const model of PRICING_MODELS) out[model] = effectivePrice(model, date);
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// 三张时段价目表（peak / off / legacy）——「按 token 消耗时刻计价」契约。
+//
+// effectivePrice/priceTable 只给出「某一时刻」的已解析单价；而本轮费用的
+// 正确口径是：每个 token 按它被消耗那一刻的时段价结算（官方计费规则），
+// 已消耗的量不随后续峰谷切换重算。客户端拿到三张表后即可在观察到用量
+// 增量时，按当时所处时段自主选档——推送滞后（最长一个轮询周期）不再
+// 影响计价正确性。三张表均为纯常量快照，与求值时刻无关。
+// ---------------------------------------------------------------------------
+
+/** 峰谷期高峰档全价表（全模型，含别名）。 */
+function peakPriceTable() {
+  const out = {};
+  for (const model of PRICING_MODELS) out[model] = { ...PEAK_PRICES[model] };
+  return out;
+}
+
+/** 峰谷期空闲档价表（高峰的一半）。 */
+function offPriceTable() {
+  const out = {};
+  for (const model of PRICING_MODELS) {
+    const p = PEAK_PRICES[model];
+    out[model] = { cacheMiss: p.cacheMiss / 2, cacheHit: p.cacheHit / 2, output: p.output / 2 };
+  }
+  return out;
+}
+
+/** 2026-08-17 前旧版固定价表（跨生效节点的会话结算参考）。 */
+function legacyPriceTable() {
+  const out = {};
+  for (const model of PRICING_MODELS) out[model] = { ...LEGACY_PRICES[model] };
+  return out;
+}
+
+/** 三张时段价目表打包（balance-scheduler 出站载荷 periodTables 字段的数据源）。 */
+function periodTables() {
+  return { peak: peakPriceTable(), off: offPriceTable(), legacy: legacyPriceTable() };
+}
+
+/** 峰谷定价生效节点（ISO 字符串）——客户端区分旧版固定价期的边界。 */
+function peakPricingSinceIso() {
+  return new Date(PEAK_PRICING_SINCE_UTC).toISOString();
 }
 
 function readApiKey(dshHome) {
@@ -618,6 +674,11 @@ module.exports = {
   effectivePrice,
   isPeakHour,
   priceTable,
+  periodTables,
+  peakPriceTable,
+  offPriceTable,
+  legacyPriceTable,
+  peakPricingSinceIso,
   // 端点解析（测试用）
   balanceEndpoint,
   opencodeUsageEndpoint,

--- a/dsh-desktop/docs/balance-architecture.md
+++ b/dsh-desktop/docs/balance-architecture.md
@@ -17,6 +17,7 @@ Tauri 线为 `dsh-tauri/src-tauri/src/app/src/commands/balance.rs` + sidecar
 ┌─────────────────────────────────────────────────────────────────────┐
 │ 展示层  assets/plugins/dsh-balance/lib/client.js（浏览器内）          │
 │   · normalizeUsage()：token 用量归一化（单一真源）                    │
+│   · observeCost()：按消耗时段增量计价账本（§3.1，issue #168）         │
 │   · sessionCost()/hasUsage()/money()/goUsageText()                   │
 │   · 只消费 window "dsh-balance-changed" 事件（单一投递）              │
 └───────────────────────────────▲─────────────────────────────────────┘
@@ -108,6 +109,12 @@ interface BalancePush {
   };
   prices: Prices;           // 默认模型在推送时刻的有效单价（== priceTable[默认模型]，含 balancePrices.<model> 覆盖）
   priceTable: Record<string, Prices>; // 全部已知模型同一时刻的价目表（含 balancePrices.<model> 覆盖）
+  periodTables?: {          // 三张时段价目表（issue #168：客户端「按 token 消耗时刻计价」的数据源）
+    peak: Record<string, Prices>;    // 峰谷期高峰档全价（含覆盖）
+    off: Record<string, Prices>;     // 峰谷期空闲档（高峰的一半，含覆盖）
+    legacy: Record<string, Prices>;  // 2026-08-17 前旧版固定价（含覆盖）
+  };
+  pricingSince?: string;    // 峰谷定价生效节点 ISO（periodTables 的选档边界）
   model: string;            // 默认模型名（settings.yaml agent-default-model）
   peak: boolean;            // 推送时刻是否高峰时段（与 prices/priceTable 同刻求值）
   at: string;               // 推送时刻 ISO 时间戳
@@ -122,8 +129,10 @@ interface UsageWindow {
 interface Prices { cacheMiss: number; cacheHit: number; output: number } // ¥/百万 token
 ```
 
-兼容性约定：新增字段（`warning` / `priceTable` / `at`）为可选项，旧客户端忽略未知
-字段即可正常显示；`prices` / `model` / `peak` / `balances` 等既有字段语义不变。
+兼容性约定：新增字段（`warning` / `priceTable` / `at` / `periodTables` / `pricingSince`）
+为可选项，旧客户端忽略未知字段即可正常显示；`prices` / `model` / `peak` / `balances`
+等既有字段语义不变。`periodTables` 与 `pricingSince` 配套出现：客户端观察到用量
+增量时按自身时钟选档入账（见 §3.1），推送滞后不再影响计价正确性。
 
 ---
 
@@ -170,6 +179,32 @@ DISJOINT 计数）：
 2. usage 携带的模型不在价目表 → 回退默认模型，title 标注「…会话模型 X 不在价目表内」；
 3. usage 无模型字段（会话投影未透传）→ 回退默认模型，title 标注
    「…会话实际模型未知」——绝不假装精确。
+
+### 3.1 按消耗时段计价（issue #168）
+
+官方峰谷计费口径：**每个 token 按它被消耗那一刻的时段单价结算，已结算的量
+不随后续峰谷切换重算**。`tokenUsage` 投影只给出累计四桶、不带时间戳，因此
+本轮费用在展示层做**增量计价账本**（`assets/plugins/dsh-balance/lib/client.js`
+的 `observeCost`）：
+
+- 每次观察到累计用量前进，只对**增量**按「观察时刻」的时段价入账；
+- 基线（首次观察到的存量）按当时时段价一次性入账；
+- 时段价从推送的 `periodTables`（peak/off/legacy 三张表）按客户端自身时钟
+  选档（`isPeakAt`，镜像 `balance.js` `isPeakHour`，含周末规则）——推送滞后
+  （一个轮询周期）不影响计价正确性；
+- 账本按会话 id 键控、localStorage 持久化（页面重载延续，容量 32 会话
+  LRU；存储脏数据/配额满静默降级为纯内存账本）；
+- 同一 usage 重复观察增量为零（幂等）：渲染期调用安全，React 严格模式
+  双渲染/丢弃渲染不会重复入账；累计回退（`(turn,step)` 样本替换）按有符号
+  增量冲回，总费用下限 0。
+
+已知近似（token 无时间戳的架构边界，fail-soft 取舍）：基线与页面关闭期间
+消耗的量按「观察/重开时刻」的时段价估算；自插件在场起的新增量全部按真实
+消耗时段计价。峰谷切换只影响之后的新增量——显示不再随推送整段跳变。
+
+用户 `balancePrices.<model>` 覆盖由编排层同时并入三张表（覆盖语义 =
+「该模型就用这套价」，与时段无关），`prices` 恒等于 `priceTable[默认模型]`
+的不变量保持不变。
 
 ---
 
@@ -229,13 +264,14 @@ DISJOINT 计数）：
 - OpenCode Go 端点：`OPENCODE_USAGE_URL`（代理/镜像场景）>
   `https://opencode.ai/zen/go/v1/usage`。
 - 定价：2026-08-17 起峰谷定价（北京 9:00-12:00 / 14:00-18:00 全价，其余半价），
-  此前旧版固定价；`isPeakHour` 在峰谷生效节点之前恒为 false，保证 chip 与
-  计价档一致。
-- **切换瞬间价格跳变**：按小时切价是官方计费规则本身（整点切换、
-  无比例过渡），费用估算无法对跨整点的 token 做比例拆分（token 无时间戳）。
-  架构决策：保持整点切换，与官方计费口径一致；通过「单一 now」保证界面显示的
-  价格与计价档永远自洽。若产品后续要求平滑显示，可在展示层对 chip 做过渡动画，
-  不影响计价正确性。
+  此前旧版固定价；**2026-08-23 起周末（周六/周日）全天按空闲价计费**
+  （官方公告，不溯及既往——生效节点前的周末仍按小时窗口判定）。
+  `isPeakHour` 在峰谷生效节点之前恒为 false，保证 chip 与计价档一致。
+- **按消耗时段计价**：本轮费用对每个用量增量按其**消耗时刻**的时段价入账
+  （见 §3.1），官方按请求发生时刻结算的口径一致。峰谷切换只影响之后的
+  新增量，已入账部分不随推送重算——「整点切换价格跳变」被限制在边界时刻
+  之后的新 token 上（官方计费规则本身，无比例过渡）；推送滞后一个轮询
+  周期不再传染计价（客户端本地选档）。
 
 ## 8. 安全与隔离（测试约定）
 
@@ -256,6 +292,8 @@ DISJOINT 计数）：
 | 🟠 高 | refreshBalance 无并发去重，last-writer-wins | balance-scheduler.js in-flight 去重 + latest-sequence 守卫 |
 | 🟠 高 | 持久失败 30s 无限重试 | balance-scheduler.js 指数退避（30s→1m→2m→5m 封顶，成功清零） |
 | 🟠 高 | 默认模型价估实际会话费用（3x 偏差） | main.js 推送 `priceTable`；openai-compat.js usage 携带 model；client.js 按模型选档 + 估算标注 |
+| 🟠 高 | 本轮费用随峰谷切换整段重算（累计 token × 推送时刻价，历史被重定价，issue #168） | balance-scheduler.js 推送 `periodTables`/`pricingSince`；client.js 增量计价账本 `observeCost`（§3.1） |
+| 🟠 高 | `isPeakHour` 缺周末规则（2026-08-23 起周末全天空闲，官方公告；周末误报高峰价/全价计费，issue #168） | balance.js `isPeakHour` 周末判定（`WEEKEND_OFFPEAK_SINCE_UTC`）；client.js `isPeakAt` 同口径 |
 | 🟡 中 | peak 与 prices 双 `new Date()` + 切换点 | balance-scheduler.js 单一 now；balance.js `isPeakHour` 旧版期返回 false |
 | 🟡 中 | pickUsageWindow 把 percent:null 转 0 | balance.js `pickUsageWindow` `== null` 分支 |
 | 🟡 中 | 超时为空闲超时 + 1MB 按字符计 | balance.js fetchJson 总 deadline + 按字节累计 |
@@ -276,7 +314,9 @@ DISJOINT 计数）：
 ## 10. 维护约定
 
 - 价目表变更：只改 `balance.js` 的 `PEAK_PRICES` / `LEGACY_PRICES` /
-  `PEAK_PRICING_SINCE_UTC`，客户端零改动（`priceTable` 自动同步）。
+  `PEAK_PRICING_SINCE_UTC` / `WEEKEND_OFFPEAK_SINCE_UTC`，客户端零改动
+  （`priceTable` 与 `periodTables` 自动同步；客户端镜像的时段判定
+  `isPeakAt`/`WEEKEND_OFFPEAK_SINCE` 需同步常量——两处必须同口径）。
 - 新增模型别名：加入 `PRICING_MODELS`。
 - 新增网络边界参数：一律走 `fetchJson` options（timeoutMs / maxRedirects /
   maxBodyBytes），默认值集中在 `balance.js` 顶部常量。

--- a/dsh-desktop/scripts/test/edge-client.test.js
+++ b/dsh-desktop/scripts/test/edge-client.test.js
@@ -23,10 +23,33 @@ const SRC = fs.readFileSync(CLIENT_PATH, 'utf8');
 // ---------------------------------------------------------------------------
 // 测试床：每次 loadClient() 生成全新沙箱（模块级状态如 bridgePushedOnce 隔离）
 // ---------------------------------------------------------------------------
+// opts.now        —— 固定沙箱时钟（Date.now()/无参 new Date()）：时段计价用例
+// opts.storage    —— 注入 localStorage mock（跨 loadClient 共享 = 模拟页面重载）
+// opts.sessionId  —— sessions 服务返回的当前会话 id（费用账本键控）
+// ---------------------------------------------------------------------------
 
-function loadClient(bridgeOverrides) {
+function makeStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => { m.set(k, String(v)); },
+    removeItem: (k) => { m.delete(k); },
+  };
+}
+
+function loadClient(bridgeOverrides, opts = {}) {
   const calls = { refreshBalance: 0, handler: null };
   const listeners = new Map();
+  // 时间源控制：沙箱 Date 的静态 now()/无参构造返回固定值；
+  // new Date(ms) 原样透传（beijingPartsOf 的 UTC 平移读法依赖数值构造）。
+  const realDate = Date;
+  const fixedNow = Number.isFinite(opts.now) ? { value: opts.now } : null;
+  const SandboxDate = fixedNow === null ? realDate : class extends realDate {
+    constructor(...args) { super(...(args.length > 0 ? args : [fixedNow.value])); }
+    static now() { return fixedNow.value; }
+  };
+  const storage = opts.storage !== undefined ? opts.storage : null;
+  let sessionId = opts.sessionId;
   const sandboxWindow = {
     __ModuleLoader__: { load: (obj) => { calls.captured = obj; } },
     dshDesktop: bridgeOverrides && bridgeOverrides.dshDesktop !== undefined
@@ -47,7 +70,9 @@ function loadClient(bridgeOverrides) {
     // unref：不清理的挂起定时器不阻塞测试进程退出。
     setTimeout: (fn, ms, ...args) => { const t = setTimeout(fn, ms, ...args); if (t.unref) t.unref(); return t; },
     clearTimeout,
+    Date: SandboxDate,
   };
+  if (storage !== null) sandbox.localStorage = storage;
   vm.createContext(sandbox);
   vm.runInContext(SRC, sandbox, { filename: 'client.js' });
 
@@ -100,6 +125,9 @@ function loadClient(bridgeOverrides) {
   // declared」的冷启动竞态，见 lib/client.js apply 注释）：mock 的 inject
   // 立即求值 factory，落到与旧 register 相同的捕获路径，断言语义不变。
   const fakeCtx = {
+    get: (name) => (name === 'sessions' && sessionId !== undefined
+      ? { list: { getSnapshot: () => ({ current: sessionId }) } }
+      : undefined),
     slots: {
       register(slotInfo, Component) { dockComponent = Component; },
       inject(key, factory) {
@@ -128,7 +156,11 @@ function loadClient(bridgeOverrides) {
     for (const { cb } of pendingEffects) cb();
   }
 
-  return { calls, listeners, render, runEffects, resetHooks, dock: () => dockComponent, setPresetData: (d) => { presetData = d; } };
+  return {
+    calls, listeners, render, runEffects, resetHooks, dock: () => dockComponent, setPresetData: (d) => { presetData = d; },
+    setNow: (ms) => { if (fixedNow !== null) fixedNow.value = ms; },
+    setSessionId: (id) => { sessionId = id; },
+  };
 }
 
 /** 收集渲染树全部文本。 */
@@ -279,14 +311,31 @@ test('纯浏览器降级：无 data 时按 FALLBACK_PRICES 计价', () => {
 });
 
 test('sessionCost: prices 覆盖生效；非法价格字段回退内置默认档', () => {
-  const h = loadClient();
   const usage = { uncachedInputTokens: 1e6, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
-  // 合法覆盖
+  // 合法覆盖（新账本 → 基线按覆盖价入账）
+  let h = loadClient();
   let r = h.render(usage, { prices: { cacheMiss: 1, cacheHit: 0.5, output: 8 } });
   assert.strictEqual(costChipText(r), '本轮 ¥1.000');
-  // 非法覆盖（NaN/负数）→ 回退默认档（FALLBACK_PRICES，与 deepseek-v4-pro 一致）
+  // 非法覆盖（NaN/负数）→ 回退默认档（FALLBACK_PRICES，与 deepseek-v4-pro 一致）。
+  // 必须用全新账本：增量计价语义下同一 usage 换价不再重算已入账部分（见下一条用例）。
+  h = loadClient();
   r = h.render(usage, { prices: { cacheMiss: NaN, cacheHit: -1, output: 8 } });
   assert.strictEqual(costChipText(r), '本轮 ¥9.000');
+});
+
+test('增量计价回归（issue #168）：同一用量、推送价目变化 → 费用不重算', () => {
+  const usage = { uncachedInputTokens: 1e6, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+  const h = loadClient();
+  // 基线：合法覆盖价 1 元/百万 → 1M miss = ¥1。
+  let r = h.render(usage, { prices: { cacheMiss: 1, cacheHit: 0.5, output: 8 } });
+  assert.strictEqual(costChipText(r), '本轮 ¥1.000');
+  // 推送换价（含非法字段回退默认档 9 元）：已入账的 1M 仍按入账时的 1 元计，
+  // 绝不随新推送整段重算——旧实现此处显示 ¥9.000（峰谷切换费用跳变的根因）。
+  r = h.render(usage, { prices: { cacheMiss: NaN, cacheHit: -1, output: 8 } });
+  assert.strictEqual(costChipText(r), '本轮 ¥1.000');
+  // 新增量才按新价入账：再消耗 1M miss × 9 = +¥9 → 累计 ¥10。
+  r = h.render({ uncachedInputTokens: 2e6, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, { prices: { cacheMiss: NaN, cacheHit: -1, output: 8 } });
+  assert.strictEqual(costChipText(r), '本轮 ¥10.00');
 });
 
 // ---------------------------------------------------------------------------
@@ -431,4 +480,147 @@ test('渲染形态：仅 Go（无余额无用量）→ 直接 goDock', () => {
   const r = h.render(null, data);
   assert.strictEqual(r.result.type, 'a');
   assert.ok(String(r.result.props.className).includes('dsh-balance-go'));
+});
+
+// ---------------------------------------------------------------------------
+// 按消耗时段计价（issue #168）：增量账本 + periodTables 三张表 + 周末规则
+//
+// 官方计费口径：每个 token 按其消耗时刻的时段价结算，已结算量不随后续
+// 峰谷切换重算。旧实现「累计 token × 推送时刻价」在峰谷切换后整段跳变。
+// 时间锚点（北京 = UTC+8）：
+//   周三 2026-08-26 10:30（02:30Z）→ 高峰（9-12 窗口内）
+//   周三 2026-08-26 20:00（12:00Z）→ 空闲
+//   周三 2026-08-26 11:30（03:30Z）→ 高峰；12:30（04:30Z）→ 空闲（跨边界）
+//   周六 2026-08-29 10:00（02:00Z）→ 周末全天空闲（2026-08-23 起）
+//   周六 2026-08-22 10:00（02:00Z）→ 生效日前：仍按小时窗口（高峰）
+//   2026-08-10 10:00（02:00Z）→ 峰谷生效日前 → legacy 固定价
+// ---------------------------------------------------------------------------
+
+const FLASH_PEAK = { cacheMiss: 3, cacheHit: 0.1, output: 9 };
+const FLASH_OFF = { cacheMiss: 1.5, cacheHit: 0.05, output: 4.5 };
+const FLASH_LEGACY = { cacheMiss: 1, cacheHit: 0.02, output: 2 };
+const PRO_PEAK = { cacheMiss: 9, cacheHit: 0.3, output: 27 };
+const PERIOD_DATA = {
+  ok: true,
+  balances: [{ currency: 'CNY', total: 88.5, granted: 10, toppedUp: 78.5 }],
+  prices: FLASH_PEAK, // 推送时刻的解析价（可能滞后于真实时段）
+  priceTable: { 'deepseek-v4-flash': FLASH_PEAK, 'deepseek-v4-pro': PRO_PEAK },
+  periodTables: {
+    peak: { 'deepseek-v4-flash': FLASH_PEAK, 'deepseek-v4-pro': PRO_PEAK },
+    off: { 'deepseek-v4-flash': FLASH_OFF, 'deepseek-v4-pro': { cacheMiss: 4.5, cacheHit: 0.15, output: 13.5 } },
+    legacy: { 'deepseek-v4-flash': FLASH_LEGACY, 'deepseek-v4-pro': { cacheMiss: 3, cacheHit: 0.025, output: 6 } },
+  },
+  pricingSince: '2026-08-16T16:00:00.000Z',
+  model: 'deepseek-v4-flash',
+  peak: true, // 推送时刻=高峰（对空闲时刻的用例构成「推送滞后」场景）
+};
+const U1M = { uncachedInputTokens: 1e6, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+const U2M = { uncachedInputTokens: 2e6, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+test('时段计价（#168）：高峰基线 → 空闲时段同用量重渲染 → 费用不整段重算', () => {
+  const peakMs = Date.parse('2026-08-26T02:30:00.000Z'); // 周三 10:30 北京
+  const offMs = Date.parse('2026-08-26T12:00:00.000Z');  // 周三 20:00 北京
+  const h = loadClient({}, { now: peakMs });
+  // 基线：1M miss × 高峰价 3 = ¥3。
+  let r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000');
+  assert.ok(collectText(r.result).includes('⛰ 高峰价'), '高峰时刻 chip 为高峰');
+  // 跨到空闲时段：同用量、新推送（prices 仍是高峰解析价 + peak=true 滞后）。
+  // 已入账的 1M 仍按消耗时（高峰）的 3 元计——旧实现此处显示 ¥1.500。
+  h.setNow(offMs);
+  r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000', '峰谷切换后同用量费用不得重算');
+  // chip 用客户端本地判定即时切换（不受推送 peak=true 滞后影响）。
+  assert.ok(collectText(r.result).includes('🌙 空闲价'), '空闲时刻 chip 应即时切换');
+});
+
+test('时段计价（#168）：跨峰谷边界的增量分段计价', () => {
+  const peakMs = Date.parse('2026-08-26T03:30:00.000Z'); // 周三 11:30 北京（高峰）
+  const offMs = Date.parse('2026-08-26T04:30:00.000Z');  // 周三 12:30 北京（空闲）
+  const h = loadClient({}, { now: peakMs });
+  let r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000', '高峰段 1M × 3');
+  h.setNow(offMs);
+  r = h.render(U2M, PERIOD_DATA); // 新增 1M miss 在空闲段消耗 × 1.5
+  assert.strictEqual(costChipText(r), '本轮 ¥4.500', '3 + 1.5：增量按空闲价，基线不重算');
+});
+
+test('时段计价（#168）：2026-08-23 起周末全天空闲（客户端判定与计价一致）', () => {
+  const satMs = Date.parse('2026-08-29T02:00:00.000Z'); // 周六 10:00 北京
+  const h = loadClient({}, { now: satMs });
+  const r = h.render(U1M, PERIOD_DATA); // 推送 peak=true（滞后/旧规则）也不影响
+  assert.strictEqual(costChipText(r), '本轮 ¥1.500', '周末 1M × 空闲价 1.5');
+  assert.ok(collectText(r.result).includes('🌙 空闲价'), '周末 chip 为空闲');
+});
+
+test('时段计价（#168）：生效日前的周六仍按小时窗口判高峰（不溯及既往）', () => {
+  const satBeforeMs = Date.parse('2026-08-22T02:00:00.000Z'); // 周六 10:00 北京（8-23 前）
+  const h = loadClient({}, { now: satBeforeMs });
+  const r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000', '生效日前周六 10:00 仍为高峰全价');
+  assert.ok(collectText(r.result).includes('⛰ 高峰价'));
+});
+
+test('时段计价（#168）：峰谷生效日之前按 legacy 固定价表计价', () => {
+  const legacyMs = Date.parse('2026-08-10T02:00:00.000Z'); // 周一 10:00 北京（8-17 前）
+  const h = loadClient({}, { now: legacyMs });
+  const r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥1.000', '旧版固定价 flash miss=1');
+  assert.ok(collectText(r.result).includes('🌙 空闲价') || !collectText(r.result).includes('⛰ 高峰价'), 'legacy 期无高峰概念');
+});
+
+test('时段计价（#168）：会话切换账本键控——回切原会话费用保留', () => {
+  const peakMs = Date.parse('2026-08-26T02:30:00.000Z');
+  const h = loadClient({}, { now: peakMs, sessionId: 'sess-a' });
+  let r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000');
+  // 切到会话 B：2M 存量按 B 自己的基线（高峰全价）入账。
+  h.setSessionId('sess-b');
+  r = h.render(U2M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥6.000', '会话 B 独立基线 2M × 3');
+  // 切回会话 A：账本保留，仍为 ¥3（不受 B 的基线污染）。
+  h.setSessionId('sess-a');
+  r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000', '回切 A 费用保留');
+});
+
+test('时段计价（#168）：页面重载（localStorage）延续账本，不重置不重算', () => {
+  const peakMs = Date.parse('2026-08-26T02:30:00.000Z');
+  const offMs = Date.parse('2026-08-26T12:00:00.000Z');
+  const storage = makeStorage();
+  // 第一段页面生命：高峰段 1M 入账 ¥3，写入 localStorage。
+  const h1 = loadClient({}, { now: peakMs, storage, sessionId: 'sess-a' });
+  let r = h1.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000');
+  // 模拟页面重载：全新沙箱（模块级账本清空）、共享 storage、时钟已到空闲段。
+  const h2 = loadClient({}, { now: offMs, storage, sessionId: 'sess-a' });
+  r = h2.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000', '重载后延续账本（旧实现按空闲价重算成 ¥1.500）');
+  // 新增量按当前（空闲）时段价入账。
+  r = h2.render(U2M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥4.500', '重载后增量 1M × 1.5');
+});
+
+test('时段计价（#168）：localStorage 脏数据/不可用 → 空账本降级不炸', () => {
+  const peakMs = Date.parse('2026-08-26T02:30:00.000Z');
+  // 脏数据（非法 JSON）→ 解析失败按空账本，功能不受影响。
+  const badStorage = { getItem: () => '{not-json', setItem: () => {}, removeItem: () => {} };
+  const h = loadClient({}, { now: peakMs, storage: badStorage, sessionId: 'sess-a' });
+  let r = h.render(U1M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥3.000', '脏 storage 降级为内存账本');
+  // setItem 抛异常（配额满/隐私模式）→ 静默转纯内存账本。
+  const throwStorage = { getItem: () => null, setItem: () => { throw new Error('quota'); }, removeItem: () => {} };
+  const h2 = loadClient({}, { now: peakMs, storage: throwStorage, sessionId: 'sess-a' });
+  r = h2.render(U1M, PERIOD_DATA);
+  assert.ok(!r.threw && costChipText(r) === '本轮 ¥3.000', '写失败不传染渲染');
+  r = h2.render(U2M, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥6.000', '内存账本继续增量计价');
+});
+
+test('时段计价（#168）：usage 模型档在 periodTables 下同样生效', () => {
+  const peakMs = Date.parse('2026-08-26T02:30:00.000Z');
+  const h = loadClient({}, { now: peakMs });
+  const usage = { ...U1M, model: 'deepseek-v4-pro' };
+  const r = h.render(usage, PERIOD_DATA);
+  assert.strictEqual(costChipText(r), '本轮 ¥9.000', 'usage.model=pro → 高峰 pro 档 miss=9');
 });

--- a/dsh-desktop/scripts/test/unit-balance-scheduler.test.js
+++ b/dsh-desktop/scripts/test/unit-balance-scheduler.test.js
@@ -109,6 +109,53 @@ test('组装契约：result 含 prices/priceTable/model/peak/at/opencodeGo，单
   assert.strictEqual(scheduler.getCache(), result);
 });
 
+test('periodTables 载荷（issue #168）：注入时出站含三张表 + pricingSince；未注入不产生字段', async () => {
+  const tables = {
+    peak: { 'deepseek-v4-flash': { cacheMiss: 3, cacheHit: 0.1, output: 9 } },
+    off: { 'deepseek-v4-flash': { cacheMiss: 1.5, cacheHit: 0.05, output: 4.5 } },
+    legacy: { 'deepseek-v4-flash': { cacheMiss: 1, cacheHit: 0.02, output: 2 } },
+  };
+  const { scheduler } = makeHarness({
+    schedulerOptions: {
+      periodTables: () => tables,
+      pricingSinceIso: () => '2026-08-16T16:00:00.000Z',
+    },
+  });
+  const result = await scheduler.refresh();
+  assert.strictEqual(result.periodTables, tables, '三张表原样出站（引用透传，客户端只读）');
+  assert.strictEqual(result.pricingSince, '2026-08-16T16:00:00.000Z');
+  // 未注入（旧接线形态）→ 字段缺席，客户端回退旧口径（prices/priceTable）。
+  const plain = await makeHarness().scheduler.refresh();
+  assert.strictEqual(plain.periodTables, undefined);
+  assert.strictEqual(plain.pricingSince, undefined);
+});
+
+test('periodTables 覆盖（issue #168）：balancePrices.<model> 同时并入三张表', async () => {
+  const { scheduler } = makeHarness({
+    settings: {
+      balancePrices: {
+        'deepseek-v4-flash': { cacheMiss: 1, cacheHit: 0.5, output: 8 },
+        'my-model': { cacheMiss: 2, cacheHit: 0.2, output: 7 },
+      },
+    },
+    schedulerOptions: {
+      periodTables: () => ({
+        peak: { 'deepseek-v4-flash': { cacheMiss: 3, cacheHit: 0.1, output: 9 } },
+        off: { 'deepseek-v4-flash': { cacheMiss: 1.5, cacheHit: 0.05, output: 4.5 } },
+        legacy: { 'deepseek-v4-flash': { cacheMiss: 1, cacheHit: 0.02, output: 2 } },
+      }),
+      pricingSinceIso: () => '2026-08-16T16:00:00.000Z',
+    },
+  });
+  const result = await scheduler.refresh();
+  // 已有模型：覆盖字段并入三张表（覆盖语义 = 该模型就用这套价，与时段无关）。
+  for (const k of ['peak', 'off', 'legacy']) {
+    assert.deepStrictEqual(result.periodTables[k]['deepseek-v4-flash'], { cacheMiss: 1, cacheHit: 0.5, output: 8 });
+    // 表外新模型：以默认模型档为基底并入（覆盖字段全给时基底被全覆盖）。
+    assert.deepStrictEqual(result.periodTables[k]['my-model'], { cacheMiss: 2, cacheHit: 0.2, output: 7 });
+  }
+});
+
 test('节流：30s 窗口内重复 maybeRefresh 不重复请求；force 绕过', async () => {
   const { scheduler, calls } = makeHarness();
   await scheduler.maybeRefresh();      // 第一次实际请求

--- a/dsh-desktop/scripts/test/unit-balance.test.js
+++ b/dsh-desktop/scripts/test/unit-balance.test.js
@@ -132,6 +132,67 @@ test('isPeakHour: 无效日期 / 非 Date 输入不抛异常且语义明确', ()
 });
 
 // ---------------------------------------------------------------------------
+// isPeakHour 周末规则（issue #168：官方 2026-08-23 公告，周末全天空闲）
+// ---------------------------------------------------------------------------
+
+test('isPeakHour: 2026-08-23 起周末全天空闲（周六/周日原高峰窗口 → false）', () => {
+  // 周六 2026-08-29 10:30 北京（02:30Z）：生效日后 → 空闲。
+  assert.equal(balance.isPeakHour(new Date('2026-08-29T02:30:00Z')), false);
+  // 周日 2026-08-30 16:00 北京（08:00Z）：下午高峰窗口 → 空闲。
+  assert.equal(balance.isPeakHour(new Date('2026-08-30T08:00:00Z')), false);
+  // 生效瞬间（北京 8/23 00:00 = 8/22 16:00Z）之后的周末深夜同样空闲。
+  assert.equal(balance.isPeakHour(new Date('2026-08-29T18:30:00Z')), false);
+});
+
+test('isPeakHour: 生效日前的周末仍按小时窗口判高峰（不溯及既往）', () => {
+  // 周六 2026-08-22 10:30 北京（02:30Z）：8-23 规则未生效 → 高峰。
+  assert.equal(balance.isPeakHour(new Date('2026-08-22T02:30:00Z')), true);
+  // 周六 2026-08-22 20:00 北京（12:00Z）：非窗口时段 → 空闲（与规则无关）。
+  assert.equal(balance.isPeakHour(new Date('2026-08-22T12:00:00Z')), false);
+});
+
+test('isPeakHour: 周末规则生效后工作日高峰窗口不受影响', () => {
+  // 周三 2026-08-26 10:30 / 16:00 北京：仍为高峰。
+  assert.equal(balance.isPeakHour(new Date('2026-08-26T02:30:00Z')), true);
+  assert.equal(balance.isPeakHour(new Date('2026-08-26T08:00:00Z')), true);
+  // 周三 12:30 / 20:00 北京：仍为空闲。
+  assert.equal(balance.isPeakHour(new Date('2026-08-26T04:30:00Z')), false);
+  assert.equal(balance.isPeakHour(new Date('2026-08-26T12:00:00Z')), false);
+});
+
+// ---------------------------------------------------------------------------
+// periodTables（issue #168：按 token 消耗时刻计价的契约载荷）
+// ---------------------------------------------------------------------------
+
+test('periodTables: 三张表内容与求值时刻无关，off = peak 的一半', () => {
+  const tables = balance.periodTables();
+  assert.deepStrictEqual(Object.keys(tables).sort(), ['legacy', 'off', 'peak']);
+  // peak 表 = 全价快照。
+  assert.deepStrictEqual(tables.peak['deepseek-v4-flash'], { cacheMiss: 3, cacheHit: 0.1, output: 9 });
+  assert.deepStrictEqual(tables.peak['deepseek-v4-pro'], { cacheMiss: 9, cacheHit: 0.3, output: 27 });
+  // off 表 = 高峰一半。
+  assert.deepStrictEqual(tables.off['deepseek-v4-flash'], { cacheMiss: 1.5, cacheHit: 0.05, output: 4.5 });
+  assert.deepStrictEqual(tables.off['deepseek-v4-pro'], { cacheMiss: 4.5, cacheHit: 0.15, output: 13.5 });
+  // legacy 表 = 旧版固定价。
+  assert.deepStrictEqual(tables.legacy['deepseek-v4-flash'], { cacheMiss: 1, cacheHit: 0.02, output: 2 });
+  assert.deepStrictEqual(tables.legacy['deepseek-v4-pro'], { cacheMiss: 3, cacheHit: 0.025, output: 6 });
+  // 别名同档 + 与求值时刻无关（两次调用同值）。
+  assert.deepStrictEqual(tables.peak['deepseek-chat'], tables.peak['deepseek-v4-flash']);
+  assert.deepStrictEqual(balance.periodTables(), tables);
+  // 纯快照：深拷贝语义（改副本不污染常量表）。
+  tables.peak['deepseek-v4-flash'].cacheMiss = 999;
+  assert.strictEqual(balance.periodTables().peak['deepseek-v4-flash'].cacheMiss, 3);
+});
+
+test('periodTables: 单表函数与打包函数一致；peakPricingSinceIso 锚定生效节点', () => {
+  const tables = balance.periodTables();
+  assert.deepStrictEqual(balance.peakPriceTable(), tables.peak);
+  assert.deepStrictEqual(balance.offPriceTable(), tables.off);
+  assert.deepStrictEqual(balance.legacyPriceTable(), tables.legacy);
+  assert.strictEqual(balance.peakPricingSinceIso(), '2026-08-16T16:00:00.000Z');
+});
+
+// ---------------------------------------------------------------------------
 // priceTable
 // ---------------------------------------------------------------------------
 

--- a/dsh-tauri/sidecar/cli.js
+++ b/dsh-tauri/sidecar/cli.js
@@ -1110,9 +1110,10 @@ async function main() {
         // 编排半边在 Rust 侧 commands/balance.rs）：复用 payload 的
         // balance.js + balance-scheduler.js（refresh() 直刷 + pollMs:0 不装
         // 轮询定时器），组装出与 Electron 完全同构的事件载荷
-        // （ok/balances/prices/priceTable/model/peak/opencodeGo/at，
-        // 契约见 docs/balance-architecture.md §2）。stdout 末行 JSON 即结果；
-        // 密钥不出本进程（Rust 只透传 JSON，见 balance-scheduler 出站模型）。
+        // （ok/balances/prices/priceTable/model/peak/opencodeGo/at
+        // /periodTables/pricingSince，契约见 docs/balance-architecture.md §2）。
+        // stdout 末行 JSON 即结果；密钥不出本进程（Rust 只透传 JSON，
+        // 见 balance-scheduler 出站模型）。
         const c = ctx();
         const balance = require(path.join(c.appDir, 'balance'));
         const { createBalanceScheduler } = require(path.join(c.appDir, 'balance-scheduler'));
@@ -1126,6 +1127,8 @@ async function main() {
           readActiveModel: balance.readActiveModel,
           effectivePrice: balance.effectivePrice,
           priceTable: balance.priceTable,
+          periodTables: balance.periodTables,
+          pricingSinceIso: balance.peakPricingSinceIso,
           isPeakHour: balance.isPeakHour,
           push: (r) => { result = r; },
           log: (topic, msg) => process.stderr.write('[' + topic + '] ' + msg + '\n'),


### PR DESCRIPTION
Fixes #168

## 问题

对话底部统计栏的「本轮 ¥」会随时间变化：旧实现是 **累计 token × 推送时刻的时段价**——`balance-scheduler` 每 ~3 分钟（及回合完成）推送按当时刻解析的 `prices`/`peak`，客户端把**整份历史用量**乘以新价目。高峰/空闲切换后整段费用跟着跳变（如高峰期 ¥12 的会话到晚上显示 ¥6），与官方「按请求发生时刻结算、不追溯」的计费口径不符。

顺带修复同一时段判定逻辑里的另一个 bug：`balance.js` `isPeakHour` 缺**周末规则**——官方 2026-08-23 公告起周六/周日全天按空闲价计费，但旧实现在周末 9-12/14-18 仍判高峰（dock 误显 ⛰高峰价、费用按全价估算），与 `dsh-offpeak`（issue #158）口径不一致。

## 修复方案

**展示层增量计价账本**（`tokenUsage` 投影只有累计四桶、无时间戳，这是不改上游投影契约前提下的正确落点）：

- **客户端**（`dsh-balance/lib/client.js` 新增 `observeCost`）：每次观察到累计用量前进，只对**增量**按「观察时刻」的时段价入账；基线（首次观察到的存量）按当时时段价一次性入账。同一 usage 重复观察增量为零（幂等，渲染期调用安全）；累计回退（(turn,step) 样本替换）按有符号增量冲回。账本按会话 id 键控、localStorage 持久化（页面重载延续、32 会话 LRU、脏数据/配额满静默降级纯内存）。
- **主进程**（`balance-scheduler.js` `doRefresh`）：出站载荷新增 `periodTables`（peak/off/legacy 三张时段价目表）+ `pricingSince`（峰谷生效节点）——客户端按自身时钟选档，**推送滞后不再影响计价正确性**；`balancePrices.<model>` 用户覆盖同时并入三张表（覆盖语义与时段无关）。未注入时（旧接线形态）不产生新字段，客户端回退旧口径，向后兼容。Tauri sidecar `cli.js` balance-fetch 同步接线。
- **`balance.js`**：`isPeakHour` 补周末全天空闲（`WEEKEND_OFFPEAK_SINCE_UTC`，不溯及既往）；新增 `periodTables()`/`peakPriceTable()`/`offPriceTable()`/`legacyPriceTable()`/`peakPricingSinceIso()` 纯函数。
- **峰谷 chip** 改客户端本地判定（`isPeakAt` 镜像主进程口径）：整点切换即时生效，不受 3 分钟推送周期滞后影响；旧形态载荷回退主进程 `peak`。

### 已知近似（架构边界，fail-soft 取舍）

token 无时间戳：基线与页面关闭期间消耗的量按「观察/重开时刻」的时段价估算；自插件在场起的新增量全部按真实消耗时段计价。修复的核心目标——**显示不再随推送整段跳变**——不受此近似影响。详见 `docs/balance-architecture.md` §3.1。

## 测试

- `unit-balance.test.js`：`isPeakHour` 周末矩阵（生效前后周六/周日、工作日不受影响）+ `periodTables` 三张表内容/纯快照/单表函数一致性（+5 例）
- `unit-balance-scheduler.test.js`：`periodTables`/`pricingSince` 载荷契约（未注入不产生字段）+ 用户覆盖并入三张表（+2 例）
- `edge-client.test.js`：时段计价回归组（+9 例，含核心回归「峰→谷同用量费用不重算」、跨边界增量分段、周末/legacy 选档、会话键控、localStorage 重载延续、脏 storage 降级、模型档）；「prices 覆盖」用例改为新语义（同一用量换价不重算——旧断言锁定的正是本 bug 行为）
- balance 相关 91 用例全绿；`check-syntax.js` 通过；全量 `npm test` 与 main 基线对照：失败集完全一致（42 个文件均为本机 clone 缺 node_modules 的既有环境失败，与本 PR 无关）

## 文档

`docs/balance-architecture.md` §2 载荷契约（`periodTables`/`pricingSince` 可选字段）、§3.1 按消耗时段计价（账本语义与近似边界）、§7 定价/切换语义、§9 缺陷映射、§10 维护约定（双端时段常量同步）同步更新；CHANGELOG [Unreleased] 记录。