### PR TITLE
[fix] 修复 macOS 右上角菜单溢出（#182）

### DIFF
--- a/dsh-desktop/scripts/test/ta13-soak-bridge-shim.test.js
+++ b/dsh-desktop/scripts/test/ta13-soak-bridge-shim.test.js
@@ -142,6 +142,17 @@ function loadShim() {
 
 function heapMB() { return process.memoryUsage().heapUsed / 1024 / 1024; }
 
+test('issue #182：原生标题栏菜单先注入公共视口样式', () => {
+  const src = fs.readFileSync(SHIM, 'utf8');
+  const inject = src.slice(src.indexOf('function injectChromeBar()'), src.indexOf('function onBodyReady'));
+  assert.ok(
+    inject.indexOf("right:8px;width:272px") < inject.indexOf('if (NATIVE_TITLE_BAR)'),
+    'macOS/Linux 分流前必须已注入 right 锚定的公共菜单样式',
+  );
+  const ball = src.slice(src.indexOf('function injectMenuBall()'), src.indexOf('function injectChromeBar()'));
+  assert.ok(ball.includes("style[data-for=\"' + BALL_ID + '\"]"), '悬浮按钮样式必须独立查重');
+});
+
 test('bridge 垫片 soak：事件风暴 1e4 + 菜单开/关 1000 轮，DOM 节点终态稳定 + 堆稳定', async () => {
   const { sandbox, doc, byId, eventHandlers } = loadShim();
   const dsh = sandbox.window.dshDesktop;

--- a/dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js
+++ b/dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js
@@ -792,12 +792,11 @@
   function injectMenuBall() {
     try {
       var head = document.head || document.documentElement;
-      // 菜单面板样式与全宽条形态共用同一份（style data-for=CHROME_ID 幂等；
-      // 条专属选择器都挂在 #CHROME_ID 下，对钮形态不命中，冗余无害）。
-      var css = document.querySelector('style[data-for="' + CHROME_ID + '"]');
+      // 悬浮钮样式独立查重；公共菜单样式已由 injectChromeBar 注入。
+      var css = document.querySelector('style[data-for="' + BALL_ID + '"]');
       if (!css) {
         css = document.createElement('style');
-        css.setAttribute('data-for', CHROME_ID);
+        css.setAttribute('data-for', BALL_ID);
         css.textContent =
           '#' + BALL_ID + '{position:fixed;top:10px;right:10px;z-index:2147483000;width:32px;height:32px;' +
           'display:grid;place-items:center;border:1px solid color-mix(in srgb,var(--dsw-alias-border-l1,rgba(127,127,127,.25)) 60%,transparent);' +
@@ -855,8 +854,6 @@
       if ((shellBar && shellBar.hasAttribute('data-tauri-drag-region')) || document.getElementById('titlebar')) return;
       // 平台门：原生标题栏平台（mac/linux）不注入全宽条，降级为 ⋯ 悬浮钮
       // （与 windows.rs decorations 平台门配套，防双份标题栏 + body 下推）。
-      if (NATIVE_TITLE_BAR) { injectMenuBall(); return; }
-
       var head = document.head || document.documentElement;
       // 样式幂等：自愈重注只补条本体，<head> 里的样式不动（SPA 反复摘条
       // 不得在 head 里无限叠 <style>——data-for 与条同 id 查重）。
@@ -972,6 +969,7 @@
           'box-shadow:0 0 0 2px color-mix(in srgb,var(--dsw-alias-bg-base,var(--dch-bg,#0b1220)) 88%,transparent)}';
         head.appendChild(css);
       }
+      if (NATIVE_TITLE_BAR) { injectMenuBall(); return; }
       // 内容区整体下移（对齐 Electron：普通流走 padding，fixed 侧边栏走属性声明）。
       var layout = document.querySelector('style[data-for="' + CHROME_ID + '-layout"]');
       if (!layout) {


### PR DESCRIPTION
## 变更概述

修复原生标题栏平台的右上角 `⋯` 菜单缺少公共面板样式，导致 macOS 上菜单向窗口外溢出并被裁剪。Closes #182

## 变更内容

- [x] 让 macOS/Linux 分流发生在公共菜单样式注入之后，复用已有的 `position: fixed; right: 8px; width: 272px` 视口锚定
- [x] 将悬浮按钮样式改为独立 `data-for` 键，避免公共样式存在时跳过按钮样式
- [x] 新增 #182 回归检查，锁住样式注入与平台分流顺序

涉及文件：
- `dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js`
- `dsh-desktop/scripts/test/ta13-soak-bridge-shim.test.js`

## 测试与验证（必填）

- [x] 已补充 #182 回归用例
- [x] `node scripts/check-syntax.js` 通过
- [x] `node --test scripts/test/ta13-soak-bridge-shim.test.js`：2 tests / 2 pass / 0 fail / 0 skipped
- [ ] `npm test`：已在 `npm ci` 后运行；#182 用例通过，但全量套件在 macOS 上仍有与本改动无关的既有平台/运行时布局失败（例如 Windows junction 与 appDir 内核副本断言），因此未虚报全绿
- [ ] 未手动启动 Tauri 应用：当前环境未安装 Rust/Cargo

## 影响面

- [ ] 破坏性变更
- [ ] 需要更新 CHANGELOG.md
- [x] 涉及 UI 变更
- [x] 涉及平台：macOS / Linux（原生标题栏分支）；Windows 控制条路径保持不变

## Review 提示

请重点确认 `injectChromeBar()` 在 `NATIVE_TITLE_BAR` 分流前只安装公共样式、不注入 Windows 控制条或布局 padding；随后 `injectMenuBall()` 使用独立样式键注入按钮。

## 截图

当前环境无法启动 Tauri 壳，未生成新的实机截图；issue 中已有修复前截图。