### PR TITLE
[fix] 客户端更新：页面就绪后主动补查，兜住启动期丢失的 client-update-available（#189）

### DIFF
--- a/dsh-desktop/scripts/test/ta5-dom-behavior.test.js
+++ b/dsh-desktop/scripts/test/ta5-dom-behavior.test.js
@@ -733,6 +733,104 @@ async function main() {
       && !s.doc.getElementById('dsh-tauri-chrome').querySelector('button.dch-menu-btn').classList.contains('dch-dot'));
   }
 
+  // ---- 3.7b 页面引导期主动补查（#189 回归）----
+  // 壳的启动检查在 webview 挂上监听之前就广播完了 client-update-available
+  // （updater_client.rs 模块文档已写明该风险），事件不重放 ⇒ 垫片必须在页面
+  // 就绪后主动补查一次，否则红点/通知/自动安装每次启动都落空。
+  console.log('\n[7b] 页面引导期主动补查 check-client-update（#189 回归）');
+  {
+    const acts = [];
+    const s = bootShim({
+      appInfo: Object.assign({}, APP_INFO, { autoInstallUpdates: true }),
+      routes: {
+        menu_action: (args) => {
+          acts.push(args.action);
+          if (args.action === 'check-client-update') return { ok: true, upToDate: true };
+          return undefined;
+        },
+      },
+    });
+    await flush();
+    check('引导后主动补查一次 check-client-update', acts.length === 1 && acts[0] === 'check-client-update', JSON.stringify(acts));
+    const btn = s.doc.getElementById('dsh-tauri-chrome').querySelector('button.dch-menu-btn');
+    check('补查 upToDate → 无红点 / 无通知 / 不安装',
+      !btn.classList.contains('dch-dot') && s.count('plugin:notification|notify') === 0
+      && !acts.includes('install-client-update'));
+    s.timers.advance(60000);
+    await flush();
+    check('补查每页一次（不随定时器重复）', acts.length === 1, JSON.stringify(acts));
+  }
+  {
+    const acts = [];
+    const s = bootShim({
+      appInfo: Object.assign({}, APP_INFO, { autoInstallUpdates: true }),
+      routes: {
+        menu_action: (args) => {
+          acts.push(args.action);
+          if (args.action === 'check-client-update') return { ok: true, next: '9.9.9', source: 'github' };
+          if (args.action === 'install-client-update') return { installing: true };
+          return undefined;
+        },
+      },
+    });
+    await flush();
+    const btn = s.doc.getElementById('dsh-tauri-chrome').querySelector('button.dch-menu-btn');
+    check('补查命中 → 红点', btn.classList.contains('dch-dot'));
+    check('补查命中 → 系统通知一次', s.count('plugin:notification|notify') === 1);
+    check('补查命中 + 无会话 → 自动安装（与事件链同闸门）', acts.includes('install-client-update'), JSON.stringify(acts));
+  }
+  {
+    const acts = [];
+    const s = bootShim({
+      appInfo: Object.assign({}, APP_INFO, { autoInstallUpdates: true }),
+      routes: {
+        menu_action: (args) => {
+          acts.push(args.action);
+          if (args.action === 'check-client-update') return { ok: true, next: '9.9.9' };
+          return undefined;
+        },
+      },
+    });
+    s.storage.setItem('dsh.sessions.current', JSON.stringify({ sessionId: 'busy' }));
+    s.timers.advance(3000); // 3s 轮询读到会话之后再补查
+    await flush();
+    check('有会话 → 补查只提醒不自动装', !acts.includes('install-client-update'), JSON.stringify(acts));
+    check('有会话 → 红点仍打上',
+      s.doc.getElementById('dsh-tauri-chrome').querySelector('button.dch-menu-btn').classList.contains('dch-dot'));
+  }
+  {
+    const acts = [];
+    const s = bootShim({
+      appInfo: APP_INFO,
+      pathname: '/loading.html',
+      routes: { menu_action: (args) => { acts.push(args.action); return { ok: true, next: '9.9.9' }; } },
+    });
+    await flush();
+    check('壳页（loading.html）不补查（跨 origin 会话态不可信）', acts.length === 0, JSON.stringify(acts));
+  }
+  {
+    const acts = [];
+    const s = bootShim({
+      appInfo: APP_INFO,
+      label: 'float',
+      routes: { menu_action: (args) => { acts.push(args.action); return { ok: true, next: '9.9.9' }; } },
+    });
+    await flush();
+    check('非主窗不补查（防浮窗/宠物窗并发安装）', acts.length === 0, JSON.stringify(acts));
+  }
+  {
+    const acts = [];
+    const s = bootShim({
+      appInfo: APP_INFO,
+      routes: { menu_action: (args) => { acts.push(args.action); throw new Error('[UPDATE_CHECK_FAILED] offline'); } },
+    });
+    await flush();
+    check('补查失败静默（不抛异常）', acts.length === 1 && acts[0] === 'check-client-update', JSON.stringify(acts));
+    check('补查失败 → 无红点 / 无通知',
+      !s.doc.getElementById('dsh-tauri-chrome').querySelector('button.dch-menu-btn').classList.contains('dch-dot')
+      && s.count('plugin:notification|notify') === 0);
+  }
+
   // ---- 3.8 拖放悬停层 ----
   console.log('\n[8] 拖放悬停层：enter 创建 / leave+drop 移除 / ESC 残留（现状）');
   {

--- a/dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js
+++ b/dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js
@@ -555,6 +555,31 @@
     }
     if (menuOpen) renderMenu();
   }
+  // 页面就绪后主动补查一次（U2 兜底，修 #189）：壳的启动检查在 webview 挂上
+  // 监听之前就广播完了 client-update-available（updater_client.rs 模块文档已
+  // 写明该风险：「启动早期 webview 可能尚未挂监听而错过该事件——垫片可经菜单
+  // check-client-update 通道主动再查兜底」），而 Tauri 事件不重放 ⇒ 每次启动
+  // 的检测结果都到不了本页，红点/通知/自动安装一起落空。这里复用 ⋯ 菜单同一条
+  // 通道主动再查一次，结果交给 handleClientUpdateAvailable 统一消费（主窗守卫/
+  // 同版本通知去重/自动安装闸门的口径与事件链完全一致）。
+  // 壳页（loading/recovery/poc）跳过：其 localStorage 属另一 origin，
+  // currentSessionId 恒为空，会让「无会话才自动装」的闸门误判。
+  // 每页一次；失败/形态异常静默（与壳的「更新检查失败（静默忽略）」同口径）。
+  var clientUpdateProbed = false;
+  function probeClientUpdate() {
+    if (clientUpdateProbed || !isMainWindow()) return;
+    try {
+      if (/(^|\/)(loading|recovery|poc)\.html$/.test(location.pathname)) return;
+    } catch (e) { return; }
+    clientUpdateProbed = true;
+    try {
+      dshDesktop.menu.action('check-client-update').then(function (r) {
+        if (!r || r.ok !== true) return; // 形态异常：菜单路径才就地报错
+        if (r.upToDate) return;          // 已是最新：无红点、无通知、不安装
+        if (r.next) handleClientUpdateAvailable({ next: r.next, source: r.source });
+      }).catch(function () { /* 检查失败静默：同壳口径 */ });
+    } catch (e) { /* 同上 */ }
+  }
   // 下载进度：直接改行尾文本（不整面板重渲染）；100% 转「正在安装…」
   //（Windows 下进程即将退出，页面随之消亡）。
   listeners.updProgress.push(function (p) {
@@ -1143,7 +1168,8 @@
 
   // 自初始化：回填 appVersion（失败静默——浏览器模式常见）+ 订阅客户端
   // 更新事件（启动自动检查命中：红点/通知/自动安装，仅主窗——见
-  // handleClientUpdateAvailable 的守卫说明）。
+  // handleClientUpdateAvailable 的守卫说明）；事件在启动期就已经广播完
+  // （webview 尚未挂监听），故 getInfo merge 之后再主动补查一次兜底。
   // RV3 P1-1：getInfo 结果必须 merge 进 menuState——否则 autoInstallUpdates
   // 恒为缺省 false，重启后「自动安装客户端更新」永不触发（除非本会话先
   // 开过一次 ⋯ 菜单触发 openMenu 的 getInfo）。
@@ -1154,8 +1180,8 @@
           try { menuState[k] = info[k]; } catch (e) { /* 只读字段跳过 */ }
         }
       }
-    }).catch(function () {});
-  } catch (e) {}
+    }).catch(function () {}).then(probeClientUpdate);
+  } catch (e) { probeClientUpdate(); }
   listeners.clientUpdate.push(handleClientUpdateAvailable);
 
   // ---- 文件拖放转发（F1，2026-08）----------------------------------------


### PR DESCRIPTION
## 变更概述

修 #189：客户端「自动安装客户端更新」形同虚设。

壳的启动检查在 webview 挂上监听之前（启动后 ~15s，而内核页就绪还要再等 ~40s）就广播完了 `client-update-available`，Tauri 事件不重放 ⇒ 每次启动的检测结果都到不了页面，红点 / 系统通知 / 自动安装一起落空。`updater_client.rs` 的模块文档其实已经写明该风险并要求「垫片可经菜单 check-client-update 通道主动再查兜底」，但这个兜底一直没落地 —— `check-client-update` 在垫片里只出现在菜单项渲染与菜单点击处理两处，页面引导段（`getInfo` 之后）没有任何主动复查。

Closes #189

## 变更内容

- [x] 功能实现 / bug 修复说明
  - `dsh-tauri/src-tauri/crates/bridge/dist/bridge-shim.js`：在 `getInfo` merge 进 `menuState` **之后**（保证 `autoInstallUpdates` 已回填，RV3 P1-1 同源问题）主动补查一次 `check-client-update`，结果交给既有的 `handleClientUpdateAvailable` 统一消费 —— 主窗守卫、同版本通知去重、「有会话只提醒不自动装」的闸门口径与事件链完全一致，不新增状态机、不改协议。
  - 每页一次；**壳页（loading/recovery/poc）跳过**：其 localStorage 属另一 origin，`currentSessionId` 恒为空，会让「无会话才自动装」的闸门误判成可自动安装。
  - 检查失败或返回形态异常静默（与壳的 `[update] 更新检查失败（静默忽略）` 同口径）。
- [x] 涉及文件范围：2 个文件，+127 / -3（无行尾噪声；仓库以 LF 存储，工作树 CRLF 未混入）

## 测试与验证（必填）

- [x] 已按测试规范补充回归用例：`dsh-desktop/scripts/test/ta5-dom-behavior.test.js` 新增 `[7b] 页面引导期主动补查 check-client-update（#189 回归）`，12 项断言（用例加载的是真实 `dist/bridge-shim.js` 源码，非 stub）：
  - 引导后主动补查一次 `check-client-update`；不随定时器重复
  - `upToDate` → 无红点 / 无通知 / 不安装
  - 命中 + 无会话 + `autoInstallUpdates` → 红点 + 系统通知一次 + 自动安装
  - 有会话运行 → 只提醒不自动装（红点仍打上）
  - 壳页（loading.html）不补查；非主窗（label=float）不补查
  - 检查抛错 → 静默（不抛异常、无红点、无通知）
- [x] 本地已通过语法预检：`node scripts/check-syntax.js` → `[check-syntax] 全部入口文件语法检查通过。`（exit 0）
- [x] 本地逐文件单测（本机未 `npm ci`，故按文件直接 `node scripts/test/<file>`；`npm test` 的 glob 覆盖同名文件）：

  | 文件 | 结果 |
  | --- | --- |
  | `ta5-dom-behavior` | **127 ok, 0 FAIL**（改动前基线 115 ok；+12 为本 PR 新增用例） |
  | `ta13-soak-bridge-shim` | `# fail 0` |
  | `ta15-shim-mainwindow-interleave` | `# fail 0` |
  | `ta4-shim-onevent-dual-form` | `# fail 0` |
  | `ta2-file-drop` | `# pass 6 / # fail 0` |
  | `ta3-file-drop-chain` | `# pass 6 / # fail 0` |

  `skipped` 与改动前一致（未新增任何 `skip`）。
- [!] **`ta16-golden` 在本次 checkout 上 `# pass 5 / # fail 2`，且本 PR 补丁前/后完全一致（即与本改动无关）**。顺手定位到根因，供维护者参考：快照 `error-messages.json` 里有 3 条字符串在 `aca7263` 的源码中已不存在（疑似 v0.6.3 改名后未刷新快照）——`'[update] 启动更新检查失败（静默忽略）：{e}'`（现为「更新检查失败」）、`'DSH Desktop 已在运行'`、`'已查 {scanned:?}，均无 {os}/{arch} 可用安装包（Gitee 100MB 限可能缺席大资产）'`；反之实测侧没有金样之外的新字符串。与垫片相关的 `shim-menu-text.json` 金样**通过**。本 PR 未改快照。
- [ ] 已手动启动应用验证相关功能路径：**未做**。本机没有可用的完整 workspace 构建环境（跑 `cargo run` 需装齐 `dsh-tauri/src-tauri` 全量依赖 + WebView2 构建链），故无截图。该路径由「真实 `dist/bridge-shim.js` + 最小 DOM + mock `__TAURI_INTERNALS__` + 假定时器」的行为测试覆盖；如需我在有条件的环境补一次真机验证，请 review 中指出。

## 影响面

- [ ] 破坏性变更：无。补查走的是既有 `menu_action('check-client-update')` 通道，沿用菜单路径既有返回契约（`{ok,upToDate}` / `{ok,next,source}`）。
- [ ] 需要更新 CHANGELOG.md：由维护者决定。
- [ ] 涉及 UI 变更：无新 UI；仅在命中新版本时按既有逻辑打红点 / 发系统通知。
- [x] 涉及平台：Windows / macOS / Linux（纯 JS 垫片，三平台同源）。

## Review 提示

1. 补查刻意排在 `getInfo` 的 merge 之后 —— 否则自动安装闸门会读到缺省 `false` 的 `autoInstallUpdates`（与 RV3 P1-1 同一类时序问题）。
2. 壳页跳过不是可选优化：不跳过会在「上一次实例有会话」时从 loading 页触发自动安装，正是闸门要避免的中断。
3. 未动的部分：壳侧 6h 循环重检的首查点仍在启动后 15s（`lib.rs`），若希望首查就落在内核就绪之后，属于壳侧排期改动，可另开一条；本 PR 只补齐垫片侧文档已承诺的兜底。
